### PR TITLE
feat: add scroll-to-bottom button on terminal screen

### DIFF
--- a/lib/screens/terminal/terminal_screen.dart
+++ b/lib/screens/terminal/terminal_screen.dart
@@ -20,6 +20,7 @@ import '../../services/tmux/pane_navigator.dart';
 import '../../services/tmux/tmux_commands.dart';
 import '../../services/tmux/tmux_parser.dart';
 import '../../theme/design_colors.dart';
+import '../../widgets/scroll_to_bottom_button.dart';
 import '../../widgets/special_keys_bar.dart';
 import '../../providers/terminal_display_provider.dart';
 import '../settings/settings_screen.dart';
@@ -97,6 +98,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   final _secureStorage = SecureStorageService();
   final _scaffoldKey = GlobalKey<ScaffoldState>();
   final _ansiTextViewKey = GlobalKey<AnsiTextViewState>();
+  final _scrollToBottomKey = GlobalKey<ScrollToBottomButtonState>();
   final _terminalScrollController = ScrollController();
 
   // 接続状態（ローカルで管理）
@@ -165,6 +167,9 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   void initState() {
     super.initState();
     WidgetsBinding.instance.addObserver(this);
+
+    // スクロール時にスクロールボタンを表示
+    _terminalScrollController.addListener(_onTerminalScroll);
 
     // 次フレームでリスナーを設定（ref使用のため）
     WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -774,6 +779,11 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     );
   }
 
+  /// スクロール時にスクロールボタンを表示
+  void _onTerminalScroll() {
+    _scrollToBottomKey.currentState?.show();
+  }
+
   @override
   void dispose() {
     // まず_isDisposedをセットして非同期処理を停止
@@ -799,7 +809,8 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     _treeRefreshTimer = null;
     // ValueNotifierを破棄
     _viewNotifier.dispose();
-    // スクロールコントローラーを破棄
+    // スクロールコントローラーのリスナーを削除して破棄
+    _terminalScrollController.removeListener(_onTerminalScroll);
     _terminalScrollController.dispose();
     super.dispose();
   }
@@ -859,6 +870,9 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
                                   backgroundColor: Theme.of(context).scaffoldBackgroundColor,
                                   foregroundColor: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.9),
                                   onKeyInput: _handleKeyInput,
+                                  onTap: () {
+                                    _scrollToBottomKey.currentState?.show();
+                                  },
                                   mode: _terminalMode,
                                   zoomEnabled: true,
                                   onZoomChanged: (scale) {
@@ -886,6 +900,17 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
                           builder: (context, ref, _) {
                             final tmuxState = ref.watch(tmuxProvider);
                             return _buildPaneIndicator(tmuxState);
+                          },
+                        ),
+                      ),
+                      // スクロールボタン: ターミナルエリア右下
+                      Positioned(
+                        bottom: 8,
+                        right: 16,
+                        child: ScrollToBottomButton(
+                          key: _scrollToBottomKey,
+                          onPressed: () {
+                            _ansiTextViewKey.currentState?.scrollToBottom();
                           },
                         ),
                       ),
@@ -1421,7 +1446,9 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
           ),
         );
       },
-    );
+    ).then((_) {
+      _scrollToBottomKey.currentState?.show();
+    });
   }
 
   /// ウィンドウ選択ダイアログを表示
@@ -1504,7 +1531,9 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
           ),
         );
       },
-    );
+    ).then((_) {
+      _scrollToBottomKey.currentState?.show();
+    });
   }
 
   /// ペイン選択ダイアログを表示
@@ -1626,7 +1655,9 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
           ),
         );
       },
-    );
+    ).then((_) {
+      _scrollToBottomKey.currentState?.show();
+    });
   }
 
   Widget _buildBreadcrumbItem(
@@ -1890,7 +1921,9 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
           ),
         );
       },
-    );
+    ).then((_) {
+      _scrollToBottomKey.currentState?.show();
+    });
   }
 
   /// 切断確認ダイアログを表示
@@ -2195,7 +2228,9 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
           if (sheetContext.mounted) Navigator.pop(sheetContext);
         },
       ),
-    );
+    ).then((_) {
+      _scrollToBottomKey.currentState?.show();
+    });
   }
 
   /// 複数行テキストを送信（行ごとにテキスト+Enterを送信）

--- a/lib/screens/terminal/widgets/ansi_text_view.dart
+++ b/lib/screens/terminal/widgets/ansi_text_view.dart
@@ -90,6 +90,9 @@ class AnsiTextView extends ConsumerStatefulWidget {
   /// 各方向にペインが存在するかのマップ（視覚フィードバック用）
   final Map<SwipeDirection, bool>? navigableDirections;
 
+  /// ターミナル領域タップ時のコールバック
+  final VoidCallback? onTap;
+
   const AnsiTextView({
     super.key,
     required this.text,
@@ -107,6 +110,7 @@ class AnsiTextView extends ConsumerStatefulWidget {
     this.onArrowSwipe,
     this.onTwoFingerSwipe,
     this.navigableDirections,
+    this.onTap,
   });
 
   @override
@@ -951,7 +955,10 @@ class AnsiTextViewState extends ConsumerState<AnsiTextView>
           autofocus: true,
           onKeyEvent: _handleKeyEvent,
           child: GestureDetector(
-            onTap: () => _focusNode.requestFocus(),
+            onTap: () {
+              _focusNode.requestFocus();
+              widget.onTap?.call();
+            },
             onLongPressStart: _onLongPressStart,
             onLongPressMoveUpdate: _onLongPressMoveUpdate,
             onLongPressEnd: _onLongPressEnd,

--- a/lib/widgets/scroll_to_bottom_button.dart
+++ b/lib/widgets/scroll_to_bottom_button.dart
@@ -1,0 +1,115 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import '../theme/design_colors.dart';
+
+/// 画面下部へスクロールするボタン
+///
+/// ESC/TABバーの上に配置され、タップで最下部にスクロールする。
+/// アクティブ時は塗りつぶし背景で表示、非アクティブ時は薄い白枠+白矢印+透明背景。
+class ScrollToBottomButton extends StatefulWidget {
+  final VoidCallback onPressed;
+
+  const ScrollToBottomButton({
+    super.key,
+    required this.onPressed,
+  });
+
+  @override
+  State<ScrollToBottomButton> createState() => ScrollToBottomButtonState();
+}
+
+class ScrollToBottomButtonState extends State<ScrollToBottomButton> {
+  bool _active = false;
+  bool _visible = false;
+  Timer? _fadeTimer;
+
+  /// ボタンをアクティブ表示にし、3秒後に非アクティブに遷移する
+  void show() {
+    if (!mounted) return;
+    _fadeTimer?.cancel();
+    setState(() {
+      _active = true;
+      _visible = true;
+    });
+    _fadeTimer = Timer(const Duration(seconds: 3), () {
+      if (!mounted) return;
+      setState(() {
+        _active = false;
+      });
+    });
+  }
+
+  /// ボタンを完全に非表示にする
+  void hide() {
+    if (!mounted) return;
+    _fadeTimer?.cancel();
+    setState(() {
+      _active = false;
+      _visible = false;
+    });
+  }
+
+  @override
+  void dispose() {
+    _fadeTimer?.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!_visible) return const SizedBox.shrink();
+
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final colorScheme = Theme.of(context).colorScheme;
+
+    final bgColor = _active
+        ? (isDark ? DesignColors.keyBackground : DesignColors.keyBackgroundLight)
+        : Colors.transparent;
+
+    final borderColor = _active
+        ? colorScheme.outline.withValues(alpha: 0.3)
+        : Colors.white.withValues(alpha: 0.15);
+
+    final iconColor = _active
+        ? colorScheme.onSurface.withValues(alpha: 0.8)
+        : Colors.white.withValues(alpha: 0.15);
+
+    return GestureDetector(
+      onTap: () {
+        HapticFeedback.lightImpact();
+        widget.onPressed();
+      },
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 300),
+        width: 36,
+        height: 36,
+        decoration: BoxDecoration(
+          color: bgColor,
+          borderRadius: BorderRadius.circular(18),
+          border: Border.all(color: borderColor),
+          boxShadow: _active
+              ? [
+                  BoxShadow(
+                    color: Colors.black.withValues(alpha: isDark ? 0.4 : 0.15),
+                    blurRadius: 4,
+                    offset: const Offset(0, 2),
+                  ),
+                ]
+              : [],
+        ),
+        child: TweenAnimationBuilder<Color?>(
+          tween: ColorTween(end: iconColor),
+          duration: const Duration(milliseconds: 300),
+          builder: (context, color, _) => Icon(
+            Icons.keyboard_double_arrow_down,
+            size: 18,
+            color: color,
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Add a scroll-to-bottom button at the bottom-right of the terminal area for quick navigation to the end of long output
- Button shows active state (filled background) on tap/scroll/panel close, fades to inactive state (transparent background with subtle white border and arrow) after 3 seconds

## Changes
- **`lib/widgets/scroll_to_bottom_button.dart`** (new): ScrollToBottomButton widget with active/inactive states, animated via AnimatedContainer + TweenAnimationBuilder
- **`lib/screens/terminal/terminal_screen.dart`**: Place button in terminal area Stack, wire up scroll/tap/panel-close events
- **`lib/screens/terminal/widgets/ansi_text_view.dart`**: Add `onTap` callback property to notify external listeners of terminal area taps

## Test plan
- [ ] Button is hidden on initial terminal screen load
- [ ] Tapping the terminal area shows the button in active state (filled background)
- [ ] Scrolling also triggers active state
- [ ] Button fades to inactive state (transparent bg, subtle white border/arrow) after 3 seconds
- [ ] Tapping the button scrolls to the bottom of terminal output
- [ ] Dismissing panels (session/window/pane selectors, menu, input dialog) triggers button display
- [ ] `flutter analyze` passes with no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)