### PR TITLE
fix(input): handle CTRL/ALT modifier keys with Samsung IME composing

### DIFF
--- a/lib/widgets/special_keys_bar.dart
+++ b/lib/widgets/special_keys_bar.dart
@@ -110,8 +110,40 @@ class _SpecialKeysBarState extends State<SpecialKeysBar> {
     _isComposing = value.composing.isValid && !value.composing.isCollapsed;
 
     if (_isComposing) {
-      // 変換中: composingテキストを記録（iOS重複検出用）して送信しない
+      // Record composing text for iOS duplicate detection
       _lastComposingText = text.replaceAll(_sentinel, '');
+
+      // Samsung IME composing workaround:
+      // Samsung (and some Android IMEs) treat English letters as composing,
+      // so composing=false may NEVER arrive while the user keeps typing.
+      // When a modifier (CTRL/ALT) is active, intercept the first composing
+      // character immediately instead of waiting for composing to end.
+      // Guards:
+      //   - length == 1: only the first composing char (avoids accumulated repeats)
+      //   - ASCII letter regex: don't intercept Korean (ㅊ) or other non-ASCII composing
+      if ((_ctrlPressed || _altPressed) && _lastComposingText!.length == 1) {
+        final char = _lastComposingText!;
+        if (RegExp(r'^[A-Za-z]$').hasMatch(char)) {
+          if (widget.hapticFeedback) {
+            HapticFeedback.lightImpact();
+          }
+          final List<String> modifiers = [];
+          if (_ctrlPressed) {
+            modifiers.add('C');
+            setState(() => _ctrlPressed = false);
+          }
+          if (_altPressed) {
+            modifiers.add('M');
+            setState(() => _altPressed = false);
+          }
+          final prefix = modifiers.join('-');
+          widget.onSpecialKeyPressed('$prefix-${char.toLowerCase()}');
+          _lastComposingText = null;
+          _resetToSentinel();
+          return;
+        }
+      }
+
       return;
     }
 
@@ -145,13 +177,26 @@ class _SpecialKeysBarState extends State<SpecialKeysBar> {
       }
       _lastComposingText = null;
 
-      // CTRLボタンが押されている場合はCtrl+キーとして送信
-      if (_ctrlPressed && textToSend.length == 1 && RegExp(r'^[A-Za-z]$').hasMatch(textToSend)) {
+      // Send modifier+key when CTRL/ALT is active (non-composing path)
+      // This handles IMEs that commit without composing (e.g. Gboard English)
+      // tmux format: C-c (Ctrl+C), M-a (Alt+A), C-M-x (Ctrl+Alt+X)
+      if ((_ctrlPressed || _altPressed) &&
+          textToSend.length == 1 &&
+          RegExp(r'^[A-Za-z]$').hasMatch(textToSend)) {
         if (widget.hapticFeedback) {
           HapticFeedback.lightImpact();
         }
-        widget.onSpecialKeyPressed('C-${textToSend.toLowerCase()}');
-        setState(() => _ctrlPressed = false);
+        final List<String> modifiers = [];
+        if (_ctrlPressed) {
+          modifiers.add('C');
+          setState(() => _ctrlPressed = false);
+        }
+        if (_altPressed) {
+          modifiers.add('M');
+          setState(() => _altPressed = false);
+        }
+        final prefix = modifiers.join('-');
+        widget.onSpecialKeyPressed('$prefix-${textToSend.toLowerCase()}');
       } else {
         widget.onKeyPressed(textToSend);
       }


### PR DESCRIPTION
## 概要

- DirectInputモードでSamsungキーボード使用時、CTRL/ALT + 文字キーの組み合わせが動作しない問題を修正
- Samsung IMEは英文入力もcomposing（変換中）として扱うため、`composing=false`イベントが到着しない場合がある — 既存のpost-composing修飾子チェックに到達不能だった
- 既存のCTRL専用ハンドラをALT修飾子（`M-`プレフィックス）にも対応するよう拡張

## 原因

Samsung等のAndroid IMEは英文入力をcomposing（変換中）として扱います。CTRLをトグルしてユーザーが`c`を入力すると：

```
text="c",      composing=true  → early return（蓄積中）
text="cc",     composing=true  → early return
text="cccccc", composing=true  → early return（composingが終了しない）
```

`composing=false`イベントがすぐに（またはタイピング中まったく）到着しないため、既存の `_ctrlPressed && textToSend.length == 1` チェックに到達できませんでした。結果：`Ctrl+C`の代わりにリテラル`"cccccc"`が送信されます。

## 修正内容

composing終了を待つ代わりに、修飾子キーが有効な状態で**最初のcomposing文字**（`length == 1`）を即座にインターセプトします：

```dart
if (_isComposing) {
  _lastComposingText = text.replaceAll(_sentinel, '');

  // Samsung IMEワークアラウンド：修飾子有効時に最初の文字をインターセプト
  if ((_ctrlPressed || _altPressed) && _lastComposingText!.length == 1) {
    final char = _lastComposingText!;
    if (RegExp(r'^[A-Za-z]$').hasMatch(char)) {
      // 修飾子プレフィックスを構築して即座に送信
      widget.onSpecialKeyPressed('C-${char.toLowerCase()}');
      _resetToSentinel();
      return;
    }
  }
  return;
}
```

ガード条件で誤検知を防止：
- `length == 1`：最初のcomposing文字のみ（蓄積された繰り返しを回避）
- `RegExp(r'^[A-Za-z]$')`：ASCII英字のみ。韓国語キーボードでは`c`キーの位置に`ㅊ`（韓国語の子音）が割り当てられており、韓国語入力モードで`c`を押すと`ㅊ`が入力されます。このような非ASCIIのcomposingはインターセプトせず、通常のcomposingフローを維持します。

## テスト

**Galaxy Z Fold (SM-F966N)**、Android 16 (API 36)、Samsungキーボードでテスト済み：
- ✅ CTRL + c → `C-c`（Ctrl+C）送信
- ✅ CTRL + d → `C-d`（Ctrl+D）送信
- ✅ CTRL + z → `C-z`（Ctrl+Z）送信
- ✅ 韓国語入力（ㅊ等）は影響なし — composingが正常に進行
- ✅ 修飾子なしの通常入力は影響なし
