### PR TITLE
feat: ペインclose機能を追加 (#19)

### DIFF
--- a/lib/screens/terminal/terminal_screen.dart
+++ b/lib/screens/terminal/terminal_screen.dart
@@ -1587,6 +1587,161 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     }
   }
 
+  /// ペインを閉じる確認ダイアログを表示
+  void _confirmAndKillPane({
+    required String paneId,
+    required String paneTitle,
+    required bool isLastPane,
+    required bool isLastWindow,
+  }) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    showDialog(
+      context: context,
+      builder: (dialogContext) {
+        return AlertDialog(
+          backgroundColor:
+              isDark ? DesignColors.surfaceDark : DesignColors.surfaceLight,
+          title: Text(
+            'Close Pane?',
+            style: TextStyle(
+              color: isDark
+                  ? DesignColors.textPrimary
+                  : DesignColors.textPrimaryLight,
+            ),
+          ),
+          content: Text(
+            isLastPane && isLastWindow
+                ? 'This is the last pane in the last window. Closing it will end the session and disconnect from the server.'
+                : isLastPane
+                    ? 'This is the last pane in this window. Closing it will also close the window.'
+                    : 'Are you sure you want to close pane "$paneTitle"?',
+            style: TextStyle(
+              color: isDark
+                  ? DesignColors.textSecondary
+                  : DesignColors.textSecondaryLight,
+            ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(dialogContext),
+              child: Text(
+                'Cancel',
+                style: TextStyle(
+                  color: isDark
+                      ? DesignColors.textSecondary
+                      : DesignColors.textSecondaryLight,
+                ),
+              ),
+            ),
+            ElevatedButton(
+              onPressed: () {
+                Navigator.pop(dialogContext);
+                // 実行直前にペインがまだ存在するか再検証
+                final currentWindow = ref.read(tmuxProvider).activeWindow;
+                if (currentWindow == null ||
+                    !currentWindow.panes.any((p) => p.id == paneId)) {
+                  if (mounted) {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(
+                          content:
+                              Text('This pane no longer exists')),
+                    );
+                  }
+                  return;
+                }
+                _killPane(
+                  paneId: paneId,
+                  isLastPane: isLastPane,
+                  isLastWindow: isLastWindow,
+                );
+              },
+              style: ElevatedButton.styleFrom(
+                backgroundColor: DesignColors.error,
+                foregroundColor: Colors.white,
+              ),
+              child: const Text('Close'),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  /// ペインを閉じる（SSH経由でkill-pane実行）
+  Future<void> _killPane({
+    required String paneId,
+    required bool isLastPane,
+    required bool isLastWindow,
+  }) async {
+    final sshClient = ref.read(sshProvider.notifier).client;
+    if (sshClient == null || !sshClient.isConnected) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('SSH connection is not available')),
+        );
+      }
+      return;
+    }
+
+    // ポーリング停止（SSH競合回避）
+    _pollTimer?.cancel();
+
+    try {
+      await sshClient.exec(TmuxCommands.killPane(paneId));
+      await _refreshSessionTree();
+      if (!mounted || _isDisposed) return;
+
+      // セッション消滅確認（最後のウィンドウの最後のペインだった場合）
+      if (isLastPane && isLastWindow) {
+        final sessionsOutput =
+            await sshClient.exec('tmux list-sessions 2>/dev/null || true');
+        if (!mounted || _isDisposed) return;
+        if (sessionsOutput.trim().isEmpty) {
+          await _disconnect();
+          return;
+        }
+      }
+
+      // 最後のペインだった場合→tmuxが自動選択した新ウィンドウに同期
+      if (isLastPane) {
+        final newTmuxState = ref.read(tmuxProvider);
+        final newSession = newTmuxState.activeSession;
+        if (newSession != null) {
+          final newActiveWindow =
+              newSession.windows.where((w) => w.active).firstOrNull ??
+                  newSession.windows.firstOrNull;
+          if (newActiveWindow != null) {
+            await _selectWindow(newSession.name, newActiveWindow.index);
+          }
+        }
+      } else {
+        // 同じウィンドウ内の残りペインに同期
+        final newTmuxState = ref.read(tmuxProvider);
+        final activeWindow = newTmuxState.activeWindow;
+        if (activeWindow != null) {
+          final newActivePane =
+              activeWindow.panes.where((p) => p.active).firstOrNull ??
+                  activeWindow.panes.firstOrNull;
+          if (newActivePane != null) {
+            await _selectPane(newActivePane.id);
+          }
+        }
+      }
+    } catch (e) {
+      debugPrint('[Terminal] Failed to kill pane: $e');
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Failed to close pane: $e')),
+        );
+      }
+    } finally {
+      // ポーリング再開
+      if (mounted && !_isDisposed) {
+        _startPolling();
+      }
+    }
+  }
+
   /// ペイン選択ダイアログを表示
   void _showPaneSelector(TmuxState tmuxState) {
     final window = tmuxState.activeWindow;
@@ -1655,49 +1810,37 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
                           : (pane.currentCommand?.isNotEmpty == true
                               ? pane.currentCommand!
                               : 'Pane ${pane.index}');
-                      return ListTile(
-                        leading: Container(
-                          width: 32,
-                          height: 32,
-                          decoration: BoxDecoration(
-                            color: isActive
-                                ? colorScheme.primary.withValues(alpha: 0.2)
-                                : colorScheme.onSurface.withValues(alpha: 0.05),
-                            borderRadius: BorderRadius.circular(8),
-                            border: Border.all(
-                              color: isActive
-                                  ? colorScheme.primary.withValues(alpha: 0.5)
-                                  : colorScheme.onSurface.withValues(alpha: 0.1),
-                            ),
-                          ),
-                          child: Center(
-                            child: Text(
-                              '${pane.index}',
-                              style: GoogleFonts.jetBrainsMono(
-                                fontSize: 14,
-                                fontWeight: FontWeight.w700,
-                                color: isActive ? colorScheme.primary : colorScheme.onSurface.withValues(alpha: 0.6),
-                              ),
-                            ),
-                          ),
-                        ),
-                        title: Text(
-                          paneTitle,
-                          style: TextStyle(
-                            color: isActive ? colorScheme.primary : colorScheme.onSurface,
-                            fontWeight: isActive ? FontWeight.bold : FontWeight.normal,
-                          ),
-                        ),
-                        subtitle: Text(
-                          '${pane.width}x${pane.height}',
-                          style: TextStyle(color: colorScheme.onSurface.withValues(alpha: 0.38)),
-                        ),
-                        trailing: isActive
-                            ? Icon(Icons.check, color: colorScheme.primary)
-                            : null,
+                      return TmuxPaneTile(
+                        pane: pane,
+                        paneTitle: paneTitle,
+                        isActive: isActive,
                         onTap: () {
                           Navigator.pop(context);
                           _selectPane(pane.id);
+                        },
+                        onLongPress: () {
+                          Navigator.pop(context);
+                          _confirmAndKillPane(
+                            paneId: pane.id,
+                            paneTitle: paneTitle,
+                            isLastPane: window.panes.length == 1,
+                            isLastWindow:
+                                (tmuxState.activeSession?.windows.length ??
+                                        0) ==
+                                    1,
+                          );
+                        },
+                        onClose: () {
+                          Navigator.pop(context);
+                          _confirmAndKillPane(
+                            paneId: pane.id,
+                            paneTitle: paneTitle,
+                            isLastPane: window.panes.length == 1,
+                            isLastWindow:
+                                (tmuxState.activeSession?.windows.length ??
+                                        0) ==
+                                    1,
+                          );
                         },
                       );
                     },

--- a/lib/widgets/active_list_tile.dart
+++ b/lib/widgets/active_list_tile.dart
@@ -12,6 +12,7 @@ class ActiveListTile extends StatelessWidget {
   final String? subtitle;
   final Widget? trailing;
   final VoidCallback? onTap;
+  final VoidCallback? onLongPress;
   final bool showLeftBar;
   final Color? leftBarColor;
   final double leftBarWidth;
@@ -24,6 +25,7 @@ class ActiveListTile extends StatelessWidget {
     this.subtitle,
     this.trailing,
     this.onTap,
+    this.onLongPress,
     this.showLeftBar = true,
     this.leftBarColor,
     this.leftBarWidth = 3,
@@ -61,6 +63,7 @@ class ActiveListTile extends StatelessWidget {
             : null,
         trailing: trailing,
         onTap: onTap,
+        onLongPress: onLongPress,
       ),
     );
   }

--- a/lib/widgets/tmux_tiles.dart
+++ b/lib/widgets/tmux_tiles.dart
@@ -34,6 +34,99 @@ class TmuxSessionTile extends StatelessWidget {
   }
 }
 
+/// tmuxペイン用ListTile
+class TmuxPaneTile extends StatelessWidget {
+  final TmuxPane pane;
+  final String paneTitle;
+  final bool isActive;
+  final VoidCallback? onTap;
+  final VoidCallback? onLongPress;
+  final VoidCallback? onClose;
+
+  const TmuxPaneTile({
+    super.key,
+    required this.pane,
+    required this.paneTitle,
+    required this.isActive,
+    this.onTap,
+    this.onLongPress,
+    this.onClose,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return ActiveListTile(
+      isActive: isActive,
+      leading: Container(
+        width: 32,
+        height: 32,
+        decoration: BoxDecoration(
+          color: isActive
+              ? colorScheme.primary.withValues(alpha: 0.2)
+              : colorScheme.onSurface.withValues(alpha: 0.05),
+          borderRadius: BorderRadius.circular(8),
+          border: Border.all(
+            color: isActive
+                ? colorScheme.primary.withValues(alpha: 0.5)
+                : colorScheme.onSurface.withValues(alpha: 0.1),
+          ),
+        ),
+        child: Center(
+          child: Text(
+            '${pane.index}',
+            style: TextStyle(
+              fontFamily: 'JetBrains Mono',
+              fontSize: 14,
+              fontWeight: FontWeight.w700,
+              color: isActive
+                  ? colorScheme.primary
+                  : colorScheme.onSurface.withValues(alpha: 0.6),
+            ),
+          ),
+        ),
+      ),
+      title: paneTitle,
+      subtitle: '${pane.width}x${pane.height}',
+      trailing: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          if (onClose != null)
+            PopupMenuButton<String>(
+              icon: Icon(
+                Icons.more_vert,
+                size: 20,
+                color: colorScheme.onSurface.withValues(alpha: 0.6),
+              ),
+              padding: EdgeInsets.zero,
+              itemBuilder: (menuContext) => [
+                PopupMenuItem(
+                  value: 'close',
+                  child: Row(
+                    children: [
+                      Icon(Icons.close, size: 18, color: DesignColors.error),
+                      const SizedBox(width: 8),
+                      Text('Close Pane',
+                          style: TextStyle(color: DesignColors.error)),
+                    ],
+                  ),
+                ),
+              ],
+              onSelected: (value) {
+                if (value == 'close') {
+                  onClose?.call();
+                }
+              },
+            ),
+        ],
+      ),
+      onTap: onTap,
+      onLongPress: onLongPress,
+    );
+  }
+}
+
 /// tmuxウィンドウ用ListTile
 class TmuxWindowTile extends StatelessWidget {
   final TmuxWindow window;

--- a/test/services/tmux/tmux_commands_test.dart
+++ b/test/services/tmux/tmux_commands_test.dart
@@ -1,0 +1,159 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_muxpod/services/tmux/tmux_commands.dart';
+
+void main() {
+  group('TmuxCommands', () {
+    group('killPane', () {
+      test('generates correct kill-pane command for standard pane ID', () {
+        expect(TmuxCommands.killPane('%0'), 'tmux kill-pane -t %0');
+      });
+
+      test('generates correct kill-pane command for multi-digit pane ID', () {
+        expect(TmuxCommands.killPane('%42'), 'tmux kill-pane -t %42');
+      });
+
+      test('escapes pane ID with special characters', () {
+        // Normally pane IDs are %N, but _escapeArg should handle edge cases
+        expect(
+          TmuxCommands.killPane('%1'),
+          'tmux kill-pane -t %1',
+        );
+      });
+    });
+
+    group('selectPane', () {
+      test('generates correct select-pane command', () {
+        expect(TmuxCommands.selectPane('%0'), 'tmux select-pane -t %0');
+      });
+    });
+
+    group('splitWindowHorizontal', () {
+      test('generates basic horizontal split command', () {
+        expect(
+          TmuxCommands.splitWindowHorizontal(target: '%0'),
+          'tmux split-window -h -t %0',
+        );
+      });
+
+      test('generates horizontal split with percentage', () {
+        expect(
+          TmuxCommands.splitWindowHorizontal(target: '%1', percentage: 50),
+          'tmux split-window -h -t %1 -p 50',
+        );
+      });
+
+      test('generates horizontal split with start directory', () {
+        expect(
+          TmuxCommands.splitWindowHorizontal(
+            target: '%0',
+            startDirectory: '/home/user',
+          ),
+          'tmux split-window -h -t %0 -c /home/user',
+        );
+      });
+
+      test('generates horizontal split with directory containing spaces', () {
+        expect(
+          TmuxCommands.splitWindowHorizontal(
+            target: '%0',
+            startDirectory: '/home/my projects',
+          ),
+          'tmux split-window -h -t %0 -c "/home/my projects"',
+        );
+      });
+    });
+
+    group('splitWindowVertical', () {
+      test('generates basic vertical split command', () {
+        expect(
+          TmuxCommands.splitWindowVertical(target: '%0'),
+          'tmux split-window -v -t %0',
+        );
+      });
+    });
+
+    group('killSession', () {
+      test('generates correct kill-session command', () {
+        expect(
+          TmuxCommands.killSession('my-session'),
+          'tmux kill-session -t my-session',
+        );
+      });
+
+      test('escapes session name with spaces', () {
+        expect(
+          TmuxCommands.killSession('my session'),
+          'tmux kill-session -t "my session"',
+        );
+      });
+    });
+
+    group('killWindow', () {
+      test('generates correct kill-window command', () {
+        expect(
+          TmuxCommands.killWindow('my-session', 2),
+          'tmux kill-window -t my-session:2',
+        );
+      });
+    });
+
+    group('resizePane', () {
+      test('generates zoom command', () {
+        expect(
+          TmuxCommands.resizePane('%0', zoom: true),
+          'tmux resize-pane -t %0 -Z',
+        );
+      });
+
+      test('generates unzoom command', () {
+        expect(
+          TmuxCommands.resizePane('%0', zoom: false),
+          'tmux resize-pane -t %0 -z',
+        );
+      });
+    });
+
+    group('sendKeys', () {
+      test('generates literal send-keys command', () {
+        // _escapeArg escapes backslashes, so \\ becomes \\\\
+        expect(
+          TmuxCommands.sendKeys('%0', '\\x1b[I', literal: true),
+          'tmux send-keys -t %0 -l "\\\\x1b[I"',
+        );
+      });
+
+      test('generates non-literal send-keys command', () {
+        expect(
+          TmuxCommands.sendKeys('%0', 'Enter'),
+          'tmux send-keys -t %0 Enter',
+        );
+      });
+    });
+
+    group('chain', () {
+      test('chains multiple commands with &&', () {
+        expect(
+          TmuxCommands.chain(['tmux kill-pane -t %0', 'tmux list-panes']),
+          'tmux kill-pane -t %0 && tmux list-panes',
+        );
+      });
+    });
+  });
+
+  group('SplitDirection', () {
+    test('has horizontal and vertical values', () {
+      expect(SplitDirection.values, contains(SplitDirection.horizontal));
+      expect(SplitDirection.values, contains(SplitDirection.vertical));
+    });
+  });
+
+  group('TmuxLayout', () {
+    test('name returns correct tmux layout string', () {
+      expect(TmuxLayout.evenHorizontal.name, 'even-horizontal');
+      expect(TmuxLayout.evenVertical.name, 'even-vertical');
+      expect(TmuxLayout.mainHorizontal.name, 'main-horizontal');
+      expect(TmuxLayout.mainVertical.name, 'main-vertical');
+      expect(TmuxLayout.tiled.name, 'tiled');
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- tmuxペインを閉じる機能を実装（Issue #19）
- feat/issue018-close-window をmergeし、共通コンポーネント（`ActiveListTile`, `TmuxPaneTile`）を統一
- `TmuxCommands` のユニットテストを追加

## Changes

### 共通コンポーネント
- `lib/widgets/active_list_tile.dart` — `onLongPress` サポート追加
- `lib/widgets/tmux_tiles.dart` — `TmuxPaneTile` を追加（三点リーダーメニュー + 長押し + 左端バーインジケーター）

### ペインclose機能 (`terminal_screen.dart`)
- `_confirmAndKillPane` — 確認ダイアログ（最後のペイン/ウィンドウ時に特別警告）
- `_killPane` — SSH経由で `kill-pane` 実行 → `_refreshSessionTree` → 状態同期
- `_showPaneSelector` のListTileを `TmuxPaneTile` に置換
- 最後のペイン → 前のウィンドウに自動切替
- セッション消滅時 → `_disconnect()` で接続一覧に戻る
- 通常ケース → 残りペインへ `_selectPane` で自動切替

### テスト
- `test/services/tmux/tmux_commands_test.dart` — killPane, selectPane, splitWindow, killSession, killWindow, resizePane, sendKeys, chain 等をカバー

### issue018 からのmerge含む
- ウィンドウclose機能
- `SessionTree` のTmuxParser型統一 + 左端バーインジケーター
- 未使用の `SessionDrawer` 削除

## Test plan
- [ ] `flutter analyze` — 静的解析パス
- [ ] `flutter test test/services/tmux/` — 40テスト全パス
- [ ] 2ペイン状態で1ペイン削除 → 残りペインに自動切替
- [ ] 最後のペイン削除 → ウィンドウ自動切替
- [ ] 最後のウィンドウの最後のペイン → セッション終了、接続一覧に戻る
- [ ] 三点リーダーメニュー / 長押しでClose Pane確認ダイアログ表示
- [ ] 確認ダイアログでキャンセル → 何も起きない

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)