### PR TITLE
feat: ウィンドウ/ペインリサイズ機能を追加 (#28)

### DIFF
--- a/lib/providers/terminal_display_provider.dart
+++ b/lib/providers/terminal_display_provider.dart
@@ -17,6 +17,9 @@ class TerminalDisplayState {
   /// 利用可能なスクリーン幅（ピクセル）
   final double screenWidth;
 
+  /// 利用可能なスクリーン高さ（ピクセル）
+  final double screenHeight;
+
   /// 計算されたフォントサイズ
   final double calculatedFontSize;
 
@@ -36,6 +39,7 @@ class TerminalDisplayState {
     this.paneWidth = 80,
     this.paneHeight = 24,
     this.screenWidth = 0.0,
+    this.screenHeight = 0.0,
     this.calculatedFontSize = 14.0,
     this.needsHorizontalScroll = false,
     this.horizontalScrollOffset = 0.0,
@@ -55,6 +59,7 @@ class TerminalDisplayState {
     int? paneWidth,
     int? paneHeight,
     double? screenWidth,
+    double? screenHeight,
     double? calculatedFontSize,
     bool? needsHorizontalScroll,
     double? horizontalScrollOffset,
@@ -65,6 +70,7 @@ class TerminalDisplayState {
       paneWidth: paneWidth ?? this.paneWidth,
       paneHeight: paneHeight ?? this.paneHeight,
       screenWidth: screenWidth ?? this.screenWidth,
+      screenHeight: screenHeight ?? this.screenHeight,
       calculatedFontSize: calculatedFontSize ?? this.calculatedFontSize,
       needsHorizontalScroll: needsHorizontalScroll ?? this.needsHorizontalScroll,
       horizontalScrollOffset: horizontalScrollOffset ?? this.horizontalScrollOffset,
@@ -81,6 +87,7 @@ class TerminalDisplayState {
           paneWidth == other.paneWidth &&
           paneHeight == other.paneHeight &&
           screenWidth == other.screenWidth &&
+          screenHeight == other.screenHeight &&
           calculatedFontSize == other.calculatedFontSize &&
           needsHorizontalScroll == other.needsHorizontalScroll &&
           horizontalScrollOffset == other.horizontalScrollOffset &&
@@ -92,6 +99,7 @@ class TerminalDisplayState {
         paneWidth,
         paneHeight,
         screenWidth,
+        screenHeight,
         calculatedFontSize,
         needsHorizontalScroll,
         horizontalScrollOffset,
@@ -130,6 +138,15 @@ class TerminalDisplayNotifier extends Notifier<TerminalDisplayState> {
     if (state.screenWidth == width) return; // 変更なしなら何もしない
     state = state.copyWith(screenWidth: width);
     _recalculateFontSize();
+  }
+
+  /// スクリーンサイズを更新
+  ///
+  /// LayoutBuilder から幅と高さの両方を更新する。
+  void updateScreenSize(double width, double height) {
+    state = state.copyWith(screenWidth: width, screenHeight: height);
+    _recalculateFontSize();
+    _updateScrollRequirement();
   }
 
   /// 水平スクロール位置を更新

--- a/lib/screens/terminal/terminal_screen.dart
+++ b/lib/screens/terminal/terminal_screen.dart
@@ -19,6 +19,8 @@ import '../../services/ssh/ssh_client.dart' show SshConnectOptions;
 import '../../services/tmux/pane_navigator.dart';
 import '../../services/tmux/tmux_commands.dart';
 import '../../services/tmux/tmux_parser.dart';
+import '../../services/tmux/tmux_version.dart';
+import '../../widgets/dialogs/resize_dialog.dart';
 import '../../theme/design_colors.dart';
 import '../../widgets/scroll_to_bottom_button.dart';
 import '../../widgets/special_keys_bar.dart';
@@ -168,6 +170,12 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
 
   // ウィンドウ作成中フラグ（連打防止）
   bool _isCreatingWindow = false;
+
+  // リサイズ中フラグ（排他制御）
+  bool _isResizing = false;
+
+  // tmuxバージョン情報（リサイズ機能判定用）
+  TmuxVersionInfo? _tmuxVersion;
 
   // Riverpodリスナー
   ProviderSubscription<SshState>? _sshSubscription;
@@ -364,7 +372,17 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         return;
       }
 
-      // 4. セッションツリー全体を取得
+      // 3.5. tmuxバー��ョン取得（リサイズ機能判定用）
+      try {
+        final versionOutput = await sshNotifier.client?.exec(TmuxCommands.version());
+        if (versionOutput != null) {
+          _tmuxVersion = TmuxVersionInfo.parse(versionOutput);
+        }
+      } catch (_) {
+        _tmuxVersion = null;
+      }
+
+      // 4. セ���ションツリー全体を取得
       await _refreshSessionTree();
       if (!mounted || _isDisposed) {
         return;
@@ -1523,6 +1541,16 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
                       ),
                       const Spacer(),
                       IconButton(
+                        icon: Icon(Icons.open_in_full, color: colorScheme.primary),
+                        tooltip: 'Resize Window',
+                        onPressed: () {
+                          Navigator.pop(sheetContext);
+                          Future.delayed(const Duration(milliseconds: 200), () {
+                            if (mounted) _showResizeWindowChooser(tmuxState);
+                          });
+                        },
+                      ),
+                      IconButton(
                         icon: Icon(Icons.add, color: colorScheme.primary),
                         tooltip: 'New Window',
                         onPressed: () {
@@ -1549,6 +1577,10 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
                         onTap: () {
                           Navigator.pop(context);
                           _selectWindow(session.name, window.index);
+                        },
+                        onResize: () {
+                          Navigator.pop(context);
+                          _handleResizeWindow(window);
                         },
                         onClose: () {
                           Navigator.pop(context);
@@ -1745,6 +1777,167 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     );
   }
 
+  /// リサイズ対象のペインをグラフィカルに選択するダイアログ
+  void _showResizePaneChooser(TmuxState tmuxState) {
+    final window = tmuxState.activeWindow;
+    if (window == null || window.panes.isEmpty) return;
+
+    showDialog(
+      context: context,
+      builder: (dialogContext) {
+        return _ResizePaneChooserDialog(
+          panes: window.panes,
+          activePaneId: tmuxState.activePaneId,
+          onResize: (selectedPane) {
+            Navigator.pop(dialogContext);
+            _handleResizePane(selectedPane);
+          },
+        );
+      },
+    );
+  }
+
+  /// リサイズ対象のウィンドウをグラフィカルに選択するダイアログ
+  void _showResizeWindowChooser(TmuxState tmuxState) {
+    final session = tmuxState.activeSession;
+    if (session == null || session.windows.isEmpty) return;
+
+    showDialog(
+      context: context,
+      builder: (dialogContext) {
+        return _ResizeWindowChooserDialog(
+          windows: session.windows,
+          activeWindowIndex: tmuxState.activeWindowIndex,
+          onResize: (selectedWindow) {
+            Navigator.pop(dialogContext);
+            _handleResizeWindow(selectedWindow);
+          },
+        );
+      },
+    );
+  }
+
+  /// ペインをリサイズ
+  Future<void> _handleResizePane(TmuxPane pane) async {
+    if (_isResizing) return;
+
+    final displayState = ref.read(terminalDisplayProvider);
+    final settings = ref.read(settingsProvider);
+    final tmuxState = ref.read(tmuxProvider);
+
+    // 現在のウィンドウの全ペインを取���
+    final activeWindow = tmuxState.activeWindow;
+    final allPanes = activeWindow?.panes ?? [pane];
+
+    debugPrint('[ResizePane] pane=${pane.id} size=${pane.width}x${pane.height} '
+        'left=${pane.left} top=${pane.top} allPanes=${allPanes.length}');
+    debugPrint('[ResizePane] screenWidth=${displayState.screenWidth} '
+        'screenHeight=${displayState.screenHeight} '
+        'fontSize=${displayState.calculatedFontSize} '
+        'fontFamily=${settings.fontFamily}');
+
+    final result = await showDialog<ResizeResult>(
+      context: context,
+      builder: (context) => ResizePaneDialog(
+        targetPane: pane,
+        allPanesInWindow: allPanes,
+        currentCols: pane.width,
+        currentRows: pane.height,
+        screenWidth: displayState.screenWidth,
+        screenHeight: displayState.screenHeight,
+        fontSize: displayState.calculatedFontSize,
+        fontFamily: settings.fontFamily,
+      ),
+    );
+
+    if (result == null || !mounted) return;
+
+    _isResizing = true;
+    _pollTimer?.cancel();
+    try {
+      final sshClient = ref.read(sshProvider.notifier).client;
+      if (sshClient == null) return;
+      await sshClient.exec(
+        TmuxCommands.resizePaneToSize(pane.id, cols: result.cols, rows: result.rows),
+      );
+      await _refreshSessionTree();
+      // 明示的にupdatePaneを呼んでフォント再計算
+      final activePane = ref.read(tmuxProvider).activePane;
+      if (activePane != null) {
+        ref.read(terminalDisplayProvider.notifier).updatePane(activePane);
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Resize failed: $e')),
+        );
+      }
+    } finally {
+      _isResizing = false;
+      if (mounted && !_isDisposed) _startPolling();
+    }
+  }
+
+  /// ウィンドウをリサイズ
+  Future<void> _handleResizeWindow(TmuxWindow window) async {
+    if (_isResizing) return;
+
+    final displayState = ref.read(terminalDisplayProvider);
+    final settings = ref.read(settingsProvider);
+
+    // ウィンドウサイズはペインのwidth+leftの最大値で推定
+    final panes = window.panes;
+    int windowCols = 80;
+    int windowRows = 24;
+    if (panes.isNotEmpty) {
+      windowCols = panes.map((p) => p.left + p.width).reduce((a, b) => a > b ? a : b);
+      windowRows = panes.map((p) => p.top + p.height).reduce((a, b) => a > b ? a : b);
+    }
+
+    final result = await showDialog<ResizeResult>(
+      context: context,
+      builder: (context) => ResizeWindowDialog(
+        window: window,
+        panes: panes,
+        currentCols: windowCols,
+        currentRows: windowRows,
+        screenWidth: displayState.screenWidth,
+        screenHeight: displayState.screenHeight,
+        fontSize: displayState.calculatedFontSize,
+        fontFamily: settings.fontFamily,
+        supportsResizeWindow: _tmuxVersion?.supportsResizeWindow ?? false,
+      ),
+    );
+
+    if (result == null || !mounted) return;
+
+    _isResizing = true;
+    _pollTimer?.cancel();
+    try {
+      final sshClient = ref.read(sshProvider.notifier).client;
+      if (sshClient == null) return;
+      final tmuxState = ref.read(tmuxProvider);
+      final target = '${tmuxState.activeSessionName}:${window.index}';
+      await sshClient.exec(
+        TmuxCommands.resizeWindow(target, cols: result.cols, rows: result.rows),
+      );
+      await _refreshSessionTree();
+      final activePane = ref.read(tmuxProvider).activePane;
+      if (activePane != null) {
+        ref.read(terminalDisplayProvider.notifier).updatePane(activePane);
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Resize failed: $e')),
+        );
+      }
+    } finally {
+      _isResizing = false;
+      if (mounted && !_isDisposed) _startPolling();
+    }
+  }
+
   /// ペインを閉じる（SSH経由でkill-pane実行）
   Future<void> _killPane({
     required String paneId,
@@ -1856,6 +2049,17 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
                           color: colorScheme.onSurface,
                         ),
                       ),
+                      const Spacer(),
+                      IconButton(
+                        icon: Icon(Icons.open_in_full, color: colorScheme.primary),
+                        tooltip: 'Resize Pane',
+                        onPressed: () {
+                          Navigator.pop(sheetContext);
+                          Future.delayed(const Duration(milliseconds: 200), () {
+                            if (mounted) _showResizePaneChooser(tmuxState);
+                          });
+                        },
+                      ),
                     ],
                   ),
                 ),
@@ -1907,6 +2111,10 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
                                         0) ==
                                     1,
                           );
+                        },
+                        onResize: () {
+                          Navigator.pop(context);
+                          _handleResizePane(pane);
                         },
                         onClose: () {
                           Navigator.pop(context);
@@ -3475,6 +3683,418 @@ class _NewWindowDialogState extends State<_NewWindowDialog> {
           child: const Text('Create'),
         ),
       ],
+    );
+  }
+}
+
+// ====================================================================
+// _ResizePaneChooserDialog
+// ====================================================================
+
+/// リサイズ対象ペインをグラフィカルに選択するダイアログ
+class _ResizePaneChooserDialog extends StatefulWidget {
+  final List<TmuxPane> panes;
+  final String? activePaneId;
+  final void Function(TmuxPane selectedPane) onResize;
+
+  const _ResizePaneChooserDialog({
+    required this.panes,
+    this.activePaneId,
+    required this.onResize,
+  });
+
+  @override
+  State<_ResizePaneChooserDialog> createState() =>
+      _ResizePaneChooserDialogState();
+}
+
+class _ResizePaneChooserDialogState extends State<_ResizePaneChooserDialog> {
+  late String? _selectedPaneId;
+
+  @override
+  void initState() {
+    super.initState();
+    // デフォルト: 現在アクティブなペインが選択状態
+    _selectedPaneId = widget.activePaneId;
+  }
+
+  TmuxPane? get _selectedPane {
+    if (_selectedPaneId == null) return null;
+    try {
+      return widget.panes.firstWhere((p) => p.id == _selectedPaneId);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final selected = _selectedPane;
+
+    return AlertDialog(
+      backgroundColor: DesignColors.surfaceDark,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      title: const Text(
+        'Resize Pane',
+        style: TextStyle(color: DesignColors.textPrimary),
+      ),
+      content: SizedBox(
+        width: MediaQuery.of(context).size.width * 0.8,
+        child: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            // ペインレイアウトのグリッドプレビュー
+            _buildSelectablePaneGrid(),
+            const SizedBox(height: 12),
+            // 選択中のペイン情報
+            if (selected != null)
+              Text(
+                'Selected: Pane ${selected.index} (${selected.width}x${selected.height})',
+                style: const TextStyle(
+                  fontSize: 13,
+                  color: DesignColors.textSecondary,
+                ),
+              )
+            else
+              const Text(
+                'Tap a pane to select',
+                style: TextStyle(
+                  fontSize: 13,
+                  color: DesignColors.textSecondary,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          onPressed: selected != null ? () => widget.onResize(selected) : null,
+          style: FilledButton.styleFrom(
+            backgroundColor: DesignColors.primary,
+          ),
+          child: const Text('Resize'),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildSelectablePaneGrid() {
+    if (widget.panes.isEmpty) return const SizedBox.shrink();
+
+    // ウィンドウ全体のサイズを計算
+    int maxRight = 0;
+    int maxBottom = 0;
+    for (final pane in widget.panes) {
+      final right = pane.left + pane.width;
+      final bottom = pane.top + pane.height;
+      if (right > maxRight) maxRight = right;
+      if (bottom > maxBottom) maxBottom = bottom;
+    }
+    if (maxRight == 0) maxRight = 1;
+    if (maxBottom == 0) maxBottom = 1;
+
+    return Container(
+      height: 150,
+      clipBehavior: Clip.hardEdge,
+      decoration: BoxDecoration(
+        color: DesignColors.canvasDark,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: DesignColors.borderDark),
+      ),
+      child: LayoutBuilder(
+          builder: (context, constraints) {
+            const pad = 4.0;
+            final areaW = constraints.maxWidth - pad * 2;
+            final areaH = constraints.maxHeight - pad * 2;
+            final scaleX = areaW / maxRight;
+            final scaleY = areaH / maxBottom;
+
+            return Padding(
+              padding: const EdgeInsets.all(pad),
+              child: Stack(
+                children: [
+                  SizedBox(width: areaW, height: areaH),
+                  ...widget.panes.map((pane) {
+                  final isSelected = pane.id == _selectedPaneId;
+                  final left = pane.left * scaleX;
+                  final top = pane.top * scaleY;
+                  final width = (pane.width * scaleX).clamp(20.0, areaW - left);
+                  final height = (pane.height * scaleY).clamp(14.0, areaH - top);
+
+                  return Positioned(
+                    left: left,
+                    top: top,
+                    width: width,
+                    height: height,
+                    child: GestureDetector(
+                      onTap: () => setState(() => _selectedPaneId = pane.id),
+                      child: AnimatedContainer(
+                        duration: const Duration(milliseconds: 150),
+                        decoration: BoxDecoration(
+                          color: isSelected
+                              ? DesignColors.primary.withValues(alpha: 0.25)
+                              : DesignColors.surfaceDark,
+                          borderRadius: BorderRadius.circular(4),
+                          border: Border.all(
+                            color: isSelected
+                                ? DesignColors.primary
+                                : DesignColors.borderDark,
+                            width: isSelected ? 2 : 1,
+                          ),
+                        ),
+                        alignment: Alignment.center,
+                        child: FittedBox(
+                          fit: BoxFit.scaleDown,
+                          child: Padding(
+                            padding: const EdgeInsets.symmetric(horizontal: 2),
+                            child: Text(
+                              '${pane.index}\n${pane.width}x${pane.height}',
+                              textAlign: TextAlign.center,
+                              style: TextStyle(
+                                fontSize: 10,
+                                color: isSelected
+                                    ? DesignColors.primary
+                                    : DesignColors.textSecondary,
+                              ),
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                  );
+                }),
+              ]),
+            );
+          },
+        ),
+      );
+  }
+}
+
+// ====================================================================
+// _ResizeWindowChooserDialog
+// ====================================================================
+
+/// リサイズ対象ウィンドウをグラフィカルに選択するダイアログ
+class _ResizeWindowChooserDialog extends StatefulWidget {
+  final List<TmuxWindow> windows;
+  final int? activeWindowIndex;
+  final void Function(TmuxWindow selectedWindow) onResize;
+
+  const _ResizeWindowChooserDialog({
+    required this.windows,
+    this.activeWindowIndex,
+    required this.onResize,
+  });
+
+  @override
+  State<_ResizeWindowChooserDialog> createState() =>
+      _ResizeWindowChooserDialogState();
+}
+
+class _ResizeWindowChooserDialogState
+    extends State<_ResizeWindowChooserDialog> {
+  late int? _selectedWindowIndex;
+
+  @override
+  void initState() {
+    super.initState();
+    // デフォルト: 現在アクティブなウィンドウが選択状態
+    _selectedWindowIndex = widget.activeWindowIndex;
+  }
+
+  TmuxWindow? get _selectedWindow {
+    if (_selectedWindowIndex == null) return null;
+    try {
+      return widget.windows
+          .firstWhere((w) => w.index == _selectedWindowIndex);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final selected = _selectedWindow;
+
+    return AlertDialog(
+      backgroundColor: DesignColors.surfaceDark,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      title: const Text(
+        'Resize Window',
+        style: TextStyle(color: DesignColors.textPrimary),
+      ),
+      content: SizedBox(
+        width: MediaQuery.of(context).size.width * 0.8,
+        child: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              // ウィンドウカード一覧
+              ...widget.windows.map((window) {
+                final isSelected = window.index == _selectedWindowIndex;
+                return Padding(
+                  padding: const EdgeInsets.only(bottom: 8),
+                  child: _buildWindowCard(window, isSelected),
+                );
+              }),
+              const SizedBox(height: 4),
+              // 選択中のウィンドウ情報
+              if (selected != null) ...[
+                Text(
+                  'Selected: ${selected.name} (${_windowSizeString(selected)})',
+                  style: const TextStyle(
+                    fontSize: 13,
+                    color: DesignColors.textSecondary,
+                  ),
+                ),
+              ] else
+                const Text(
+                  'Tap a window to select',
+                  style: TextStyle(
+                    fontSize: 13,
+                    color: DesignColors.textSecondary,
+                  ),
+                ),
+            ],
+          ),
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          onPressed:
+              selected != null ? () => widget.onResize(selected) : null,
+          style: FilledButton.styleFrom(
+            backgroundColor: DesignColors.primary,
+          ),
+          child: const Text('Resize'),
+        ),
+      ],
+    );
+  }
+
+  String _windowSizeString(TmuxWindow window) {
+    final panes = window.panes;
+    if (panes.isEmpty) return '?x?';
+    final cols =
+        panes.map((p) => p.left + p.width).reduce((a, b) => a > b ? a : b);
+    final rows =
+        panes.map((p) => p.top + p.height).reduce((a, b) => a > b ? a : b);
+    return '${cols}x$rows';
+  }
+
+  Widget _buildWindowCard(TmuxWindow window, bool isSelected) {
+    final panes = window.panes;
+    return GestureDetector(
+      onTap: () => setState(() => _selectedWindowIndex = window.index),
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 150),
+        decoration: BoxDecoration(
+          color: DesignColors.canvasDark,
+          borderRadius: BorderRadius.circular(8),
+          border: Border.all(
+            color: isSelected ? DesignColors.primary : DesignColors.borderDark,
+            width: isSelected ? 2 : 1,
+          ),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // ウィンドウヘッダー
+            Container(
+              width: double.infinity,
+              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
+              decoration: BoxDecoration(
+                color: isSelected
+                    ? DesignColors.primary.withValues(alpha: 0.15)
+                    : DesignColors.surfaceDark,
+                borderRadius: const BorderRadius.only(
+                  topLeft: Radius.circular(7),
+                  topRight: Radius.circular(7),
+                ),
+              ),
+              child: Text(
+                '${window.name}  ${_windowSizeString(window)}',
+                style: TextStyle(
+                  fontSize: 12,
+                  color: isSelected
+                      ? DesignColors.primary
+                      : DesignColors.textPrimary,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ),
+            // ペインレイアウトプレビュー
+            if (panes.isNotEmpty)
+              SizedBox(
+                height: 60,
+                child: _buildPaneLayoutPreview(panes),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildPaneLayoutPreview(List<TmuxPane> panes) {
+    int maxRight = 0;
+    int maxBottom = 0;
+    for (final p in panes) {
+      final right = p.left + p.width;
+      final bottom = p.top + p.height;
+      if (right > maxRight) maxRight = right;
+      if (bottom > maxBottom) maxBottom = bottom;
+    }
+    if (maxRight == 0) maxRight = 1;
+    if (maxBottom == 0) maxBottom = 1;
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final areaW = constraints.maxWidth - 8;
+        final areaH = constraints.maxHeight - 8;
+
+        return Padding(
+          padding: const EdgeInsets.all(4),
+          child: Stack(
+            children: [
+              SizedBox(width: areaW, height: areaH),
+              ...panes.map((pane) {
+              final left = (pane.left / maxRight) * areaW;
+              final top = (pane.top / maxBottom) * areaH;
+              final width = (pane.width / maxRight) * areaW;
+              final height = (pane.height / maxBottom) * areaH;
+
+              return Positioned(
+                left: left,
+                top: top,
+                width: width.clamp(16.0, areaW),
+                height: height.clamp(10.0, areaH),
+                child: Container(
+                  decoration: BoxDecoration(
+                    borderRadius: BorderRadius.circular(2),
+                    border: Border.all(
+                      color: DesignColors.borderDark,
+                      width: 1,
+                    ),
+                  ),
+                ),
+              );
+            }),
+          ]),
+        );
+      },
     );
   }
 }

--- a/lib/screens/terminal/widgets/ansi_text_view.dart
+++ b/lib/screens/terminal/widgets/ansi_text_view.dart
@@ -4,6 +4,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../providers/settings_provider.dart';
+import '../../../providers/terminal_display_provider.dart';
 import '../../../services/terminal/ansi_parser.dart';
 import '../../../services/terminal/font_calculator.dart';
 import '../../../services/terminal/terminal_diff.dart';
@@ -705,6 +706,22 @@ class AnsiTextViewState extends ConsumerState<AnsiTextView>
 
     return LayoutBuilder(
       builder: (context, constraints) {
+        // スクリーンサイズをTerminalDisplayProviderに通知（リサイズダイアログ用）
+        // build中のprovider変更は禁止のためフレーム後に実行
+        // 値が変わった時のみ更新（無限ループ防止）
+        final currentDisplay = ref.read(terminalDisplayProvider);
+        if (currentDisplay.screenWidth != constraints.maxWidth ||
+            currentDisplay.screenHeight != constraints.maxHeight) {
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            if (mounted) {
+              ref.read(terminalDisplayProvider.notifier).updateScreenSize(
+                    constraints.maxWidth,
+                    constraints.maxHeight,
+                  );
+            }
+          });
+        }
+
         // フォントサイズを決定
         late final double fontSize;
         late final bool needsHorizontalScroll;

--- a/lib/services/terminal/font_calculator.dart
+++ b/lib/services/terminal/font_calculator.dart
@@ -400,6 +400,30 @@ class FontCalculator {
     return 1;
   }
 
+  /// 指定フォントサイズで画面幅に収まる最大カラム数を計算
+  static int calculateMaxCols({
+    required double screenWidth,
+    required double fontSize,
+    required String fontFamily,
+  }) {
+    final charWidthRatio = measureCharWidthRatio(fontFamily);
+    final charWidth = charWidthRatio * fontSize;
+    if (charWidth <= 0) return 80;
+    return (screenWidth / charWidth).floor().clamp(10, 999);
+  }
+
+  /// 指定フォントサイズで画面高さに収まる最大行数を計算
+  static int calculateMaxRows({
+    required double screenHeight,
+    required double fontSize,
+    required String fontFamily,
+    double lineHeightRatio = 1.2,
+  }) {
+    final lineHeight = fontSize * lineHeightRatio;
+    if (lineHeight <= 0) return 24;
+    return (screenHeight / lineHeight).floor().clamp(5, 999);
+  }
+
   /// テキストのターミナル表示幅（カラム数）を計算
   ///
   /// 異体字セレクタ（VS16等）を考慮した正確な幅計算を行う。

--- a/lib/services/tmux/tmux_commands.dart
+++ b/lib/services/tmux/tmux_commands.dart
@@ -203,6 +203,23 @@ class TmuxCommands {
     return 'tmux resize-pane -t ${_escapeArg(paneId)} ${zoom ? '-Z' : '-z'}';
   }
 
+  /// ペインを指定サイズにリサイズする
+  /// cols/rowsはオプション（片方のみ指定可、tmuxは未指定の方を変更しない）
+  static String resizePaneToSize(String paneId, {int? cols, int? rows}) {
+    final args = <String>['-t', _escapeArg(paneId)];
+    if (cols != null) args.addAll(['-x', '$cols']);
+    if (rows != null) args.addAll(['-y', '$rows']);
+    return 'tmux resize-pane ${args.join(' ')}';
+  }
+
+  /// ウィンドウを指定サイズにリサイズする（tmux 2.9+必須）
+  static String resizeWindow(String target, {int? cols, int? rows}) {
+    final args = <String>['-t', _escapeArg(target)];
+    if (cols != null) args.addAll(['-x', '$cols']);
+    if (rows != null) args.addAll(['-y', '$rows']);
+    return 'tmux resize-window ${args.join(' ')}';
+  }
+
   // ===== 入力・キー送信 =====
 
   /// キーを送信

--- a/lib/services/tmux/tmux_version.dart
+++ b/lib/services/tmux/tmux_version.dart
@@ -1,0 +1,34 @@
+/// tmuxのバージョン情報を保持し、機能の対応状況を判定するクラス
+class TmuxVersionInfo {
+  final int major;
+  final int minor;
+
+  const TmuxVersionInfo(this.major, this.minor);
+
+  /// "tmux 3.4" や "tmux 2.9a" 形式の文字列をパースする
+  /// パース失敗時はnullを返す
+  static TmuxVersionInfo? parse(String versionOutput) {
+    final match = RegExp(r'tmux\s+(\d+)\.(\d+)').firstMatch(versionOutput);
+    if (match == null) return null;
+    return TmuxVersionInfo(
+      int.parse(match.group(1)!),
+      int.parse(match.group(2)!),
+    );
+  }
+
+  /// resize-window -x -y は tmux 2.9+ で追加
+  bool get supportsResizeWindow => major > 2 || (major == 2 && minor >= 9);
+
+  /// resize-pane -x -y は tmux 1.7+ で追加（実質全バージョン対応）
+  bool get supportsResizePaneToSize => major > 1 || (major == 1 && minor >= 7);
+
+  @override
+  String toString() => 'tmux $major.$minor';
+
+  @override
+  bool operator ==(Object other) =>
+      other is TmuxVersionInfo && major == other.major && minor == other.minor;
+
+  @override
+  int get hashCode => Object.hash(major, minor);
+}

--- a/lib/widgets/dialogs/resize_dialog.dart
+++ b/lib/widgets/dialogs/resize_dialog.dart
@@ -1,0 +1,730 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+
+import '../../services/terminal/font_calculator.dart';
+import '../../services/tmux/tmux_parser.dart';
+import '../../theme/design_colors.dart';
+
+/// リサイズ結果
+class ResizeResult {
+  final int cols;
+  final int rows;
+  const ResizeResult({required this.cols, required this.rows});
+}
+
+/// プリセットサイズ定義
+class _SizePreset {
+  final String label;
+  final int cols;
+  final int rows;
+  const _SizePreset(this.label, this.cols, this.rows);
+}
+
+// ====================================================================
+// ResizePaneDialog
+// ====================================================================
+
+/// ペインリサイズ用ダイアログ
+class ResizePaneDialog extends StatefulWidget {
+  final TmuxPane targetPane;
+  final List<TmuxPane> allPanesInWindow;
+  final int currentCols;
+  final int currentRows;
+  final double screenWidth;
+  final double screenHeight;
+  final double fontSize;
+  final String fontFamily;
+
+  const ResizePaneDialog({
+    super.key,
+    required this.targetPane,
+    required this.allPanesInWindow,
+    required this.currentCols,
+    required this.currentRows,
+    required this.screenWidth,
+    required this.screenHeight,
+    required this.fontSize,
+    required this.fontFamily,
+  });
+
+  @override
+  State<ResizePaneDialog> createState() => _ResizePaneDialogState();
+}
+
+class _ResizePaneDialogState extends State<ResizePaneDialog> {
+  late int _cols;
+  late int _rows;
+
+  @override
+  void initState() {
+    super.initState();
+    _cols = widget.currentCols;
+    _rows = widget.currentRows;
+  }
+
+  List<_SizePreset> get _presets {
+    final matchCols = FontCalculator.calculateMaxCols(
+      screenWidth: widget.screenWidth,
+      fontSize: widget.fontSize,
+      fontFamily: widget.fontFamily,
+    );
+    final matchRows = FontCalculator.calculateMaxRows(
+      screenHeight: widget.screenHeight,
+      fontSize: widget.fontSize,
+      fontFamily: widget.fontFamily,
+    );
+    return [
+      const _SizePreset('80x24 (Standard)', 80, 24),
+      const _SizePreset('120x40 (Wide)', 120, 40),
+      const _SizePreset('160x50 (Full HD)', 160, 50),
+      _SizePreset('Match Screen ($matchCols x $matchRows)', matchCols, matchRows),
+    ];
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final mediaSize = MediaQuery.of(context).size;
+    debugPrint('[ResizePaneDialog] build() mediaSize=$mediaSize '
+        'allPanes=${widget.allPanesInWindow.length} '
+        'target=${widget.targetPane.id} '
+        'screenW=${widget.screenWidth} screenH=${widget.screenHeight} '
+        'fontSize=${widget.fontSize} fontFamily=${widget.fontFamily}');
+
+    return AlertDialog(
+      backgroundColor: DesignColors.surfaceDark,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      title: const Text(
+        'Resize Pane',
+        style: TextStyle(color: DesignColors.textPrimary),
+      ),
+      content: SizedBox(
+        width: MediaQuery.of(context).size.width * 0.8,
+        child: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              _buildPaneGridPreview(
+                allPanes: widget.allPanesInWindow,
+                highlightPaneId: widget.targetPane.id,
+                previewPaneId: widget.targetPane.id,
+                previewCols: _cols,
+                previewRows: _rows,
+              ),
+            const SizedBox(height: 12),
+            if (widget.allPanesInWindow.length >= 2)
+              _buildWarning('Other pane sizes may also change.'),
+            const SizedBox(height: 12),
+            _buildSizeInputRow(
+              cols: _cols,
+              rows: _rows,
+              onColsChanged: (v) => setState(() => _cols = v),
+              onRowsChanged: (v) => setState(() => _rows = v),
+            ),
+            const SizedBox(height: 12),
+            _buildPresetChips(
+              presets: _presets,
+              onSelect: (p) => setState(() {
+                _cols = p.cols;
+                _rows = p.rows;
+              }),
+            ),
+            ],
+          ),
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          onPressed: () =>
+              Navigator.pop(context, ResizeResult(cols: _cols, rows: _rows)),
+          style: FilledButton.styleFrom(
+            backgroundColor: DesignColors.primary,
+          ),
+          child: const Text('Resize'),
+        ),
+      ],
+    );
+  }
+}
+
+// ====================================================================
+// ResizeWindowDialog
+// ====================================================================
+
+/// ウィンドウリサイズ用ダイアログ
+class ResizeWindowDialog extends StatefulWidget {
+  final TmuxWindow window;
+  final List<TmuxPane> panes;
+  final int currentCols;
+  final int currentRows;
+  final double screenWidth;
+  final double screenHeight;
+  final double fontSize;
+  final String fontFamily;
+  final bool supportsResizeWindow;
+
+  const ResizeWindowDialog({
+    super.key,
+    required this.window,
+    required this.panes,
+    required this.currentCols,
+    required this.currentRows,
+    required this.screenWidth,
+    required this.screenHeight,
+    required this.fontSize,
+    required this.fontFamily,
+    required this.supportsResizeWindow,
+  });
+
+  @override
+  State<ResizeWindowDialog> createState() => _ResizeWindowDialogState();
+}
+
+class _ResizeWindowDialogState extends State<ResizeWindowDialog> {
+  late int _cols;
+  late int _rows;
+
+  @override
+  void initState() {
+    super.initState();
+    _cols = widget.currentCols;
+    _rows = widget.currentRows;
+  }
+
+  List<_SizePreset> get _presets {
+    final matchCols = FontCalculator.calculateMaxCols(
+      screenWidth: widget.screenWidth,
+      fontSize: widget.fontSize,
+      fontFamily: widget.fontFamily,
+    );
+    final matchRows = FontCalculator.calculateMaxRows(
+      screenHeight: widget.screenHeight,
+      fontSize: widget.fontSize,
+      fontFamily: widget.fontFamily,
+    );
+    return [
+      const _SizePreset('80x24 (Standard)', 80, 24),
+      const _SizePreset('120x40 (Wide)', 120, 40),
+      const _SizePreset('160x50 (Full HD)', 160, 50),
+      _SizePreset('Match Screen ($matchCols x $matchRows)', matchCols, matchRows),
+    ];
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      backgroundColor: DesignColors.surfaceDark,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      title: const Text(
+        'Resize Window',
+        style: TextStyle(color: DesignColors.textPrimary),
+      ),
+      content: SizedBox(
+        width: MediaQuery.of(context).size.width * 0.8,
+        child: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              _buildWindowGridPreview(
+                window: widget.window,
+                panes: widget.panes,
+                currentCols: widget.currentCols,
+                currentRows: widget.currentRows,
+              ),
+            const SizedBox(height: 12),
+            if (!widget.supportsResizeWindow)
+              _buildWarning('Window resize requires tmux 2.9+. Resize button disabled.'),
+            const SizedBox(height: 12),
+            _buildSizeInputRow(
+              cols: _cols,
+              rows: _rows,
+              onColsChanged: (v) => setState(() => _cols = v),
+              onRowsChanged: (v) => setState(() => _rows = v),
+            ),
+            const SizedBox(height: 12),
+            _buildPresetChips(
+              presets: _presets,
+              onSelect: (p) => setState(() {
+                _cols = p.cols;
+                _rows = p.rows;
+              }),
+            ),
+            ],
+          ),
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          onPressed: widget.supportsResizeWindow
+              ? () => Navigator.pop(
+                  context, ResizeResult(cols: _cols, rows: _rows))
+              : null,
+          style: FilledButton.styleFrom(
+            backgroundColor: DesignColors.primary,
+          ),
+          child: const Text('Resize'),
+        ),
+      ],
+    );
+  }
+}
+
+// ====================================================================
+// 共通ビルダー（トップレベル関数）
+// ====================================================================
+
+/// tmuxのresize-paneを簡易シミュレーションする。
+///
+/// サイズを先に決め、位置を全て再計算する。
+/// 1. ウィンドウサイズとセパレータを算出
+/// 2. 新しいサイズを決める（カラム幅、カラム内高さ配分）
+/// 3. 位置を上から・左から再計算
+List<TmuxPane> _simulatePaneResize({
+  required List<TmuxPane> panes,
+  required String targetId,
+  required int newCols,
+  required int newRows,
+}) {
+  if (panes.isEmpty) return panes;
+  final target = panes.firstWhere((p) => p.id == targetId, orElse: () => panes.first);
+  if (!panes.any((p) => p.id == targetId)) return panes;
+
+  // === Step 1: ウィンドウサイズ・セパレータ算出 ===
+  int winW = 0, winH = 0;
+  for (final p in panes) {
+    winW = math.max(winW, p.left + p.width);
+    winH = math.max(winH, p.top + p.height);
+  }
+  if (winW == 0 || winH == 0) return panes;
+
+  // 同一カラム（targetと同じleft）
+  final colPanes = panes.where((p) => p.left == target.left).toList()
+    ..sort((a, b) => a.top.compareTo(b.top));
+
+  // 左隣ペイン（カラムの左に隣接し、垂直方向に重なるペイン）
+  final leftNeighbors = panes.where((p) =>
+      p.left != target.left &&
+      p.left + p.width < target.left &&
+      colPanes.any((cm) => p.top < cm.top + cm.height && p.top + p.height > cm.top)).toList();
+
+  // 水平セパレータ（カラムと左隣の隙間）
+  int hSep = 1; // デフォルト
+  if (leftNeighbors.isNotEmpty) {
+    hSep = target.left - (leftNeighbors.first.left + leftNeighbors.first.width);
+    if (hSep < 0) hSep = 1;
+  }
+
+  // 垂直セパレータ（カラム内ペイン間の隙間）
+  int vSep = 1; // デフォルト
+  if (colPanes.length >= 2) {
+    vSep = colPanes[1].top - (colPanes[0].top + colPanes[0].height);
+    if (vSep < 0) vSep = 1;
+  }
+
+  // === Step 2: 新しいサイズを決める ===
+
+  // カラム幅（clamp: 最小1、最大winW - hSep - 左隣最小1）
+  final maxColWidth = leftNeighbors.isNotEmpty ? winW - hSep - 1 : winW;
+  final colWidth = newCols.clamp(1, maxColWidth);
+
+  // 左隣幅
+  final leftWidth = leftNeighbors.isNotEmpty
+      ? math.max<int>(1, winW - hSep - colWidth)
+      : 0;
+
+  // カラム内高さ配分
+  // カラムの総高さ（元のカラムが使っている高さ）
+  final colTop = colPanes.first.top;
+  final colBottom = colPanes.last.top + colPanes.last.height;
+  final colTotalH = colBottom - colTop;
+  final totalVSep = vSep * (colPanes.length - 1);
+  final availableH = colTotalH - totalVSep;
+
+  // ターゲットの新しい高さ（clamp: 最小1、最大=使用可能-他ペイン最小各1）
+  final otherCount = colPanes.length - 1;
+  final maxTargetH = availableH - otherCount; // 他ペインが各最小1
+  final targetH = newRows.clamp(1, math.max<int>(1, maxTargetH));
+
+  // 残りの高さを他ペインに元の比率で配分
+  final int remainingH = math.max<int>(0, availableH - targetH);
+  final otherOriginalSum = colPanes
+      .where((p) => p.id != targetId)
+      .fold<int>(0, (s, p) => s + p.height);
+
+  final newHeights = <String, int>{};
+  newHeights[targetId] = targetH;
+
+  if (otherCount > 0 && otherOriginalSum > 0) {
+    int distributed = 0;
+    final others = colPanes.where((p) => p.id != targetId).toList();
+    for (int i = 0; i < others.length; i++) {
+      final p = others[i];
+      if (i == others.length - 1) {
+        // 最後のペインに残りを全て割り当て（端数調整）
+        newHeights[p.id] = math.max<int>(1, remainingH - distributed);
+      } else {
+        final h = math.max(1, (remainingH * p.height / otherOriginalSum).round());
+        newHeights[p.id] = h;
+        distributed += h;
+      }
+    }
+  }
+
+  // === Step 3: 位置を再計算 ===
+
+  // 左隣の新しいleft（元のまま）
+  final newColLeft = leftNeighbors.isNotEmpty
+      ? leftNeighbors.first.left + leftWidth + hSep
+      : target.left; // 左隣がなければ元の位置
+
+  // 左隣がなく、右隣がある場合
+  // （カラムが左端にある場合は位置は0のまま）
+
+  // カラム内のtopを上から再計算
+  final newTops = <String, int>{};
+  var currentTop = colTop;
+  for (final p in colPanes) {
+    newTops[p.id] = currentTop;
+    currentTop += (newHeights[p.id] ?? p.height) + vSep;
+  }
+
+  // === Step 4: 結果組み立て ===
+  return panes.map((p) {
+    if (colPanes.any((cp) => cp.id == p.id)) {
+      // カラム内ペイン
+      return p.copyWith(
+        left: newColLeft,
+        top: newTops[p.id] ?? p.top,
+        width: colWidth,
+        height: newHeights[p.id] ?? p.height,
+      );
+    } else if (leftNeighbors.any((ln) => ln.id == p.id)) {
+      // 左隣ペイン（幅変更、位置は元のまま）
+      return p.copyWith(width: leftWidth);
+    } else {
+      // その他（変化なし）
+      return p;
+    }
+  }).toList();
+}
+
+/// ペインレイアウトのグリッドプレビュー
+///
+/// [previewPaneId] が指定された場合、そのペインを [previewCols]x[previewRows] で
+/// リサイズしたシミュレーション結果を描画する。
+Widget _buildPaneGridPreview({
+  required List<TmuxPane> allPanes,
+  required String highlightPaneId,
+  String? previewPaneId,
+  int? previewCols,
+  int? previewRows,
+}) {
+  if (allPanes.isEmpty) return const SizedBox.shrink();
+
+  // リサイズシミュレーション
+  final panes = (previewPaneId != null && previewCols != null && previewRows != null)
+      ? _simulatePaneResize(
+          panes: allPanes,
+          targetId: previewPaneId,
+          newCols: previewCols,
+          newRows: previewRows,
+        )
+      : allPanes;
+
+  return Container(
+    height: 120,
+    clipBehavior: Clip.hardEdge,
+    decoration: BoxDecoration(
+      color: DesignColors.canvasDark,
+      borderRadius: BorderRadius.circular(8),
+      border: Border.all(color: DesignColors.borderDark),
+    ),
+    child: LayoutBuilder(
+      builder: (context, constraints) {
+        const pad = 4.0;
+        final areaW = constraints.maxWidth - pad * 2;
+        final areaH = constraints.maxHeight - pad * 2;
+
+        // ウィンドウ全体の範囲を算出
+        int maxRight = 0;
+        int maxBottom = 0;
+        for (final p in panes) {
+          final right = p.left + p.width;
+          final bottom = p.top + p.height;
+          if (right > maxRight) maxRight = right;
+          if (bottom > maxBottom) maxBottom = bottom;
+        }
+        if (maxRight == 0) maxRight = 1;
+        if (maxBottom == 0) maxBottom = 1;
+
+        final scaleX = areaW / maxRight;
+        final scaleY = areaH / maxBottom;
+
+        return Padding(
+          padding: const EdgeInsets.all(pad),
+          child: Stack(
+            children: [
+              SizedBox(width: areaW, height: areaH),
+              ...panes.map((pane) {
+                final isTarget = pane.id == highlightPaneId;
+                final left = pane.left * scaleX;
+                final top = pane.top * scaleY;
+                final width = (pane.width * scaleX).clamp(20.0, areaW - left);
+                final height = (pane.height * scaleY).clamp(14.0, areaH - top);
+
+                return Positioned(
+                  left: left,
+                  top: top,
+                  width: width,
+                  height: height,
+                  child: Container(
+                    decoration: BoxDecoration(
+                      color: isTarget
+                          ? DesignColors.primary.withValues(alpha: 0.25)
+                          : DesignColors.surfaceDark,
+                      borderRadius: BorderRadius.circular(4),
+                      border: Border.all(
+                        color: isTarget
+                            ? DesignColors.primary
+                            : DesignColors.borderDark,
+                        width: isTarget ? 2 : 1,
+                      ),
+                    ),
+                    alignment: Alignment.center,
+                    child: FittedBox(
+                      fit: BoxFit.scaleDown,
+                      child: Padding(
+                        padding: const EdgeInsets.symmetric(horizontal: 2),
+                        child: Text(
+                          '${pane.index}\n${pane.width}x${pane.height}',
+                          textAlign: TextAlign.center,
+                          style: TextStyle(
+                            fontSize: 10,
+                            color: isTarget
+                                ? DesignColors.primary
+                                : DesignColors.textSecondary,
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                );
+              }),
+            ],
+          ),
+        );
+      },
+    ),
+  );
+}
+
+/// ウィンドウ全体のグリッドプレビュー（ウィンドウリサイズ用）
+Widget _buildWindowGridPreview({
+  required TmuxWindow window,
+  required List<TmuxPane> panes,
+  required int currentCols,
+  required int currentRows,
+}) {
+  return Container(
+    height: 120,
+    clipBehavior: Clip.hardEdge,
+    decoration: BoxDecoration(
+      color: DesignColors.canvasDark,
+      borderRadius: BorderRadius.circular(8),
+      border: Border.all(color: DesignColors.primary, width: 2),
+    ),
+    child: Column(
+      children: [
+        // ウィンドウヘッダー
+        Container(
+          width: double.infinity,
+          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+          decoration: const BoxDecoration(
+            color: DesignColors.surfaceDark,
+            borderRadius: BorderRadius.only(
+              topLeft: Radius.circular(6),
+              topRight: Radius.circular(6),
+            ),
+          ),
+          child: Text(
+            '${window.name}  ${currentCols}x$currentRows',
+            style: const TextStyle(
+              fontSize: 11,
+              color: DesignColors.primary,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ),
+        // ペインレイアウト
+        Expanded(
+          child: _buildPaneGridPreview(
+            allPanes: panes,
+            highlightPaneId: '', // ウィンドウリサイズではペインハイライトなし
+          ),
+        ),
+      ],
+    ),
+  );
+}
+
+/// 警告メッセージ
+Widget _buildWarning(String message) {
+  return Container(
+    padding: const EdgeInsets.all(8),
+    decoration: BoxDecoration(
+      color: DesignColors.warning.withValues(alpha: 0.12),
+      borderRadius: BorderRadius.circular(6),
+      border: Border.all(color: DesignColors.warning.withValues(alpha: 0.3)),
+    ),
+    child: Row(
+      children: [
+        const Icon(Icons.warning_amber_rounded,
+            size: 16, color: DesignColors.warning),
+        const SizedBox(width: 6),
+        Expanded(
+          child: Text(
+            message,
+            style: const TextStyle(
+              fontSize: 12,
+              color: DesignColors.warning,
+            ),
+          ),
+        ),
+      ],
+    ),
+  );
+}
+
+/// Cols / Rows 数値入力行
+Widget _buildSizeInputRow({
+  required int cols,
+  required int rows,
+  required ValueChanged<int> onColsChanged,
+  required ValueChanged<int> onRowsChanged,
+}) {
+  return Row(
+    children: [
+      Expanded(
+        child: _buildNumberInput(
+          label: 'Cols',
+          value: cols,
+          onChanged: onColsChanged,
+        ),
+      ),
+      const SizedBox(width: 12),
+      Expanded(
+        child: _buildNumberInput(
+          label: 'Rows',
+          value: rows,
+          onChanged: onRowsChanged,
+        ),
+      ),
+    ],
+  );
+}
+
+/// 単一の数値入力フィールド（ラベル + ◀ 値 ▶）
+Widget _buildNumberInput({
+  required String label,
+  required int value,
+  required ValueChanged<int> onChanged,
+  int min = 10,
+  int max = 500,
+}) {
+  return Column(
+    crossAxisAlignment: CrossAxisAlignment.start,
+    children: [
+      Text(
+        label,
+        style: const TextStyle(
+          fontSize: 12,
+          color: DesignColors.textSecondary,
+        ),
+      ),
+      const SizedBox(height: 4),
+      Container(
+        decoration: BoxDecoration(
+          color: DesignColors.inputDark,
+          borderRadius: BorderRadius.circular(8),
+          border: Border.all(color: DesignColors.borderDark),
+        ),
+        child: Row(
+          children: [
+            _stepButton(
+              icon: Icons.chevron_left,
+              onPressed: value > min
+                  ? () => onChanged((value - 1).clamp(min, max))
+                  : null,
+            ),
+            Expanded(
+              child: Text(
+                '$value',
+                textAlign: TextAlign.center,
+                style: const TextStyle(
+                  fontSize: 16,
+                  fontWeight: FontWeight.w600,
+                  color: DesignColors.textPrimary,
+                ),
+              ),
+            ),
+            _stepButton(
+              icon: Icons.chevron_right,
+              onPressed: value < max
+                  ? () => onChanged((value + 1).clamp(min, max))
+                  : null,
+            ),
+          ],
+        ),
+      ),
+    ],
+  );
+}
+
+/// ステップボタン（◀ / ▶）
+Widget _stepButton({
+  required IconData icon,
+  required VoidCallback? onPressed,
+}) {
+  return IconButton(
+    icon: Icon(icon, size: 20),
+    onPressed: onPressed,
+    color: DesignColors.textSecondary,
+    disabledColor: DesignColors.textMuted,
+    splashRadius: 18,
+    padding: const EdgeInsets.all(4),
+    constraints: const BoxConstraints(minWidth: 36, minHeight: 36),
+  );
+}
+
+/// プリセットChipボタン群
+Widget _buildPresetChips({
+  required List<_SizePreset> presets,
+  required ValueChanged<_SizePreset> onSelect,
+}) {
+  return Wrap(
+    spacing: 6,
+    runSpacing: 6,
+    children: presets.map((preset) {
+      return ActionChip(
+        label: Text(
+          preset.label,
+          style: const TextStyle(fontSize: 11, color: DesignColors.textPrimary),
+        ),
+        backgroundColor: DesignColors.keyBackground,
+        side: const BorderSide(color: DesignColors.borderDark),
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+        onPressed: () => onSelect(preset),
+      );
+    }).toList(),
+  );
+}

--- a/lib/widgets/session_tree.dart
+++ b/lib/widgets/session_tree.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_muxpod/services/tmux/tmux_parser.dart';
-import 'package:flutter_muxpod/widgets/active_list_tile.dart';
 import 'package:flutter_muxpod/widgets/tmux_tiles.dart';
 
 /// tmuxセッションツリー表示Widget
@@ -10,6 +9,9 @@ class SessionTree extends StatelessWidget {
   final String? selectedPaneId;
   final void Function(String paneId)? onPaneSelected;
   final void Function(String sessionName)? onSessionDoubleTap;
+  final void Function(TmuxPane pane)? onPaneResize;
+  final void Function(String paneId)? onPaneClose;
+  final void Function(TmuxWindow window)? onWindowResize;
   final void Function(String sessionName, int windowIndex, String windowName, bool isLastWindow)? onWindowClose;
 
   const SessionTree({
@@ -18,6 +20,9 @@ class SessionTree extends StatelessWidget {
     this.selectedPaneId,
     this.onPaneSelected,
     this.onSessionDoubleTap,
+    this.onPaneResize,
+    this.onPaneClose,
+    this.onWindowResize,
     this.onWindowClose,
   });
 
@@ -39,6 +44,9 @@ class SessionTree extends StatelessWidget {
           selectedPaneId: selectedPaneId,
           onPaneSelected: onPaneSelected,
           onSessionDoubleTap: onSessionDoubleTap,
+          onPaneResize: onPaneResize,
+          onPaneClose: onPaneClose,
+          onWindowResize: onWindowResize,
           onWindowClose: onWindowClose,
         );
       },
@@ -52,6 +60,9 @@ class _SessionTile extends StatefulWidget {
   final String? selectedPaneId;
   final void Function(String paneId)? onPaneSelected;
   final void Function(String sessionName)? onSessionDoubleTap;
+  final void Function(TmuxPane pane)? onPaneResize;
+  final void Function(String paneId)? onPaneClose;
+  final void Function(TmuxWindow window)? onWindowResize;
   final void Function(String sessionName, int windowIndex, String windowName, bool isLastWindow)? onWindowClose;
 
   const _SessionTile({
@@ -59,6 +70,9 @@ class _SessionTile extends StatefulWidget {
     this.selectedPaneId,
     this.onPaneSelected,
     this.onSessionDoubleTap,
+    this.onPaneResize,
+    this.onPaneClose,
+    this.onWindowResize,
     this.onWindowClose,
   });
 
@@ -101,6 +115,9 @@ class _SessionTileState extends State<_SessionTile> {
               isLastWindow: widget.session.windows.length == 1,
               selectedPaneId: widget.selectedPaneId,
               onPaneSelected: widget.onPaneSelected,
+              onPaneResize: widget.onPaneResize,
+              onPaneClose: widget.onPaneClose,
+              onWindowResize: widget.onWindowResize,
               onWindowClose: widget.onWindowClose,
             );
           }),
@@ -116,6 +133,9 @@ class _WindowTile extends StatefulWidget {
   final bool isLastWindow;
   final String? selectedPaneId;
   final void Function(String paneId)? onPaneSelected;
+  final void Function(TmuxPane pane)? onPaneResize;
+  final void Function(String paneId)? onPaneClose;
+  final void Function(TmuxWindow window)? onWindowResize;
   final void Function(String sessionName, int windowIndex, String windowName, bool isLastWindow)? onWindowClose;
 
   const _WindowTile({
@@ -124,6 +144,9 @@ class _WindowTile extends StatefulWidget {
     required this.isLastWindow,
     this.selectedPaneId,
     this.onPaneSelected,
+    this.onPaneResize,
+    this.onPaneClose,
+    this.onWindowResize,
     this.onWindowClose,
   });
 
@@ -150,6 +173,9 @@ class _WindowTileState extends State<_WindowTile> {
             window: widget.window,
             isActive: widget.window.active,
             onTap: () => setState(() => _isExpanded = !_isExpanded),
+            onResize: widget.onWindowResize != null
+                ? () => widget.onWindowResize!(widget.window)
+                : null,
             onClose: widget.onWindowClose != null
                 ? () => widget.onWindowClose?.call(
                       widget.sessionName,
@@ -167,21 +193,19 @@ class _WindowTileState extends State<_WindowTile> {
   }
 
   Widget _buildPaneNode(BuildContext context, TmuxPane pane) {
-    final colorScheme = Theme.of(context).colorScheme;
-    final isSelected = pane.id == widget.selectedPaneId;
-
     return Padding(
       padding: const EdgeInsets.only(left: 32),
-      child: ActiveListTile(
-        isActive: isSelected,
-        showLeftBar: false,
-        leading: Icon(
-          Icons.terminal,
-          color: pane.active ? colorScheme.tertiary : colorScheme.onSurface.withValues(alpha: 0.6),
-        ),
-        title: 'Pane ${pane.index}',
-        subtitle: '${pane.width}x${pane.height}',
+      child: TmuxPaneTile(
+        pane: pane,
+        paneTitle: pane.title ?? 'Pane ${pane.index}',
+        isActive: pane.id == widget.selectedPaneId,
         onTap: () => widget.onPaneSelected?.call(pane.id),
+        onResize: widget.onPaneResize != null
+            ? () => widget.onPaneResize!(pane)
+            : null,
+        onClose: widget.onPaneClose != null
+            ? () => widget.onPaneClose!(pane.id)
+            : null,
       ),
     );
   }

--- a/lib/widgets/tmux_tiles.dart
+++ b/lib/widgets/tmux_tiles.dart
@@ -41,6 +41,7 @@ class TmuxPaneTile extends StatelessWidget {
   final bool isActive;
   final VoidCallback? onTap;
   final VoidCallback? onLongPress;
+  final VoidCallback? onResize;
   final VoidCallback? onClose;
 
   const TmuxPaneTile({
@@ -50,6 +51,7 @@ class TmuxPaneTile extends StatelessWidget {
     required this.isActive,
     this.onTap,
     this.onLongPress,
+    this.onResize,
     this.onClose,
   });
 
@@ -92,7 +94,7 @@ class TmuxPaneTile extends StatelessWidget {
       trailing: Row(
         mainAxisSize: MainAxisSize.min,
         children: [
-          if (onClose != null)
+          if (onResize != null || onClose != null)
             PopupMenuButton<String>(
               icon: Icon(
                 Icons.more_vert,
@@ -101,20 +103,35 @@ class TmuxPaneTile extends StatelessWidget {
               ),
               padding: EdgeInsets.zero,
               itemBuilder: (menuContext) => [
-                PopupMenuItem(
-                  value: 'close',
-                  child: Row(
-                    children: [
-                      Icon(Icons.close, size: 18, color: DesignColors.error),
-                      const SizedBox(width: 8),
-                      Text('Close Pane',
-                          style: TextStyle(color: DesignColors.error)),
-                    ],
+                if (onResize != null)
+                  PopupMenuItem(
+                    value: 'resize',
+                    child: Row(
+                      children: [
+                        Icon(Icons.aspect_ratio, size: 18,
+                            color: colorScheme.onSurface),
+                        const SizedBox(width: 8),
+                        const Text('Resize Pane'),
+                      ],
+                    ),
                   ),
-                ),
+                if (onClose != null)
+                  PopupMenuItem(
+                    value: 'close',
+                    child: Row(
+                      children: [
+                        Icon(Icons.close, size: 18, color: DesignColors.error),
+                        const SizedBox(width: 8),
+                        Text('Close Pane',
+                            style: TextStyle(color: DesignColors.error)),
+                      ],
+                    ),
+                  ),
               ],
               onSelected: (value) {
-                if (value == 'close') {
+                if (value == 'resize') {
+                  onResize?.call();
+                } else if (value == 'close') {
                   onClose?.call();
                 }
               },
@@ -132,6 +149,7 @@ class TmuxWindowTile extends StatelessWidget {
   final TmuxWindow window;
   final bool isActive;
   final VoidCallback? onTap;
+  final VoidCallback? onResize;
   final VoidCallback? onClose;
 
   const TmuxWindowTile({
@@ -139,6 +157,7 @@ class TmuxWindowTile extends StatelessWidget {
     required this.window,
     required this.isActive,
     this.onTap,
+    this.onResize,
     this.onClose,
   });
 
@@ -154,7 +173,7 @@ class TmuxWindowTile extends StatelessWidget {
       ),
       title: '${window.index}: ${window.name}',
       subtitle: '${window.paneCount} panes',
-      trailing: onClose != null
+      trailing: onResize != null || onClose != null
           ? PopupMenuButton<String>(
               icon: Icon(
                 Icons.more_vert,
@@ -163,19 +182,34 @@ class TmuxWindowTile extends StatelessWidget {
               ),
               padding: EdgeInsets.zero,
               itemBuilder: (menuContext) => [
-                PopupMenuItem(
-                  value: 'close',
-                  child: Row(
-                    children: [
-                      Icon(Icons.close, size: 18, color: DesignColors.error),
-                      const SizedBox(width: 8),
-                      Text('Close Window', style: TextStyle(color: DesignColors.error)),
-                    ],
+                if (onResize != null)
+                  PopupMenuItem(
+                    value: 'resize',
+                    child: Row(
+                      children: [
+                        Icon(Icons.aspect_ratio, size: 18,
+                            color: colorScheme.onSurface),
+                        const SizedBox(width: 8),
+                        const Text('Resize Window'),
+                      ],
+                    ),
                   ),
-                ),
+                if (onClose != null)
+                  PopupMenuItem(
+                    value: 'close',
+                    child: Row(
+                      children: [
+                        Icon(Icons.close, size: 18, color: DesignColors.error),
+                        const SizedBox(width: 8),
+                        Text('Close Window', style: TextStyle(color: DesignColors.error)),
+                      ],
+                    ),
+                  ),
               ],
               onSelected: (value) {
-                if (value == 'close') {
+                if (value == 'resize') {
+                  onResize?.call();
+                } else if (value == 'close') {
                   onClose?.call();
                 }
               },

--- a/test/services/terminal/font_calculator_test.dart
+++ b/test/services/terminal/font_calculator_test.dart
@@ -435,6 +435,48 @@ void main() {
       });
     });
 
+    group('calculateMaxCols', () {
+      test('画面幅からカラム数を計算する', () {
+        final result = FontCalculator.calculateMaxCols(
+          screenWidth: 800,
+          fontSize: 14,
+          fontFamily: 'JetBrains Mono',
+        );
+        expect(result, greaterThan(0));
+        expect(result, lessThanOrEqualTo(999));
+      });
+
+      test('最小値10にクランプされる', () {
+        final result = FontCalculator.calculateMaxCols(
+          screenWidth: 10,
+          fontSize: 100,
+          fontFamily: 'JetBrains Mono',
+        );
+        expect(result, greaterThanOrEqualTo(10));
+      });
+    });
+
+    group('calculateMaxRows', () {
+      test('画面高さから行数を計算する', () {
+        final result = FontCalculator.calculateMaxRows(
+          screenHeight: 600,
+          fontSize: 14,
+          fontFamily: 'JetBrains Mono',
+        );
+        expect(result, greaterThan(0));
+        expect(result, lessThanOrEqualTo(999));
+      });
+
+      test('最小値5にクランプされる', () {
+        final result = FontCalculator.calculateMaxRows(
+          screenHeight: 10,
+          fontSize: 100,
+          fontFamily: 'JetBrains Mono',
+        );
+        expect(result, greaterThanOrEqualTo(5));
+      });
+    });
+
     group('getCharDisplayWidthWithContext', () {
       test('returns 2 for emoji-eligible character followed by VS16', () {
         // ✡ (U+2721) followed by VS16 should be width 2

--- a/test/services/tmux/tmux_commands_test.dart
+++ b/test/services/tmux/tmux_commands_test.dart
@@ -113,6 +113,66 @@ void main() {
       });
     });
 
+    group('resizePaneToSize', () {
+      test('generates resize-pane with cols only', () {
+        expect(
+          TmuxCommands.resizePaneToSize('%0', cols: 120),
+          'tmux resize-pane -t %0 -x 120',
+        );
+      });
+
+      test('generates resize-pane with rows only', () {
+        expect(
+          TmuxCommands.resizePaneToSize('%0', rows: 40),
+          'tmux resize-pane -t %0 -y 40',
+        );
+      });
+
+      test('generates resize-pane with both cols and rows', () {
+        expect(
+          TmuxCommands.resizePaneToSize('%1', cols: 200, rows: 50),
+          'tmux resize-pane -t %1 -x 200 -y 50',
+        );
+      });
+
+      test('escapes pane ID with special characters', () {
+        expect(
+          TmuxCommands.resizePaneToSize('my pane', cols: 80),
+          'tmux resize-pane -t "my pane" -x 80',
+        );
+      });
+    });
+
+    group('resizeWindow', () {
+      test('generates resize-window with cols only', () {
+        expect(
+          TmuxCommands.resizeWindow('my-session:0', cols: 160),
+          'tmux resize-window -t my-session:0 -x 160',
+        );
+      });
+
+      test('generates resize-window with rows only', () {
+        expect(
+          TmuxCommands.resizeWindow('my-session:0', rows: 48),
+          'tmux resize-window -t my-session:0 -y 48',
+        );
+      });
+
+      test('generates resize-window with both cols and rows', () {
+        expect(
+          TmuxCommands.resizeWindow('@1', cols: 200, rows: 50),
+          'tmux resize-window -t @1 -x 200 -y 50',
+        );
+      });
+
+      test('escapes target with special characters', () {
+        expect(
+          TmuxCommands.resizeWindow('my session:0', cols: 80),
+          'tmux resize-window -t "my session:0" -x 80',
+        );
+      });
+    });
+
     group('sendKeys', () {
       test('generates literal send-keys command', () {
         // _escapeArg escapes backslashes, so \\ becomes \\\\

--- a/test/services/tmux/tmux_version_test.dart
+++ b/test/services/tmux/tmux_version_test.dart
@@ -1,0 +1,115 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_muxpod/services/tmux/tmux_version.dart';
+
+void main() {
+  group('TmuxVersionInfo', () {
+    group('parse', () {
+      test('標準的なバージョン文字列をパースできる', () {
+        final result = TmuxVersionInfo.parse('tmux 3.4');
+        expect(result, isNotNull);
+        expect(result!.major, 3);
+        expect(result.minor, 4);
+      });
+
+      test('サフィックス付きバージョンをパースできる', () {
+        final result = TmuxVersionInfo.parse('tmux 2.9a');
+        expect(result, isNotNull);
+        expect(result!.major, 2);
+        expect(result.minor, 9);
+      });
+
+      test('古いバージョンをパースできる', () {
+        final result = TmuxVersionInfo.parse('tmux 1.8');
+        expect(result, isNotNull);
+        expect(result!.major, 1);
+        expect(result.minor, 8);
+      });
+
+      test('サフィックスなしのバージョンをパースできる', () {
+        final result = TmuxVersionInfo.parse('tmux 2.9');
+        expect(result, isNotNull);
+        expect(result!.major, 2);
+        expect(result.minor, 9);
+      });
+
+      test('空文字列はnullを返す', () {
+        expect(TmuxVersionInfo.parse(''), isNull);
+      });
+
+      test('tmuxを含まない文字列はnullを返す', () {
+        expect(TmuxVersionInfo.parse('not-tmux'), isNull);
+      });
+
+      test('バージョン番号なしはnullを返す', () {
+        expect(TmuxVersionInfo.parse('tmux'), isNull);
+      });
+
+      test('不正なバージョン番号はnullを返す', () {
+        expect(TmuxVersionInfo.parse('tmux abc'), isNull);
+      });
+    });
+
+    group('supportsResizeWindow', () {
+      test('2.9はサポートする', () {
+        expect(const TmuxVersionInfo(2, 9).supportsResizeWindow, isTrue);
+      });
+
+      test('2.8はサポートしない', () {
+        expect(const TmuxVersionInfo(2, 8).supportsResizeWindow, isFalse);
+      });
+
+      test('3.0はサポートする', () {
+        expect(const TmuxVersionInfo(3, 0).supportsResizeWindow, isTrue);
+      });
+
+      test('1.8はサポートしない', () {
+        expect(const TmuxVersionInfo(1, 8).supportsResizeWindow, isFalse);
+      });
+    });
+
+    group('supportsResizePaneToSize', () {
+      test('1.7はサポートする', () {
+        expect(const TmuxVersionInfo(1, 7).supportsResizePaneToSize, isTrue);
+      });
+
+      test('1.6はサポートしない', () {
+        expect(const TmuxVersionInfo(1, 6).supportsResizePaneToSize, isFalse);
+      });
+
+      test('2.0はサポートする', () {
+        expect(const TmuxVersionInfo(2, 0).supportsResizePaneToSize, isTrue);
+      });
+    });
+
+    group('toString', () {
+      test('正しいフォーマットで文字列化される', () {
+        expect(const TmuxVersionInfo(3, 4).toString(), 'tmux 3.4');
+        expect(const TmuxVersionInfo(2, 9).toString(), 'tmux 2.9');
+      });
+    });
+
+    group('equality', () {
+      test('同じバージョンは等しい', () {
+        expect(const TmuxVersionInfo(3, 4), const TmuxVersionInfo(3, 4));
+      });
+
+      test('異なるバージョンは等しくない', () {
+        expect(
+          const TmuxVersionInfo(3, 4) == const TmuxVersionInfo(3, 5),
+          isFalse,
+        );
+        expect(
+          const TmuxVersionInfo(2, 4) == const TmuxVersionInfo(3, 4),
+          isFalse,
+        );
+      });
+
+      test('同じバージョンのhashCodeは一致する', () {
+        expect(
+          const TmuxVersionInfo(3, 4).hashCode,
+          const TmuxVersionInfo(3, 4).hashCode,
+        );
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- tmuxのウィンドウ/ペインサイズを任意のcols×rowsに変更できる機能を追加
- グリッドプレビュー型UIでリサイズ後のレイアウトをリアルタイムシミュレーション表示
- プリセット4種（80×24, 120×40, 160×50, Match Screen）とモバイル画面マッチ機能を搭載

## Changes

### コマンド基盤
- `TmuxCommands.resizePaneToSize()` / `resizeWindow()` — cols/rows指定のリサイズコマンド生成
- `TmuxVersionInfo` — tmuxバージョンパースとresize-window対応判定（2.9+）

### 計算基盤
- `FontCalculator.calculateMaxCols()` / `calculateMaxRows()` — 画面サイズからcols/rows逆算
- `TerminalDisplayProvider` に `screenHeight` + `updateScreenSize()` 追加

### UI
- `ResizePaneDialog` / `ResizeWindowDialog` — グリッドプレビュー型リサイズダイアログ（プリセット付き）
- リサイズシミュレーション — 同一カラムのペイン連動・セパレータ維持・位置再計算
- `TmuxPaneTile` / `TmuxWindowTile` にリサイズメニュー追加
- `SessionTree._buildPaneNode` を `TmuxPaneTile` に移行

### 統合
- `terminal_screen.dart` — tmuxバージョンチェック、リサイズハンドラ、排他制御
- BottomSheetヘッダーにリサイズボタン追加（グラフィカル選択画面）
- 三点メニューからは直接リサイズ、ヘッダーボタンからは対象選択画面を表示

## Test plan
- [ ] ペインリサイズ: Resize Paneダイアログからcols/rows変更 → tmux側でサイズ変更確認
- [ ] ウィンドウリサイズ: Resize Windowダイアログから変更 → tmux側で確認
- [ ] プリセット: 80×24, 120×40, 160×50, Match Screen の各プリセットが正しく適用される
- [ ] プレビュー: cols/rows変更時にグリッドプレビューがリアルタイムで連動する
- [ ] tmux 2.9未満: Resize Windowボタンが無効化される
- [ ] 複数ペイン: 他ペインへの影響警告が表示される
- [ ] `flutter test` — 新規テスト（TmuxCommands 8件、TmuxVersionInfo 19件、FontCalculator 4件）が通過

Issue #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)