### PR TITLE
feat: 設定画面に自動リサイズON/OFF機能を追加（Adjust Mode統合）

### DIFF
--- a/lib/providers/settings_provider.dart
+++ b/lib/providers/settings_provider.dart
@@ -1,6 +1,8 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import '../services/settings_migration.dart';
+
 /// アプリ設定
 class AppSettings {
   final bool darkMode;
@@ -12,7 +14,9 @@ class AppSettings {
   final bool keepScreenOn;
   final int scrollbackLines;
   final double minFontSize;
-  final bool autoFitEnabled;
+
+  /// 表示調整モード: 'none', 'autoFit', 'autoResize'
+  final String adjustMode;
 
   /// DirectInputモード（入力した文字を即座にターミナルに送信）
   final bool directInputEnabled;
@@ -44,7 +48,7 @@ class AppSettings {
     this.keepScreenOn = true,
     this.scrollbackLines = 10000,
     this.minFontSize = 8.0,
-    this.autoFitEnabled = true,
+    this.adjustMode = 'autoFit',
     this.directInputEnabled = false,
     this.showTerminalCursor = true,
     this.invertPaneNavigation = false,
@@ -59,6 +63,9 @@ class AppSettings {
     this.imageBracketedPaste = false,
   });
 
+  bool get isAutoFit => adjustMode == 'autoFit';
+  bool get isAutoResize => adjustMode == 'autoResize';
+
   AppSettings copyWith({
     bool? darkMode,
     double? fontSize,
@@ -69,7 +76,7 @@ class AppSettings {
     bool? keepScreenOn,
     int? scrollbackLines,
     double? minFontSize,
-    bool? autoFitEnabled,
+    String? adjustMode,
     bool? directInputEnabled,
     bool? showTerminalCursor,
     bool? invertPaneNavigation,
@@ -93,7 +100,7 @@ class AppSettings {
       keepScreenOn: keepScreenOn ?? this.keepScreenOn,
       scrollbackLines: scrollbackLines ?? this.scrollbackLines,
       minFontSize: minFontSize ?? this.minFontSize,
-      autoFitEnabled: autoFitEnabled ?? this.autoFitEnabled,
+      adjustMode: adjustMode ?? this.adjustMode,
       directInputEnabled: directInputEnabled ?? this.directInputEnabled,
       showTerminalCursor: showTerminalCursor ?? this.showTerminalCursor,
       invertPaneNavigation: invertPaneNavigation ?? this.invertPaneNavigation,
@@ -121,7 +128,7 @@ class SettingsNotifier extends Notifier<AppSettings> {
   static const String _keepScreenOnKey = 'settings_keep_screen_on';
   static const String _scrollbackKey = 'settings_scrollback';
   static const String _minFontSizeKey = 'settings_min_font_size';
-  static const String _autoFitEnabledKey = 'settings_auto_fit_enabled';
+  static const String _adjustModeKey = 'settings_adjust_mode';
   static const String _directInputEnabledKey = 'settings_direct_input_enabled';
   static const String _showTerminalCursorKey = 'settings_show_terminal_cursor';
   static const String _invertPaneNavKey = 'settings_invert_pane_nav';
@@ -143,6 +150,7 @@ class SettingsNotifier extends Notifier<AppSettings> {
 
   Future<void> _loadSettings() async {
     final prefs = await SharedPreferences.getInstance();
+    await SettingsMigrationRunner.run(prefs);
 
     state = AppSettings(
       darkMode: prefs.getBool(_darkModeKey) ?? true,
@@ -154,7 +162,7 @@ class SettingsNotifier extends Notifier<AppSettings> {
       keepScreenOn: prefs.getBool(_keepScreenOnKey) ?? true,
       scrollbackLines: prefs.getInt(_scrollbackKey) ?? 10000,
       minFontSize: prefs.getDouble(_minFontSizeKey) ?? 8.0,
-      autoFitEnabled: prefs.getBool(_autoFitEnabledKey) ?? true,
+      adjustMode: prefs.getString(_adjustModeKey) ?? 'autoFit',
       directInputEnabled: prefs.getBool(_directInputEnabledKey) ?? false,
       showTerminalCursor: prefs.getBool(_showTerminalCursorKey) ?? true,
       invertPaneNavigation: prefs.getBool(_invertPaneNavKey) ?? false,
@@ -237,10 +245,10 @@ class SettingsNotifier extends Notifier<AppSettings> {
     await _saveSetting(_minFontSizeKey, value);
   }
 
-  /// 自動フィットを設定
-  Future<void> setAutoFitEnabled(bool value) async {
-    state = state.copyWith(autoFitEnabled: value);
-    await _saveSetting(_autoFitEnabledKey, value);
+  /// 表示調整モードを設定
+  Future<void> setAdjustMode(String value) async {
+    state = state.copyWith(adjustMode: value);
+    await _saveSetting(_adjustModeKey, value);
   }
 
   /// DirectInputモードを設定

--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -38,25 +38,22 @@ class SettingsScreen extends ConsumerWidget {
                     ref.read(settingsProvider.notifier).setShowTerminalCursor(value);
                   },
                 ),
-                SwitchListTile(
-                  secondary: const Icon(Icons.fit_screen),
-                  title: const Text('Auto Fit'),
-                  subtitle: const Text('Fit terminal width to screen'),
-                  value: settings.autoFitEnabled,
-                  onChanged: (value) {
-                    ref.read(settingsProvider.notifier).setAutoFitEnabled(value);
-                  },
+                ListTile(
+                  leading: const Icon(Icons.tune),
+                  title: const Text('Adjust Mode'),
+                  subtitle: Text(_adjustModeLabel(settings.adjustMode)),
+                  onTap: () => _showAdjustModePicker(context, ref, settings.adjustMode),
                 ),
                 ListTile(
                   leading: const Icon(Icons.text_fields),
                   title: const Text('Font Size'),
                   subtitle: Text(
-                    settings.autoFitEnabled
+                    settings.isAutoFit
                         ? '${settings.fontSize.toInt()} pt (auto-fit enabled)'
                         : '${settings.fontSize.toInt()} pt',
                   ),
-                  enabled: !settings.autoFitEnabled,
-                  onTap: settings.autoFitEnabled
+                  enabled: !settings.isAutoFit,
+                  onTap: settings.isAutoFit
                       ? null
                       : () async {
                           final size = await showDialog<double>(
@@ -90,12 +87,12 @@ class SettingsScreen extends ConsumerWidget {
                   leading: const Icon(Icons.format_size),
                   title: const Text('Minimum Font Size'),
                   subtitle: Text(
-                    settings.autoFitEnabled
+                    settings.isAutoFit
                         ? '${settings.minFontSize.toInt()} pt (auto-fit limit)'
                         : '${settings.minFontSize.toInt()} pt (not used)',
                   ),
-                  enabled: settings.autoFitEnabled,
-                  onTap: settings.autoFitEnabled
+                  enabled: settings.isAutoFit,
+                  onTap: settings.isAutoFit
                       ? () async {
                           final size = await showDialog<double>(
                             context: context,
@@ -407,6 +404,43 @@ class SettingsScreen extends ConsumerWidget {
     );
   }
 
+  String _adjustModeLabel(String mode) {
+    switch (mode) {
+      case 'autoFit':
+        return 'Auto Fit';
+      case 'autoResize':
+        return 'Auto Resize';
+      default:
+        return 'None';
+    }
+  }
+
+  void _showAdjustModePicker(BuildContext context, WidgetRef ref, String current) {
+    showDialog(
+      context: context,
+      builder: (ctx) => SimpleDialog(
+        title: const Text('Adjust Mode'),
+        children: [
+          for (final entry in [
+            ('none', 'None', 'Manual font and pane size'),
+            ('autoFit', 'Auto Fit', 'Adjust font size to fit screen width'),
+            ('autoResize', 'Auto Resize', 'Resize tmux pane to fit screen'),
+          ])
+            RadioListTile<String>(
+              title: Text(entry.$2),
+              subtitle: Text(entry.$3),
+              value: entry.$1,
+              groupValue: current,
+              onChanged: (v) {
+                if (v != null) ref.read(settingsProvider.notifier).setAdjustMode(v);
+                Navigator.pop(ctx);
+              },
+            ),
+        ],
+      ),
+    );
+  }
+
   void _showResizePresetPicker(BuildContext context, WidgetRef ref, String current) {
     showDialog(
       context: context,
@@ -480,3 +514,4 @@ class _SectionHeader extends StatelessWidget {
     );
   }
 }
+

--- a/lib/screens/terminal/terminal_screen.dart
+++ b/lib/screens/terminal/terminal_screen.dart
@@ -17,6 +17,7 @@ import '../../services/network/network_monitor.dart';
 import '../../services/ssh/input_queue.dart';
 import '../../services/ssh/ssh_client.dart' show SshConnectOptions;
 import '../../services/tmux/pane_navigator.dart';
+import '../../services/terminal/font_calculator.dart';
 import '../../services/tmux/tmux_commands.dart';
 import '../../services/tmux/tmux_parser.dart';
 import '../../services/tmux/tmux_version.dart';
@@ -177,6 +178,9 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   // リサイズ中フラグ（排他制御）
   bool _isResizing = false;
 
+  // 自動リサイズのdebounceタイマー（画面サイズ変更時）
+  Timer? _autoResizeDebounceTimer;
+
   // tmuxバージョン情報（リサイズ機能判定用）
   TmuxVersionInfo? _tmuxVersion;
 
@@ -218,6 +222,23 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       case AppLifecycleState.detached:
         break;
     }
+  }
+
+  @override
+  void didChangeMetrics() {
+    super.didChangeMetrics();
+    final settings = ref.read(settingsProvider);
+    if (!settings.isAutoResize) return;
+
+    // debounce: 画面回転・折りたたみの連続サイズ変更を抑制
+    _autoResizeDebounceTimer?.cancel();
+    _autoResizeDebounceTimer = Timer(const Duration(milliseconds: 500), () {
+      if (!mounted || _isDisposed) return;
+      final activePane = ref.read(tmuxProvider).activePane;
+      if (activePane != null) {
+        _executeAutoResize(activePane);
+      }
+    });
   }
 
   /// バックグラウンド移行時にポーリングを停止
@@ -880,6 +901,8 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     _pollTimer = null;
     _treeRefreshTimer?.cancel();
     _treeRefreshTimer = null;
+    _autoResizeDebounceTimer?.cancel();
+    _autoResizeDebounceTimer = null;
     // ValueNotifierを破棄
     _viewNotifier.dispose();
     // スクロールコントローラーのリスナーを削除して破棄
@@ -1210,6 +1233,12 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       // ペイン切り替え時は初回スクロールフラグをリセット
       // 次のコンテンツ受信時に最下部へスクロールされる
       _hasInitialScrolled = false;
+
+      // 自動リサイズ: ペイン選択時に画面サイズに合わせてtmuxペインをリサイズ
+      final settings = ref.read(settingsProvider);
+      if (settings.isAutoResize) {
+        await _executeAutoResize(activePane);
+      }
 
       // セッション情報を保存（復元用）
       final sessionName = tmuxState.activeSessionName;
@@ -1837,6 +1866,57 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     );
   }
 
+  /// 自動リサイズ: 画面サイズに合わせてtmuxペインをリサイズ
+  Future<void> _executeAutoResize(TmuxPane pane) async {
+    if (_isResizing) return;
+    if (_tmuxVersion != null && !_tmuxVersion!.supportsResizePaneToSize) return;
+
+    final displayState = ref.read(terminalDisplayProvider);
+    final settings = ref.read(settingsProvider);
+
+    final fontSize = settings.fontSize;
+    final targetCols = FontCalculator.calculateMaxCols(
+      screenWidth: displayState.screenWidth,
+      fontSize: fontSize,
+      fontFamily: settings.fontFamily,
+    );
+    final targetRows = FontCalculator.calculateMaxRows(
+      screenHeight: displayState.screenHeight,
+      fontSize: fontSize,
+      fontFamily: settings.fontFamily,
+    );
+
+    debugPrint('[AutoResize] screenWidth=${displayState.screenWidth} '
+        'screenHeight=${displayState.screenHeight} '
+        'fontSize=$fontSize '
+        'fontFamily=${settings.fontFamily} '
+        'pane=${pane.id} current=${pane.width}x${pane.height} '
+        'target=${targetCols}x$targetRows');
+
+    // 既存サイズと同一ならスキップ
+    if (pane.width == targetCols && pane.height == targetRows) return;
+
+    _isResizing = true;
+    _pollTimer?.cancel();
+    try {
+      final sshClient = ref.read(sshProvider.notifier).client;
+      if (sshClient == null || !sshClient.isConnected) return;
+      await sshClient.exec(
+        TmuxCommands.resizePaneToSize(pane.id, cols: targetCols, rows: targetRows),
+      );
+      await _refreshSessionTree();
+      final updatedPane = ref.read(tmuxProvider).activePane;
+      if (updatedPane != null) {
+        ref.read(terminalDisplayProvider.notifier).updatePane(updatedPane);
+      }
+    } catch (e) {
+      debugPrint('[AutoResize] Failed: $e');
+    } finally {
+      _isResizing = false;
+      if (mounted && !_isDisposed) _startPolling();
+    }
+  }
+
   /// ペインをリサイズ
   Future<void> _handleResizePane(TmuxPane pane) async {
     if (_isResizing) return;
@@ -1848,13 +1928,6 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     // 現在のウィンドウの全ペインを取���
     final activeWindow = tmuxState.activeWindow;
     final allPanes = activeWindow?.panes ?? [pane];
-
-    debugPrint('[ResizePane] pane=${pane.id} size=${pane.width}x${pane.height} '
-        'left=${pane.left} top=${pane.top} allPanes=${allPanes.length}');
-    debugPrint('[ResizePane] screenWidth=${displayState.screenWidth} '
-        'screenHeight=${displayState.screenHeight} '
-        'fontSize=${displayState.calculatedFontSize} '
-        'fontFamily=${settings.fontFamily}');
 
     final result = await showDialog<ResizeResult>(
       context: context,

--- a/lib/screens/terminal/widgets/ansi_text_view.dart
+++ b/lib/screens/terminal/widgets/ansi_text_view.dart
@@ -726,7 +726,7 @@ class AnsiTextViewState extends ConsumerState<AnsiTextView>
         late final double fontSize;
         late final bool needsHorizontalScroll;
 
-        if (settings.autoFitEnabled) {
+        if (settings.isAutoFit) {
           // 自動フィット: 画面幅に合わせて計算
           final calcResult = FontCalculator.calculate(
             screenWidth: constraints.maxWidth,

--- a/lib/services/settings_migration.dart
+++ b/lib/services/settings_migration.dart
@@ -1,0 +1,53 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// 設定マイグレーションの基底クラス
+abstract class SettingsMigration {
+  int get version;
+  Future<void> migrate(SharedPreferences prefs);
+}
+
+/// v1: autoFitEnabled + autoResizeEnabled → adjustMode
+class MigrateAutoFitToAdjustMode extends SettingsMigration {
+  @override
+  int get version => 1;
+
+  @override
+  Future<void> migrate(SharedPreferences prefs) async {
+    final hasLegacyAutoFit = prefs.containsKey('settings_auto_fit_enabled');
+    final hasLegacyAutoResize = prefs.containsKey('settings_auto_resize_enabled');
+    if (!hasLegacyAutoFit && !hasLegacyAutoResize) return;
+
+    final autoFit = prefs.getBool('settings_auto_fit_enabled') ?? true;
+    final autoResize = prefs.getBool('settings_auto_resize_enabled') ?? false;
+    String adjustMode;
+    if (autoResize) {
+      adjustMode = 'autoResize';
+    } else if (autoFit) {
+      adjustMode = 'autoFit';
+    } else {
+      adjustMode = 'none';
+    }
+    await prefs.setString('settings_adjust_mode', adjustMode);
+    await prefs.remove('settings_auto_fit_enabled');
+    await prefs.remove('settings_auto_resize_enabled');
+  }
+}
+
+/// マイグレーションランナー
+class SettingsMigrationRunner {
+  static const String _versionKey = 'settings_migration_version';
+
+  static final List<SettingsMigration> _migrations = [
+    MigrateAutoFitToAdjustMode(),
+  ];
+
+  static Future<void> run(SharedPreferences prefs) async {
+    final currentVersion = prefs.getInt(_versionKey) ?? 0;
+    for (final migration in _migrations) {
+      if (migration.version > currentVersion) {
+        await migration.migrate(prefs);
+        await prefs.setInt(_versionKey, migration.version);
+      }
+    }
+  }
+}

--- a/test/screens/settings_screen_test.dart
+++ b/test/screens/settings_screen_test.dart
@@ -17,14 +17,22 @@ void main() {
       expect(find.text('Settings'), findsOneWidget);
     });
 
+    testWidgets('displays Adjust Mode setting', (tester) async {
+      await tester.pumpWidget(_buildApp());
+      await tester.pumpAndSettle();
+
+      expect(find.text('Adjust Mode'), findsOneWidget);
+      expect(find.text('Auto Fit'), findsOneWidget);
+    });
+
     testWidgets('displays Haptic Feedback toggle', (tester) async {
       await tester.pumpWidget(_buildApp());
       await tester.pumpAndSettle();
 
       // Haptic Feedback is in the Behavior section - may need scroll
-      final finder = find.text('Haptic Feedback');
-      await tester.ensureVisible(finder);
-      expect(finder, findsOneWidget);
+      final scrollable = find.byType(Scrollable).first;
+      await tester.scrollUntilVisible(find.text('Haptic Feedback'), 200, scrollable: scrollable);
+      expect(find.text('Haptic Feedback'), findsOneWidget);
     });
 
     testWidgets('displays Keep Screen On toggle', (tester) async {


### PR DESCRIPTION
## Summary
- 設定画面にAdjust Mode設定を追加（None / Auto Fit / Auto Resize の3択）
- Auto Resize選択時、ペイン接続/画面回転時にtmuxペインを画面サイズに自動リサイズ
- 旧設定（autoFitEnabled/autoResizeEnabled）からの自動マイグレーション対応

Closes #28

## Changes
| ファイル | 変更内容 |
|---------|---------|
| `lib/services/settings_migration.dart` | 新規: SettingsMigration基底クラスとマイグレーションランナー |
| `lib/providers/settings_provider.dart` | autoFitEnabled/autoResizeEnabled → adjustMode (String) に統合 |
| `lib/screens/settings/settings_screen.dart` | Adjust Mode ダイアログUI（RadioListTile + 説明文） |
| `lib/screens/terminal/terminal_screen.dart` | _executeAutoResize() + didChangeMetrics() debounce |
| `lib/screens/terminal/widgets/ansi_text_view.dart` | isAutoFit getter参照に移行 |
| `test/screens/settings_screen_test.dart` | Adjust Mode テスト追加 |

## Test plan
- [ ] `flutter analyze` エラーなし
- [ ] `flutter test` 新規テスト失敗なし
- [ ] 設定画面で Adjust Mode タップ → ダイアログ表示
- [ ] None / Auto Fit / Auto Resize 切り替え動作確認
- [ ] Auto Fit: フォントサイズが画面幅に自動調整されるか
- [ ] Auto Resize: ペイン切り替え時にtmuxペインがリサイズされるか
- [ ] Auto Resize: 画面回転時にdebounce後リサイズされるか
- [ ] 旧設定からのマイグレーション（autoFitEnabled=true → adjustMode=autoFit）

🤖 Generated with [Claude Code](https://claude.com/claude-code)