### PR TITLE
feat: 特殊キー送信時のオーバーレイ表示 (#24)

### DIFF
--- a/lib/providers/settings_provider.dart
+++ b/lib/providers/settings_provider.dart
@@ -23,6 +23,25 @@ class AppSettings {
   /// ペインナビゲーション方向の反転
   final bool invertPaneNavigation;
 
+  // --- キーオーバーレイ設定 ---
+  /// キーオーバーレイ全体ON/OFF
+  final bool showKeyOverlay;
+
+  /// キーオーバーレイ: 修飾キー組み合わせ（Ctrl+x, Alt+x, Shift+x）
+  final bool keyOverlayModifier;
+
+  /// キーオーバーレイ: 単独特殊キー（ESC, TAB, ENTER, S-Enter）
+  final bool keyOverlaySpecial;
+
+  /// キーオーバーレイ: 矢印キー
+  final bool keyOverlayArrow;
+
+  /// キーオーバーレイ: ショートカットキー（/, -, 1-4）
+  final bool keyOverlayShortcut;
+
+  /// キーオーバーレイ: 表示位置
+  final String keyOverlayPosition;
+
   // --- 画像転送設定 ---
   final String imageRemotePath;
   final String imageOutputFormat;
@@ -48,6 +67,12 @@ class AppSettings {
     this.directInputEnabled = false,
     this.showTerminalCursor = true,
     this.invertPaneNavigation = false,
+    this.showKeyOverlay = true,
+    this.keyOverlayModifier = true,
+    this.keyOverlaySpecial = true,
+    this.keyOverlayArrow = true,
+    this.keyOverlayShortcut = true,
+    this.keyOverlayPosition = 'aboveKeyboard',
     this.imageRemotePath = '/tmp/muxpod/',
     this.imageOutputFormat = 'original',
     this.imageJpegQuality = 85,
@@ -73,6 +98,12 @@ class AppSettings {
     bool? directInputEnabled,
     bool? showTerminalCursor,
     bool? invertPaneNavigation,
+    bool? showKeyOverlay,
+    bool? keyOverlayModifier,
+    bool? keyOverlaySpecial,
+    bool? keyOverlayArrow,
+    bool? keyOverlayShortcut,
+    String? keyOverlayPosition,
     String? imageRemotePath,
     String? imageOutputFormat,
     int? imageJpegQuality,
@@ -97,6 +128,12 @@ class AppSettings {
       directInputEnabled: directInputEnabled ?? this.directInputEnabled,
       showTerminalCursor: showTerminalCursor ?? this.showTerminalCursor,
       invertPaneNavigation: invertPaneNavigation ?? this.invertPaneNavigation,
+      showKeyOverlay: showKeyOverlay ?? this.showKeyOverlay,
+      keyOverlayModifier: keyOverlayModifier ?? this.keyOverlayModifier,
+      keyOverlaySpecial: keyOverlaySpecial ?? this.keyOverlaySpecial,
+      keyOverlayArrow: keyOverlayArrow ?? this.keyOverlayArrow,
+      keyOverlayShortcut: keyOverlayShortcut ?? this.keyOverlayShortcut,
+      keyOverlayPosition: keyOverlayPosition ?? this.keyOverlayPosition,
       imageRemotePath: imageRemotePath ?? this.imageRemotePath,
       imageOutputFormat: imageOutputFormat ?? this.imageOutputFormat,
       imageJpegQuality: imageJpegQuality ?? this.imageJpegQuality,
@@ -134,6 +171,12 @@ class SettingsNotifier extends Notifier<AppSettings> {
   static const String _imagePathFormatKey = 'settings_image_path_format';
   static const String _imageAutoEnterKey = 'settings_image_auto_enter';
   static const String _imageBracketedPasteKey = 'settings_image_bracketed_paste';
+  static const String _showKeyOverlayKey = 'settings_show_key_overlay';
+  static const String _keyOverlayModifierKey = 'settings_key_overlay_modifier';
+  static const String _keyOverlaySpecialKey = 'settings_key_overlay_special';
+  static const String _keyOverlayArrowKey = 'settings_key_overlay_arrow';
+  static const String _keyOverlayShortcutKey = 'settings_key_overlay_shortcut';
+  static const String _keyOverlayPositionKey = 'settings_key_overlay_position';
 
   @override
   AppSettings build() {
@@ -158,6 +201,12 @@ class SettingsNotifier extends Notifier<AppSettings> {
       directInputEnabled: prefs.getBool(_directInputEnabledKey) ?? false,
       showTerminalCursor: prefs.getBool(_showTerminalCursorKey) ?? true,
       invertPaneNavigation: prefs.getBool(_invertPaneNavKey) ?? false,
+      showKeyOverlay: prefs.getBool(_showKeyOverlayKey) ?? true,
+      keyOverlayModifier: prefs.getBool(_keyOverlayModifierKey) ?? true,
+      keyOverlaySpecial: prefs.getBool(_keyOverlaySpecialKey) ?? true,
+      keyOverlayArrow: prefs.getBool(_keyOverlayArrowKey) ?? true,
+      keyOverlayShortcut: prefs.getBool(_keyOverlayShortcutKey) ?? true,
+      keyOverlayPosition: prefs.getString(_keyOverlayPositionKey) ?? 'aboveKeyboard',
       imageRemotePath: prefs.getString(_imageRemotePathKey) ?? '/tmp/muxpod/',
       imageOutputFormat: prefs.getString(_imageOutputFormatKey) ?? 'original',
       imageJpegQuality: prefs.getInt(_imageJpegQualityKey) ?? 85,
@@ -264,6 +313,37 @@ class SettingsNotifier extends Notifier<AppSettings> {
   Future<void> setInvertPaneNavigation(bool value) async {
     state = state.copyWith(invertPaneNavigation: value);
     await _saveSetting(_invertPaneNavKey, value);
+  }
+
+  // --- キーオーバーレイ設定のsetter ---
+  Future<void> setShowKeyOverlay(bool value) async {
+    state = state.copyWith(showKeyOverlay: value);
+    await _saveSetting(_showKeyOverlayKey, value);
+  }
+
+  Future<void> setKeyOverlayModifier(bool value) async {
+    state = state.copyWith(keyOverlayModifier: value);
+    await _saveSetting(_keyOverlayModifierKey, value);
+  }
+
+  Future<void> setKeyOverlaySpecial(bool value) async {
+    state = state.copyWith(keyOverlaySpecial: value);
+    await _saveSetting(_keyOverlaySpecialKey, value);
+  }
+
+  Future<void> setKeyOverlayArrow(bool value) async {
+    state = state.copyWith(keyOverlayArrow: value);
+    await _saveSetting(_keyOverlayArrowKey, value);
+  }
+
+  Future<void> setKeyOverlayShortcut(bool value) async {
+    state = state.copyWith(keyOverlayShortcut: value);
+    await _saveSetting(_keyOverlayShortcutKey, value);
+  }
+
+  Future<void> setKeyOverlayPosition(String value) async {
+    state = state.copyWith(keyOverlayPosition: value);
+    await _saveSetting(_keyOverlayPositionKey, value);
   }
 
   // --- 画像転送設定のsetter ---

--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -110,6 +110,82 @@ class SettingsScreen extends ConsumerWidget {
                       : null,
                 ),
                 const Divider(),
+                const _SectionHeader(title: 'Key Overlay'),
+                SwitchListTile(
+                  secondary: const Icon(Icons.visibility),
+                  title: const Text('Key Overlay'),
+                  subtitle: const Text('Show key name overlay on special key press'),
+                  value: settings.showKeyOverlay,
+                  onChanged: (value) {
+                    ref.read(settingsProvider.notifier).setShowKeyOverlay(value);
+                  },
+                ),
+                if (settings.showKeyOverlay) ...[
+                  SwitchListTile(
+                    secondary: const Icon(Icons.keyboard),
+                    title: const Text('Modifier Keys'),
+                    subtitle: const Text('Ctrl, Alt, Shift combinations'),
+                    value: settings.keyOverlayModifier,
+                    onChanged: (value) {
+                      ref.read(settingsProvider.notifier).setKeyOverlayModifier(value);
+                    },
+                  ),
+                  SwitchListTile(
+                    secondary: const Icon(Icons.space_bar),
+                    title: const Text('Special Keys'),
+                    subtitle: const Text('ESC, TAB, ENTER, Shift+Enter'),
+                    value: settings.keyOverlaySpecial,
+                    onChanged: (value) {
+                      ref.read(settingsProvider.notifier).setKeyOverlaySpecial(value);
+                    },
+                  ),
+                  SwitchListTile(
+                    secondary: const Icon(Icons.arrow_upward),
+                    title: const Text('Arrow Keys'),
+                    subtitle: const Text('Up, Down, Left, Right'),
+                    value: settings.keyOverlayArrow,
+                    onChanged: (value) {
+                      ref.read(settingsProvider.notifier).setKeyOverlayArrow(value);
+                    },
+                  ),
+                  SwitchListTile(
+                    secondary: const Icon(Icons.shortcut),
+                    title: const Text('Shortcut Keys'),
+                    subtitle: const Text('/, -, 1, 2, 3, 4'),
+                    value: settings.keyOverlayShortcut,
+                    onChanged: (value) {
+                      ref.read(settingsProvider.notifier).setKeyOverlayShortcut(value);
+                    },
+                  ),
+                  ListTile(
+                    leading: const Icon(Icons.place),
+                    title: const Text('Overlay Position'),
+                    subtitle: Text(
+                      switch (settings.keyOverlayPosition) {
+                        'center' => 'Center of terminal',
+                        'belowHeader' => 'Below header',
+                        _ => 'Above keyboard',
+                      },
+                    ),
+                    onTap: () async {
+                      final result = await showDialog<String>(
+                        context: context,
+                        builder: (context) => SimpleDialog(
+                          title: const Text('Overlay Position'),
+                          children: [
+                            _buildPositionOption(context, 'aboveKeyboard', 'Above Keyboard', settings.keyOverlayPosition),
+                            _buildPositionOption(context, 'center', 'Center of Terminal', settings.keyOverlayPosition),
+                            _buildPositionOption(context, 'belowHeader', 'Below Header', settings.keyOverlayPosition),
+                          ],
+                        ),
+                      );
+                      if (result != null) {
+                        ref.read(settingsProvider.notifier).setKeyOverlayPosition(result);
+                      }
+                    },
+                  ),
+                ],
+                const Divider(),
                 const _SectionHeader(title: 'Behavior'),
                 SwitchListTile(
                   secondary: const Icon(Icons.vibration),
@@ -453,6 +529,27 @@ class SettingsScreen extends ConsumerWidget {
             letterSpacing: -0.5,
           ),
         ),
+      ),
+    );
+  }
+
+  Widget _buildPositionOption(
+    BuildContext context,
+    String value,
+    String label,
+    String currentValue,
+  ) {
+    return SimpleDialogOption(
+      onPressed: () => Navigator.pop(context, value),
+      child: Row(
+        children: [
+          Icon(
+            value == currentValue ? Icons.radio_button_checked : Icons.radio_button_unchecked,
+            size: 20,
+          ),
+          const SizedBox(width: 12),
+          Text(label),
+        ],
       ),
     );
   }

--- a/lib/screens/terminal/terminal_screen.dart
+++ b/lib/screens/terminal/terminal_screen.dart
@@ -22,6 +22,8 @@ import '../../services/tmux/tmux_parser.dart';
 import '../../services/tmux/tmux_version.dart';
 import '../../widgets/dialogs/resize_dialog.dart';
 import '../../theme/design_colors.dart';
+import '../../services/terminal/tmux_key_display.dart';
+import '../../widgets/key_overlay_widget.dart';
 import '../../widgets/scroll_to_bottom_button.dart';
 import '../../widgets/special_keys_bar.dart';
 import '../../widgets/image_transfer_confirm_dialog.dart';
@@ -123,6 +125,10 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   // ポーリングで頻繁に更新されるターミナル表示データ（ValueNotifierで管理）
   // 親のsetState()を回避し、ValueListenableBuilderでサブツリーのみリビルドする
   final _viewNotifier = ValueNotifier<_TerminalViewData>(const _TerminalViewData());
+
+  // キーオーバーレイ
+  final KeyOverlayState _keyOverlayState = KeyOverlayState();
+  Timer? _keyOverlayTimer;
 
   // ポーリング用タイマー
   Timer? _pollTimer;
@@ -880,6 +886,10 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     _pollTimer = null;
     _treeRefreshTimer?.cancel();
     _treeRefreshTimer = null;
+    // キーオーバーレイ
+    _keyOverlayTimer?.cancel();
+    _keyOverlayTimer = null;
+    _keyOverlayState.dispose();
     // ValueNotifierを破棄
     _viewNotifier.dispose();
     // スクロールコントローラーのリスナーを削除して破棄
@@ -956,7 +966,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
                                   verticalScrollController: _terminalScrollController,
                                   cursorX: cursor.x,
                                   cursorY: cursor.y,
-                                  onArrowSwipe: _sendSpecialKey,
+                                  onArrowSwipe: _sendSpecialKeyWithOverlay,
                                   onTwoFingerSwipe: _handleTwoFingerSwipe,
                                   navigableDirections: _getNavigableDirections(),
                                 );
@@ -987,6 +997,11 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
                           },
                         ),
                       ),
+                      // キーオーバーレイ
+                      KeyOverlayWidget(
+                        overlayState: _keyOverlayState,
+                        position: _keyOverlayPosition,
+                      ),
                     ],
                   ),
                 ),
@@ -1006,8 +1021,8 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
                 },
               ),
               SpecialKeysBar(
-                onKeyPressed: _sendKey,
-                onSpecialKeyPressed: _sendSpecialKey,
+                onKeyPressed: _sendKeyWithOverlay,
+                onSpecialKeyPressed: _sendSpecialKeyWithOverlay,
                 onInputTap: _showInputDialog,
                 directInputEnabled: _directInputEnabled,
                 onDirectInputToggle: () {
@@ -1033,11 +1048,59 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     );
   }
 
+  // --- キーオーバーレイ ラッパー ---
+
+  KeyOverlayPosition get _keyOverlayPosition {
+    final pos = ref.read(settingsProvider).keyOverlayPosition;
+    return switch (pos) {
+      'center' => KeyOverlayPosition.center,
+      'belowHeader' => KeyOverlayPosition.belowHeader,
+      _ => KeyOverlayPosition.aboveKeyboard,
+    };
+  }
+
+  /// 特殊キー送信 + オーバーレイ表示
+  void _sendSpecialKeyWithOverlay(String tmuxKey) {
+    _sendSpecialKey(tmuxKey);
+    _showKeyOverlay(tmuxKey);
+  }
+
+  /// リテラルキー送信 + ショートカットキーのオーバーレイ表示
+  void _sendKeyWithOverlay(String key) {
+    _sendKey(key);
+    if (TmuxKeyDisplay.isShortcutKey(key)) {
+      _showKeyOverlay(key);
+    }
+  }
+
+  /// オーバーレイ表示ロジック
+  void _showKeyOverlay(String key) {
+    final settings = ref.read(settingsProvider);
+    if (!settings.showKeyOverlay) return;
+
+    final category = TmuxKeyDisplay.categoryOf(key);
+    if (category == null) return;
+
+    final enabled = switch (category) {
+      KeyOverlayCategory.modifier => settings.keyOverlayModifier,
+      KeyOverlayCategory.special => settings.keyOverlaySpecial,
+      KeyOverlayCategory.arrow => settings.keyOverlayArrow,
+      KeyOverlayCategory.shortcut => settings.keyOverlayShortcut,
+    };
+    if (!enabled) return;
+
+    _keyOverlayState.show(TmuxKeyDisplay.displayText(key));
+    _keyOverlayTimer?.cancel();
+    _keyOverlayTimer = Timer(const Duration(milliseconds: 1500), () {
+      _keyOverlayState.hide();
+    });
+  }
+
   /// AnsiTextViewからのキー入力を処理
   void _handleKeyInput(KeyInputEvent event) {
-    // 特殊キーの場合はtmux形式で送信
+    // 特殊キーの場合はtmux形式で送信（オーバーレイ付き）
     if (event.isSpecialKey && event.tmuxKeyName != null) {
-      _sendSpecialKey(event.tmuxKeyName!);
+      _sendSpecialKeyWithOverlay(event.tmuxKeyName!);
     } else {
       // 通常の文字はリテラル送信
       _sendKeyData(event.data);
@@ -2967,6 +3030,10 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   }
 
   /// 複数行テキストを送信（行ごとにテキスト+Enterを送信）
+  ///
+  /// 注: _sendKey/_sendSpecialKeyを直接呼び出す。
+  /// オーバーレイラッパーを経由しないため、複数行送信時にオーバーレイは表示されない。
+  /// これは意図的な動作。
   Future<void> _sendMultilineText(String text) async {
     final lines = text.split('\n');
     for (int i = 0; i < lines.length; i++) {

--- a/lib/services/terminal/tmux_key_display.dart
+++ b/lib/services/terminal/tmux_key_display.dart
@@ -1,0 +1,90 @@
+/// キーオーバーレイのカテゴリ
+enum KeyOverlayCategory {
+  /// 修飾キー組み合わせ: Ctrl+x, Alt+x, Shift+x
+  modifier,
+
+  /// 単独特殊キー: ESC, TAB, ENTER, S-Enter, BSpace, BTab
+  special,
+
+  /// 矢印キー: Up, Down, Left, Right
+  arrow,
+
+  /// ショートカットキー: /, -, 1, 2, 3, 4
+  shortcut,
+}
+
+/// キーオーバーレイの表示位置
+enum KeyOverlayPosition {
+  /// キーボード（SpecialKeysBar）の真上
+  aboveKeyboard,
+
+  /// ターミナル領域の中央
+  center,
+
+  /// ブレッドクラムヘッダーの直下
+  belowHeader,
+}
+
+/// tmux send-keys 形式のキー名を人間可読表示に変換するユーティリティ
+class TmuxKeyDisplay {
+  static const _specialKeys = {
+    'Escape', 'Tab', 'Enter', 'BSpace', 'BTab', 'S-Enter',
+  };
+
+  static const _arrowKeys = {'Up', 'Down', 'Left', 'Right'};
+
+  static const _shortcutKeys = {'/', '-', '1', '2', '3', '4'};
+
+  static const _displayMap = {
+    'Escape': 'ESC',
+    'Tab': 'TAB',
+    'Enter': 'ENTER',
+    'S-Enter': 'Shift+Enter',
+    'BSpace': 'BS',
+    'BTab': 'Shift+TAB',
+    'Up': '↑',
+    'Down': '↓',
+    'Left': '←',
+    'Right': '→',
+  };
+
+  static final _modifierPattern = RegExp(r'^([CMS]-)+');
+
+  /// tmuxキー名からオーバーレイカテゴリを判定
+  ///
+  /// 該当しない場合は null を返す
+  static KeyOverlayCategory? categoryOf(String tmuxKey) {
+    if (_specialKeys.contains(tmuxKey)) return KeyOverlayCategory.special;
+    if (_arrowKeys.contains(tmuxKey)) return KeyOverlayCategory.arrow;
+    if (_shortcutKeys.contains(tmuxKey)) return KeyOverlayCategory.shortcut;
+    if (_modifierPattern.hasMatch(tmuxKey)) return KeyOverlayCategory.modifier;
+    return null;
+  }
+
+  /// リテラルキーがショートカットキーに該当するか判定
+  static bool isShortcutKey(String key) => _shortcutKeys.contains(key);
+
+  /// tmux形式のキー名を人間可読テキストに変換
+  static String displayText(String tmuxKey) {
+    // 固定マッピング
+    final mapped = _displayMap[tmuxKey];
+    if (mapped != null) return mapped;
+
+    // 修飾キーパターン: C-c → Ctrl+C, M-x → Alt+X, S-a → Shift+A
+    final match = _modifierPattern.firstMatch(tmuxKey);
+    if (match != null) {
+      final prefix = match.group(0)!;
+      final baseKey = tmuxKey.substring(prefix.length);
+      final parts = <String>[];
+      if (prefix.contains('C-')) parts.add('Ctrl');
+      if (prefix.contains('M-')) parts.add('Alt');
+      if (prefix.contains('S-')) parts.add('Shift');
+      final displayBase = _displayMap[baseKey] ?? baseKey.toUpperCase();
+      parts.add(displayBase);
+      return parts.join('+');
+    }
+
+    // そのまま返す（/, -, 1-4 等のリテラルキー）
+    return tmuxKey;
+  }
+}

--- a/lib/widgets/key_overlay_widget.dart
+++ b/lib/widgets/key_overlay_widget.dart
@@ -1,0 +1,142 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+import '../services/terminal/tmux_key_display.dart';
+
+/// キーオーバーレイの状態管理
+///
+/// [ValueNotifier] と異なり、同じ値でも [notifyListeners] を呼ぶため
+/// 連打時のパルスアニメーションが正しくトリガーされる。
+class KeyOverlayState extends ChangeNotifier {
+  String? _text;
+  bool _pulse = false;
+
+  String? get text => _text;
+  bool get pulse => _pulse;
+
+  void show(String newText) {
+    _pulse = _text == newText;
+    _text = newText;
+    notifyListeners();
+  }
+
+  void hide() {
+    _text = null;
+    _pulse = false;
+    notifyListeners();
+  }
+}
+
+/// キー送信時のオーバーレイ表示ウィジェット
+class KeyOverlayWidget extends StatefulWidget {
+  final KeyOverlayState overlayState;
+  final KeyOverlayPosition position;
+
+  const KeyOverlayWidget({
+    super.key,
+    required this.overlayState,
+    this.position = KeyOverlayPosition.aboveKeyboard,
+  });
+
+  @override
+  State<KeyOverlayWidget> createState() => _KeyOverlayWidgetState();
+}
+
+class _KeyOverlayWidgetState extends State<KeyOverlayWidget>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _pulseController;
+  late final Animation<double> _pulseAnimation;
+
+  @override
+  void initState() {
+    super.initState();
+    _pulseController = AnimationController(
+      duration: const Duration(milliseconds: 150),
+      vsync: this,
+    );
+    _pulseAnimation = TweenSequence<double>([
+      TweenSequenceItem(tween: Tween(begin: 1.0, end: 1.2), weight: 1),
+      TweenSequenceItem(tween: Tween(begin: 1.2, end: 1.0), weight: 1),
+    ]).animate(CurvedAnimation(
+      parent: _pulseController,
+      curve: Curves.easeInOut,
+    ));
+    widget.overlayState.addListener(_onStateChanged);
+  }
+
+  @override
+  void didUpdateWidget(KeyOverlayWidget oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.overlayState != widget.overlayState) {
+      oldWidget.overlayState.removeListener(_onStateChanged);
+      widget.overlayState.addListener(_onStateChanged);
+    }
+  }
+
+  @override
+  void dispose() {
+    widget.overlayState.removeListener(_onStateChanged);
+    _pulseController.dispose();
+    super.dispose();
+  }
+
+  void _onStateChanged() {
+    if (widget.overlayState.pulse) {
+      _pulseController.forward(from: 0);
+    }
+    setState(() {});
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final text = widget.overlayState.text;
+
+    if (widget.position == KeyOverlayPosition.center) {
+      return Positioned.fill(
+        child: IgnorePointer(
+          child: Center(child: _buildOverlay(text)),
+        ),
+      );
+    }
+
+    return Positioned(
+      top: widget.position == KeyOverlayPosition.belowHeader ? 8 : null,
+      bottom: widget.position == KeyOverlayPosition.aboveKeyboard ? 8 : null,
+      left: 0,
+      right: 0,
+      child: IgnorePointer(
+        child: Center(child: _buildOverlay(text)),
+      ),
+    );
+  }
+
+  Widget _buildOverlay(String? text) {
+    return AnimatedOpacity(
+      opacity: text != null ? 1.0 : 0.0,
+      duration: const Duration(milliseconds: 200),
+      child: text != null
+          ? ScaleTransition(
+              scale: _pulseAnimation,
+              child: Container(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 16,
+                  vertical: 8,
+                ),
+                decoration: BoxDecoration(
+                  color: const Color(0xFF2A2B35).withValues(alpha: 0.85),
+                  borderRadius: BorderRadius.circular(10),
+                ),
+                child: Text(
+                  text,
+                  style: GoogleFonts.jetBrainsMono(
+                    fontSize: 16,
+                    fontWeight: FontWeight.bold,
+                    color: Colors.white,
+                  ),
+                ),
+              ),
+            )
+          : const SizedBox.shrink(),
+    );
+  }
+}

--- a/test/services/terminal/tmux_key_display_test.dart
+++ b/test/services/terminal/tmux_key_display_test.dart
@@ -1,0 +1,173 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_muxpod/services/terminal/tmux_key_display.dart';
+
+void main() {
+  group('TmuxKeyDisplay.categoryOf', () {
+    group('modifier keys', () {
+      test('Ctrl+letter returns modifier', () {
+        expect(TmuxKeyDisplay.categoryOf('C-c'), KeyOverlayCategory.modifier);
+        expect(TmuxKeyDisplay.categoryOf('C-a'), KeyOverlayCategory.modifier);
+        expect(TmuxKeyDisplay.categoryOf('C-z'), KeyOverlayCategory.modifier);
+      });
+
+      test('Alt+letter returns modifier', () {
+        expect(TmuxKeyDisplay.categoryOf('M-x'), KeyOverlayCategory.modifier);
+        expect(TmuxKeyDisplay.categoryOf('M-a'), KeyOverlayCategory.modifier);
+      });
+
+      test('Shift+letter returns modifier', () {
+        expect(TmuxKeyDisplay.categoryOf('S-a'), KeyOverlayCategory.modifier);
+        expect(TmuxKeyDisplay.categoryOf('S-z'), KeyOverlayCategory.modifier);
+      });
+
+      test('compound modifiers return modifier', () {
+        expect(TmuxKeyDisplay.categoryOf('C-M-a'), KeyOverlayCategory.modifier);
+        expect(TmuxKeyDisplay.categoryOf('C-S-x'), KeyOverlayCategory.modifier);
+      });
+    });
+
+    group('special keys', () {
+      test('Escape returns special', () {
+        expect(TmuxKeyDisplay.categoryOf('Escape'), KeyOverlayCategory.special);
+      });
+
+      test('Enter returns special', () {
+        expect(TmuxKeyDisplay.categoryOf('Enter'), KeyOverlayCategory.special);
+      });
+
+      test('Tab returns special', () {
+        expect(TmuxKeyDisplay.categoryOf('Tab'), KeyOverlayCategory.special);
+      });
+
+      test('S-Enter returns special (not modifier)', () {
+        expect(TmuxKeyDisplay.categoryOf('S-Enter'), KeyOverlayCategory.special);
+      });
+
+      test('BSpace returns special', () {
+        expect(TmuxKeyDisplay.categoryOf('BSpace'), KeyOverlayCategory.special);
+      });
+
+      test('BTab returns special', () {
+        expect(TmuxKeyDisplay.categoryOf('BTab'), KeyOverlayCategory.special);
+      });
+    });
+
+    group('arrow keys', () {
+      test('arrow keys return arrow', () {
+        expect(TmuxKeyDisplay.categoryOf('Up'), KeyOverlayCategory.arrow);
+        expect(TmuxKeyDisplay.categoryOf('Down'), KeyOverlayCategory.arrow);
+        expect(TmuxKeyDisplay.categoryOf('Left'), KeyOverlayCategory.arrow);
+        expect(TmuxKeyDisplay.categoryOf('Right'), KeyOverlayCategory.arrow);
+      });
+    });
+
+    group('shortcut keys', () {
+      test('shortcut keys return shortcut', () {
+        expect(TmuxKeyDisplay.categoryOf('/'), KeyOverlayCategory.shortcut);
+        expect(TmuxKeyDisplay.categoryOf('-'), KeyOverlayCategory.shortcut);
+        expect(TmuxKeyDisplay.categoryOf('1'), KeyOverlayCategory.shortcut);
+        expect(TmuxKeyDisplay.categoryOf('2'), KeyOverlayCategory.shortcut);
+        expect(TmuxKeyDisplay.categoryOf('3'), KeyOverlayCategory.shortcut);
+        expect(TmuxKeyDisplay.categoryOf('4'), KeyOverlayCategory.shortcut);
+      });
+    });
+
+    group('unknown keys', () {
+      test('regular characters return null', () {
+        expect(TmuxKeyDisplay.categoryOf('a'), isNull);
+        expect(TmuxKeyDisplay.categoryOf('hello'), isNull);
+        expect(TmuxKeyDisplay.categoryOf('!'), isNull);
+      });
+    });
+  });
+
+  group('TmuxKeyDisplay.isShortcutKey', () {
+    test('shortcut keys return true', () {
+      expect(TmuxKeyDisplay.isShortcutKey('/'), isTrue);
+      expect(TmuxKeyDisplay.isShortcutKey('-'), isTrue);
+      expect(TmuxKeyDisplay.isShortcutKey('1'), isTrue);
+      expect(TmuxKeyDisplay.isShortcutKey('2'), isTrue);
+      expect(TmuxKeyDisplay.isShortcutKey('3'), isTrue);
+      expect(TmuxKeyDisplay.isShortcutKey('4'), isTrue);
+    });
+
+    test('non-shortcut keys return false', () {
+      expect(TmuxKeyDisplay.isShortcutKey('a'), isFalse);
+      expect(TmuxKeyDisplay.isShortcutKey('5'), isFalse);
+      expect(TmuxKeyDisplay.isShortcutKey('Escape'), isFalse);
+    });
+  });
+
+  group('TmuxKeyDisplay.displayText', () {
+    group('modifier keys', () {
+      test('Ctrl+letter', () {
+        expect(TmuxKeyDisplay.displayText('C-c'), 'Ctrl+C');
+        expect(TmuxKeyDisplay.displayText('C-a'), 'Ctrl+A');
+      });
+
+      test('Alt+letter', () {
+        expect(TmuxKeyDisplay.displayText('M-x'), 'Alt+X');
+        expect(TmuxKeyDisplay.displayText('M-a'), 'Alt+A');
+      });
+
+      test('Shift+letter', () {
+        expect(TmuxKeyDisplay.displayText('S-a'), 'Shift+A');
+      });
+
+      test('compound modifiers', () {
+        expect(TmuxKeyDisplay.displayText('C-M-a'), 'Ctrl+Alt+A');
+      });
+    });
+
+    group('special keys', () {
+      test('Escape → ESC', () {
+        expect(TmuxKeyDisplay.displayText('Escape'), 'ESC');
+      });
+
+      test('Enter → ENTER', () {
+        expect(TmuxKeyDisplay.displayText('Enter'), 'ENTER');
+      });
+
+      test('Tab → TAB', () {
+        expect(TmuxKeyDisplay.displayText('Tab'), 'TAB');
+      });
+
+      test('S-Enter → Shift+Enter', () {
+        expect(TmuxKeyDisplay.displayText('S-Enter'), 'Shift+Enter');
+      });
+
+      test('BSpace → BS', () {
+        expect(TmuxKeyDisplay.displayText('BSpace'), 'BS');
+      });
+
+      test('BTab → Shift+TAB', () {
+        expect(TmuxKeyDisplay.displayText('BTab'), 'Shift+TAB');
+      });
+    });
+
+    group('arrow keys', () {
+      test('arrows display as unicode symbols', () {
+        expect(TmuxKeyDisplay.displayText('Up'), '↑');
+        expect(TmuxKeyDisplay.displayText('Down'), '↓');
+        expect(TmuxKeyDisplay.displayText('Left'), '←');
+        expect(TmuxKeyDisplay.displayText('Right'), '→');
+      });
+    });
+
+    group('shortcut keys', () {
+      test('literal keys display as-is', () {
+        expect(TmuxKeyDisplay.displayText('/'), '/');
+        expect(TmuxKeyDisplay.displayText('-'), '-');
+        expect(TmuxKeyDisplay.displayText('1'), '1');
+        expect(TmuxKeyDisplay.displayText('4'), '4');
+      });
+    });
+
+    group('unknown keys', () {
+      test('unknown keys return as-is', () {
+        expect(TmuxKeyDisplay.displayText('DC'), 'DC');
+        expect(TmuxKeyDisplay.displayText('F1'), 'F1');
+      });
+    });
+  });
+}

--- a/test/widgets/key_overlay_widget_test.dart
+++ b/test/widgets/key_overlay_widget_test.dart
@@ -1,0 +1,146 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_muxpod/widgets/key_overlay_widget.dart';
+import 'package:flutter_muxpod/services/terminal/tmux_key_display.dart';
+
+void main() {
+  group('KeyOverlayState', () {
+    late KeyOverlayState state;
+
+    setUp(() {
+      state = KeyOverlayState();
+    });
+
+    tearDown(() {
+      state.dispose();
+    });
+
+    test('initial state is null and no pulse', () {
+      expect(state.text, isNull);
+      expect(state.pulse, isFalse);
+    });
+
+    test('show sets text', () {
+      state.show('Ctrl+C');
+      expect(state.text, 'Ctrl+C');
+      expect(state.pulse, isFalse);
+    });
+
+    test('show same key sets pulse true', () {
+      state.show('ESC');
+      state.show('ESC');
+      expect(state.text, 'ESC');
+      expect(state.pulse, isTrue);
+    });
+
+    test('show different key sets pulse false', () {
+      state.show('ESC');
+      state.show('TAB');
+      expect(state.text, 'TAB');
+      expect(state.pulse, isFalse);
+    });
+
+    test('hide clears text and pulse', () {
+      state.show('↑');
+      state.hide();
+      expect(state.text, isNull);
+      expect(state.pulse, isFalse);
+    });
+
+    test('notifies listeners on show', () {
+      int count = 0;
+      state.addListener(() => count++);
+      state.show('ESC');
+      expect(count, 1);
+    });
+
+    test('notifies listeners on same value show (for pulse)', () {
+      int count = 0;
+      state.show('ESC');
+      state.addListener(() => count++);
+      state.show('ESC');
+      expect(count, 1);
+    });
+  });
+
+  group('KeyOverlayWidget', () {
+    late KeyOverlayState overlayState;
+
+    setUp(() {
+      overlayState = KeyOverlayState();
+    });
+
+    tearDown(() {
+      overlayState.dispose();
+    });
+
+    Widget buildWidget({KeyOverlayPosition position = KeyOverlayPosition.aboveKeyboard}) {
+      return MaterialApp(
+        home: Scaffold(
+          body: Stack(
+            children: [
+              KeyOverlayWidget(
+                overlayState: overlayState,
+                position: position,
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    testWidgets('initially hidden when state text is null', (tester) async {
+      await tester.pumpWidget(buildWidget());
+      final opacity = tester.widget<AnimatedOpacity>(find.byType(AnimatedOpacity));
+      expect(opacity.opacity, 0.0);
+    });
+
+    testWidgets('shows text when state has value', (tester) async {
+      await tester.pumpWidget(buildWidget());
+      overlayState.show('Ctrl+C');
+      await tester.pump();
+      expect(find.text('Ctrl+C'), findsOneWidget);
+    });
+
+    testWidgets('hides text when state is hidden', (tester) async {
+      await tester.pumpWidget(buildWidget());
+      overlayState.show('ESC');
+      await tester.pump();
+      expect(find.text('ESC'), findsOneWidget);
+
+      overlayState.hide();
+      await tester.pump();
+      final opacity = tester.widget<AnimatedOpacity>(find.byType(AnimatedOpacity));
+      expect(opacity.opacity, 0.0);
+    });
+
+    testWidgets('rapid updates show latest key only', (tester) async {
+      await tester.pumpWidget(buildWidget());
+      overlayState.show('↑');
+      await tester.pump();
+      overlayState.show('↓');
+      await tester.pump();
+      overlayState.show('←');
+      await tester.pump();
+      expect(find.text('←'), findsOneWidget);
+    });
+
+    testWidgets('position aboveKeyboard uses bottom alignment', (tester) async {
+      await tester.pumpWidget(buildWidget(position: KeyOverlayPosition.aboveKeyboard));
+      overlayState.show('ESC');
+      await tester.pump();
+      final positioned = tester.widget<Positioned>(find.byType(Positioned));
+      expect(positioned.bottom, 8);
+      expect(positioned.top, isNull);
+    });
+
+    testWidgets('position belowHeader uses top alignment', (tester) async {
+      await tester.pumpWidget(buildWidget(position: KeyOverlayPosition.belowHeader));
+      overlayState.show('ESC');
+      await tester.pump();
+      final positioned = tester.widget<Positioned>(find.byType(Positioned));
+      expect(positioned.top, 8);
+      expect(positioned.bottom, isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- 特殊キー（Ctrl+C, ESC, 矢印等）送信時にキー名をトースト的オーバーレイで1.5秒間一時表示
- 全体ON/OFF + カテゴリ別ON/OFF（修飾キー/特殊キー/矢印/ショートカット）の設定
- 表示位置をキーボード上/画面中央/ヘッダー下から選択可能
- 同じキー連打時のパルスアニメーション（拡大→縮小）で再送信を視覚化

## Changes
- `lib/services/terminal/tmux_key_display.dart` (新規) — カテゴリ判定・表示テキスト変換ユーティリティ
- `lib/widgets/key_overlay_widget.dart` (新規) — KeyOverlayState (ChangeNotifier) + KeyOverlayWidget (AnimatedOpacity + ScaleTransition)
- `lib/providers/settings_provider.dart` — 6つの設定項目追加（showKeyOverlay, カテゴリ別4bool, 位置）
- `lib/screens/terminal/terminal_screen.dart` — コールバックラッパー方式で4箇所のキー送信にフック
- `lib/screens/settings/settings_screen.dart` — Key Overlayセクション追加（全体/カテゴリ別トグル + 位置選択）
- `test/services/terminal/tmux_key_display_test.dart` (新規) — 28テストケース
- `test/widgets/key_overlay_widget_test.dart` (新規) — 13テストケース

## Design decisions
- **コールバックラッパー方式**: `_sendKey()`/`_sendSpecialKey()` 自体は不変更。SpecialKeysBar内部にも触れない
- **KeyOverlayState (ChangeNotifier)**: ValueNotifierでは同じ値の再設定時に通知されないため、連打パルス検出にChangeNotifierを採用
- **`_sendMultilineText()` はラッパー非経由**: 複数行送信時のオーバーレイ誤表示を回避（意図的）

## Test plan
- [x] `flutter analyze` — エラーなし
- [x] `flutter test` — 全41テストパス
- [ ] 各カテゴリキー送信 → オーバーレイ表示確認（ESC, Ctrl+C, ↑, /, - 等）
- [ ] 設定画面でカテゴリ別OFF → 対象オーバーレイ非表示確認
- [ ] 全体OFF → 全オーバーレイ非表示確認
- [ ] 表示位置3箇所の切替確認
- [ ] 同じキー連打 → パルスアニメーション確認
- [ ] 高速連打 → 最新キーのみ表示、ちらつきなし

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)