### PR TITLE
fix(special-keys-bar): drop 100ms throttle blocking HW key repeats

### DIFF
--- a/lib/widgets/special_keys_bar.dart
+++ b/lib/widgets/special_keys_bar.dart
@@ -65,10 +65,11 @@ class _SpecialKeysBarState extends State<SpecialKeysBar> {
   /// sentinel リセット中の再入防止フラグ
   bool _isResettingController = false;
 
-  /// 二重入力防止: _handleKeyEventで処理した最終時刻
-  /// iPad外付けキーボードではFlutter KeyEventとiOSテキスト入力が
-  /// 同一キーを二重に処理するため、タイムスタンプで抑制する
-  DateTime? _lastKeyEventHandledAt;
+  /// Set to true by _markKeyEventHandled() after a hardware-key path consumes
+  /// an event. Cleared either on next frame (postFrame) or on first read
+  /// (consume). The purpose is to swallow exactly the next iOS UITextInput
+  /// duplicate text-delta that follows the same hardware keystroke.
+  bool _expectIosTextEcho = false;
 
   @override
   void initState() {
@@ -164,8 +165,8 @@ class _SpecialKeysBarState extends State<SpecialKeysBar> {
 
     // 実際のテキストがあれば送信
     if (actualText.isNotEmpty) {
-      // 外付けキーボードの二重入力防止: _handleKeyEventで処理済みならスキップ
-      if (_isRecentKeyEventHandled()) {
+      // Suppress the iOS UITextInput echo that follows the same hardware keystroke.
+      if (consumeRecentKeyEventFlag()) {
         _lastComposingText = null;
         _resetToSentinel();
         return;
@@ -212,8 +213,8 @@ class _SpecialKeysBarState extends State<SpecialKeysBar> {
 
   /// DirectInput: ソフトウェアキーボードのEnter（送信）で呼ばれる
   void _onDirectInputSubmitted(String value) {
-    // 外付けキーボードの二重入力防止: _handleKeyEventで処理済みならスキップ
-    if (_isRecentKeyEventHandled()) return;
+    // Suppress the iOS UITextInput submitted callback that echoes a HW Enter.
+    if (consumeRecentKeyEventFlag()) return;
 
     if (widget.hapticFeedback) {
       HapticFeedback.lightImpact();
@@ -257,16 +258,24 @@ class _SpecialKeysBarState extends State<SpecialKeysBar> {
     });
   }
 
-  /// 二重入力防止: _handleKeyEventで処理したことをマーク
+  /// Mark that a hardware-key event was just handled. The next iOS UITextInput
+  /// text-delta for the same keystroke should be suppressed.
   void _markKeyEventHandled() {
-    _lastKeyEventHandledAt = DateTime.now();
+    _expectIosTextEcho = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      _expectIosTextEcho = false;
+    });
   }
 
-  /// 二重入力防止: 直近100ms以内に_handleKeyEventで処理されたか
-  bool _isRecentKeyEventHandled() {
-    if (_lastKeyEventHandledAt == null) return false;
-    return DateTime.now().difference(_lastKeyEventHandledAt!) <
-        const Duration(milliseconds: 100);
+  /// Consume the iOS echo flag. Returns true and clears the flag if set,
+  /// otherwise returns false. Only the first downstream listener after a
+  /// hardware key fires gets blocked.
+  @visibleForTesting
+  bool consumeRecentKeyEventFlag() {
+    if (!_expectIosTextEcho) return false;
+    _expectIosTextEcho = false;
+    return true;
   }
 
   /// 外付けキーボードの修飾子を検出してtmux形式キー名に変換

--- a/lib/widgets/special_keys_bar.dart
+++ b/lib/widgets/special_keys_bar.dart
@@ -233,15 +233,23 @@ class _SpecialKeysBarState extends State<SpecialKeysBar> {
 
   /// DirectInput: sentinelにリセット（Backspace検出用）
   ///
-  /// _isResettingControllerの解除を次フレームまで遅延することで、
-  /// iOSプラットフォームがIME確定時に送る遅延テキスト更新を吸収する。
-  /// PostFrameCallbackでcontrollerが上書きされていれば再度sentinelにリセットする。
-  void _resetToSentinel() {
+  /// When [fastPath] is true (hardware-key origin), _isResettingController is
+  /// cleared immediately without waiting for the next frame. This prevents the
+  /// post-frame wait from blocking rapid key repeats on hardware keyboards.
+  ///
+  /// When [fastPath] is false (IME-driven path), _isResettingController is
+  /// held until the next frame so that iOS delayed text-delta updates that
+  /// arrive after composing commits are absorbed correctly.
+  void _resetToSentinel({bool fastPath = false}) {
     _isResettingController = true;
     _directInputController.value = TextEditingValue(
       text: _sentinel,
       selection: TextSelection.collapsed(offset: _sentinel.length),
     );
+    if (fastPath) {
+      _isResettingController = false;
+      return;
+    }
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
       final currentValue = _directInputController.value;
@@ -332,6 +340,9 @@ class _SpecialKeysBarState extends State<SpecialKeysBar> {
     widget.onSpecialKeyPressed(_applyHardwareModifiers(baseKey));
     // 外付けキーボード使用時はソフトウェア修飾子トグルをリセット
     _resetSoftwareModifiers();
+    // Hardware-key path: use fastPath so rapid repeats are not blocked for
+    // an extra frame by _isResettingController=true.
+    _resetToSentinel(fastPath: true);
   }
 
   /// ソフトウェア修飾子ボタンの状態をリセット
@@ -404,7 +415,9 @@ class _SpecialKeysBarState extends State<SpecialKeysBar> {
       HapticFeedback.lightImpact();
     }
     widget.onSpecialKeyPressed('Enter');
-    _resetToSentinel();
+    // Hardware-key path: skip post-frame wait so rapid Enter repeats are not
+    // held in _isResettingController=true for an entire frame each time.
+    _resetToSentinel(fastPath: true);
   }
 
   @override

--- a/test/widgets/special_keys_bar_test.dart
+++ b/test/widgets/special_keys_bar_test.dart
@@ -1,0 +1,143 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_muxpod/widgets/special_keys_bar.dart';
+
+/// Build a minimal test app around [SpecialKeysBar].
+Widget _buildTestApp({
+  required void Function(String) onKeyPressed,
+  required void Function(String) onSpecialKeyPressed,
+  bool directInputEnabled = true,
+}) {
+  return MaterialApp(
+    home: Scaffold(
+      body: SpecialKeysBar(
+        onKeyPressed: onKeyPressed,
+        onSpecialKeyPressed: onSpecialKeyPressed,
+        directInputEnabled: directInputEnabled,
+        hapticFeedback: false,
+      ),
+    ),
+  );
+}
+
+void main() {
+  group('SpecialKeysBar — hardware-key repeat, no throttle drops', () {
+    testWidgets(
+        'rapid Enter repeats (10x) all reach onSpecialKeyPressed',
+        (tester) async {
+      final List<String> received = [];
+
+      await tester.pumpWidget(_buildTestApp(
+        onKeyPressed: (_) {},
+        onSpecialKeyPressed: received.add,
+      ));
+      await tester.pump();
+
+      // Focus the direct-input field so _handleKeyEvent fires.
+      await tester.tap(find.byType(TextField));
+      await tester.pump();
+
+      for (int i = 0; i < 10; i++) {
+        await tester.sendKeyDownEvent(LogicalKeyboardKey.enter);
+        await tester.sendKeyUpEvent(LogicalKeyboardKey.enter);
+        // One frame between repeats — fastPath clears _isResettingController
+        // synchronously so _onDirectInputChanged never blocks on next press.
+        await tester.pump();
+      }
+
+      final enterCount = received.where((k) => k == 'Enter').length;
+      expect(enterCount, 10,
+          reason:
+              'Expected all 10 Enter repeats, got $enterCount. '
+              'The 100 ms throttle may still be active.');
+    });
+
+    testWidgets(
+        'rapid ArrowLeft repeats (10x) all reach onSpecialKeyPressed',
+        (tester) async {
+      final List<String> received = [];
+
+      await tester.pumpWidget(_buildTestApp(
+        onKeyPressed: (_) {},
+        onSpecialKeyPressed: received.add,
+      ));
+      await tester.pump();
+
+      await tester.tap(find.byType(TextField));
+      await tester.pump();
+
+      for (int i = 0; i < 10; i++) {
+        await tester.sendKeyDownEvent(LogicalKeyboardKey.arrowLeft);
+        await tester.sendKeyUpEvent(LogicalKeyboardKey.arrowLeft);
+        await tester.pump();
+      }
+
+      // ArrowLeft maps to 'Left' in tmux format.
+      final leftCount = received.where((k) => k == 'Left').length;
+      expect(leftCount, 10,
+          reason:
+              'Expected all 10 ArrowLeft repeats, got $leftCount.');
+    });
+  });
+
+  group('SpecialKeysBar — single-shot iOS echo suppression', () {
+    testWidgets(
+        'onDirectInputSubmitted fired by HW Enter is suppressed; '
+        'a subsequent software-Enter call goes through', (tester) async {
+      // This test verifies that consumeRecentKeyEventFlag() correctly
+      // allows only one suppression: the immediate iOS UITextInput callback
+      // that follows a hardware keystroke.
+      //
+      // Strategy: send one HW Enter (sets the flag), then trigger
+      // _onDirectInputSubmitted via TextInputAction.send (should be
+      // suppressed because the flag is set). Then trigger it again
+      // (flag consumed — should go through).
+      final List<String> received = [];
+
+      await tester.pumpWidget(_buildTestApp(
+        onKeyPressed: (_) {},
+        onSpecialKeyPressed: received.add,
+      ));
+      await tester.pump();
+
+      await tester.tap(find.byType(TextField));
+      await tester.pump();
+
+      // 1. HW Enter fires → _markKeyEventHandled() → _expectIosTextEcho = true
+      //    AND _sendDirectEnterAndClear → 'Enter' is sent, _resetToSentinel(fastPath).
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.enter);
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.enter);
+      // Do NOT pump postFrameCallback yet — flag is still hot.
+
+      final countAfterHwEnter = received.where((k) => k == 'Enter').length;
+      expect(countAfterHwEnter, 1, reason: 'HW Enter should send exactly one Enter.');
+
+      // 2. Simulate iOS UITextInput echo: the OS fires onSubmitted again for
+      //    the same keystroke. _consumeRecentKeyEventFlag() should return true
+      //    and block this second 'Enter' from reaching onSpecialKeyPressed.
+      await tester.testTextInput.receiveAction(TextInputAction.send);
+      await tester.pump();
+
+      final countAfterEcho = received.where((k) => k == 'Enter').length;
+      expect(countAfterEcho, 1,
+          reason:
+              'The OS echo of the HW Enter via onSubmitted must be suppressed '
+              'by consumeRecentKeyEventFlag(). Count should still be 1, '
+              'but got $countAfterEcho.');
+
+      // 3. Pump to let postFrameCallback run (auto-clear, already consumed).
+      await tester.pump();
+
+      // 4. A new software-keyboard Enter (no preceding HW key) should go through.
+      await tester.testTextInput.receiveAction(TextInputAction.send);
+      await tester.pump();
+
+      final countAfterSoftEnter = received.where((k) => k == 'Enter').length;
+      expect(countAfterSoftEnter, 2,
+          reason:
+              'A second onSubmitted call (software keyboard Enter) should '
+              'reach onSpecialKeyPressed because the flag was already consumed.');
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Hardware-keyboard repeats (Enter, arrow keys, etc.) were dropped during rapid input in DirectInput mode. The cause was a 100 ms time-based throttle in `SpecialKeysBar` plus a `_resetToSentinel` post-frame wait that together discarded any key event arriving within ~16–100 ms of a previous hardware keystroke. This change replaces the throttle with a single-shot consumable flag and adds a synchronous fast path for sentinel reset on hardware-key origin.

This affects all platforms when a hardware (Bluetooth or USB) keyboard is connected — Android, iOS / iPadOS, and desktop alike.

## Root cause

Two mechanisms cooperated to drop key events:

1. **Time-based throttle** — `_isRecentKeyEventHandled()` returned `true` for 100 ms after `_markKeyEventHandled()`. Every call site (`_onDirectInputChanged`, `_onDirectInputSubmitted`) silently bailed out during that window, capping the effective hardware-key throughput to ~10 events / second regardless of the actual keystroke rate.
2. **Post-frame sentinel reset** — `_resetToSentinel()` always deferred clearing `_isResettingController = false` to `addPostFrameCallback`. While that flag was set, `_onDirectInputChanged` early-returned, so any text-edit arriving in the same frame as a hardware key was ignored.

The original goal of the throttle was to swallow exactly one duplicate text-delta that iOS UITextInput emits after a `_handleKeyEvent` already processed the same physical keystroke. A 100 ms window is overkill for that purpose — only the very next text-delta in the same render cycle needs to be suppressed.

## Fix

**`refactor(special-keys-bar): single-shot echo flag`**

- Replace `DateTime? _lastKeyEventHandledAt` with `bool _expectIosTextEcho`.
- `_markKeyEventHandled()` sets the flag and schedules an `addPostFrameCallback` to clear it (safety net in case the iOS echo never arrives).
- New `_consumeRecentKeyEventFlag()` returns the flag value and immediately clears it, so only the first downstream listener after a hardware key sees `true`.
- All previous `_isRecentKeyEventHandled()` call sites switch to `_consumeRecentKeyEventFlag()`. Behaviour change: rapid hardware keys after the very first echo are no longer suppressed.

**`fix(special-keys-bar): skip post-frame on HW reset`**

- Add `{bool fastPath = false}` to `_resetToSentinel()`.
- Hardware-key paths (`_sendHwSpecialKey`, `_sendDirectEnterAndClear`) pass `fastPath: true` and clear `_isResettingController` synchronously, so subsequent key events in the same frame are not blocked.
- The IME-driven path inside `_onDirectInputChanged` keeps the default (post-frame) behaviour, since IME text-deltas can legitimately arrive a frame after the controller is reset.

## Manual test checklist

- [ ] **Android** with Bluetooth keyboard: hold Enter / arrow keys — every keypress reaches the tmux session.
- [ ] **iPad / iPadOS** with Bluetooth keyboard: rapid Enter / arrow repeats propagate without drops; iOS UITextInput echo is still suppressed (no double-input).
- [ ] **macOS** with built-in or external keyboard: same as above.
- [ ] **Software keyboard regression**: typing multi-character text via IME commits correctly (no double-send, no dropped chars).
- [ ] **Software keyboard Enter** (no hardware keyboard connected): Enter still reaches the terminal.
- [ ] **Modifier shortcuts**: Ctrl+C / Ctrl+A via hardware keyboard still fire and clear the modifier state correctly.
- [ ] **Empty Backspace sentinel**: pressing Backspace on an empty buffer still emits `BSpace` to tmux.
- [ ] **Samsung IME / Ctrl+letter shortcut path** (untouched in this PR): no regression.

## Tested

Widget tests added in `test/widgets/special_keys_bar_test.dart` cover:

1. 10 rapid Enter key repeats → all 10 reach `onSpecialKeyPressed`.
2. 10 rapid ArrowLeft repeats → all 10 reach `onSpecialKeyPressed`.
3. Single-shot echo suppression → first `onSubmitted` after a hardware Enter is blocked, the second one goes through.

`flutter analyze` and `flutter test` were not run locally for this PR (Flutter SDK is not installed in the environment where the patch was prepared); please rely on CI for the automated check.

## Related

A separate PR addresses the IME-Enter mis-send issue in the command input dialog (`terminal_screen.dart`). The two fixes touch disjoint files and are intentionally split to keep review scope minimal.
