### PR TITLE
fix(terminal): send multi-line text in one SSH round-trip

### DIFF
--- a/lib/screens/terminal/terminal_screen.dart
+++ b/lib/screens/terminal/terminal_screen.dart
@@ -3129,26 +3129,52 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     });
   }
 
-  /// 複数行テキストを送信（行ごとにテキスト+Enterを送信）
+  /// Send multi-line text in a single SSH round-trip by batching all
+  /// tmux send-keys commands into one shell invocation joined with `;`.
   ///
-  /// 注: _sendKey/_sendSpecialKeyを直接呼び出す。
-  /// オーバーレイラッパーを経由しないため、複数行送信時にオーバーレイは表示されない。
-  /// これは意図的な動作。
+  /// Enter-emission rules are identical to the previous per-line
+  /// implementation; only the round-trip count changes.
   Future<void> _sendMultilineText(String text) async {
     final lines = text.split('\n');
+    final target = ref.read(tmuxProvider.notifier).currentTarget;
+    if (target == null) return;
+
+    final commands = <String>[];
     for (int i = 0; i < lines.length; i++) {
       final line = lines[i];
       if (line.isNotEmpty) {
-        await _sendKey(line);
+        commands.add(TmuxCommands.sendKeys(target, line, literal: true));
       }
-      // 最後の行以外はEnterを送信、または空行でもEnterを送信
+      // Send Enter after every line except the last non-empty line,
+      // and also for empty lines that are not the last element.
       if (i < lines.length - 1 || line.isEmpty) {
-        await _sendSpecialKey('Enter');
+        commands.add(TmuxCommands.sendKeys(target, 'Enter', literal: false));
       }
     }
-    // 最後の行が空でなければEnterを送信
+    // Closing Enter for the last non-empty line.
     if (lines.isNotEmpty && lines.last.isNotEmpty) {
-      await _sendSpecialKey('Enter');
+      commands.add(TmuxCommands.sendKeys(target, 'Enter', literal: false));
+    }
+
+    if (commands.isEmpty) return;
+
+    final sshClient = ref.read(sshProvider.notifier).client;
+    if (sshClient == null || !sshClient.isConnected) {
+      // Offline: enqueue literal-key commands only (preserves existing behaviour).
+      for (final line in lines) {
+        if (line.isNotEmpty) {
+          _inputQueue.enqueue(line);
+        }
+      }
+      if (mounted) setState(() {});
+      return;
+    }
+
+    try {
+      await sshClient.exec(commands.join(' ; '));
+      _boostPolling();
+    } catch (_) {
+      // Silently ignore send errors; polling will reflect actual state.
     }
   }
 


### PR DESCRIPTION
## Summary

- `_sendMultilineText()` previously called `await sshClient.exec()` once per line and once per Enter key, serialising every round-trip over the SSH link.
- All `tmux send-keys` commands are now collected into a list and joined with ` ; `, then sent in a **single** `sshClient.exec()` call.
- Enter-emission ordering is byte-for-byte identical to the previous implementation — only the round-trip count changes.

## Root cause

Each `_sendKey()` and `_sendSpecialKey()` issued its own `await sshClient.exec(TmuxCommands.sendKeys(...))`. For a 5-line paste over a slow link that means ~10 serial SSH round-trips, causing the visible per-line delivery delay.

## Fix (Option A — `;`-chaining)

```dart
await sshClient.exec(commands.join(' ; '));
```

All `tmux send-keys` invocations run in a single remote shell. Option B (multi-argument `send-keys`) was not chosen because the existing `TmuxCommands.sendKeys()` API does not model mixed literal/non-literal arguments in a single call.

## Offline / queue behaviour

When `sshClient` is null or disconnected, the method falls back to enqueuing only the literal-text lines (same as `_sendKey()` did before), preserving the existing offline behaviour.

## Manual test plan

- [ ] Open input dialog, type or paste 5+ lines, press Send.
- [ ] Verify all lines arrive at the remote tmux pane together (no line-by-line delay).
- [ ] Verify single-line send still appends Enter as before.
- [ ] Verify empty string input is a no-op (nothing sent).
- [ ] Verify trailing-newline input (e.g. `"line1\n"`) sends `line1` then Enter.

Note: `flutter test` / `flutter analyze` were not run locally (Flutter SDK not available in the CI environment for this worktree). The change is scoped to a single private method with no signature changes.