### PR TITLE
fix(macos): grant keychain and network entitlements

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,23 @@ Contributions welcome! Feel free to:
 
 ---
 
+## Building on macOS
+
+The macOS target uses `flutter_secure_storage`, which requires a signed
+Keychain Sharing entitlement on macOS / Apple Silicon. Open the Xcode
+workspace and select a signing Team for the Runner target before building:
+
+```bash
+open macos/Runner.xcworkspace
+```
+
+In Xcode → Runner target → Signing & Capabilities:
+
+- Enable **Automatically manage signing**.
+- Pick a **Team**. A free Personal Team (added via Xcode → Settings → Accounts) is sufficient for local builds. Without a Team selected, the build fails with `-34018 errSecMissingEntitlement` at runtime.
+
+---
+
 ## License
 
 [Apache License 2.0](LICENSE) © 2025 mox

--- a/README.md
+++ b/README.md
@@ -258,6 +258,25 @@ In Xcode → Runner target → Signing & Capabilities:
 - Enable **Automatically manage signing**.
 - Pick a **Team**. A free Personal Team (added via Xcode → Settings → Accounts) is sufficient for local builds. Without a Team selected, the build fails with `-34018 errSecMissingEntitlement` at runtime.
 
+### Keychain Sharing capability
+
+The Xcode project (`macos/Runner.xcodeproj/project.pbxproj`) has `Keychain Sharing` enabled for the Runner target. This matches the `keychain-access-groups` entitlement present in both `DebugProfile.entitlements` and `Release.entitlements`, which is required by `flutter_secure_storage` on macOS.
+
+### If you change the Bundle Identifier
+
+The `keychain-access-groups` array in both entitlement files contains the application identifier:
+
+```
+$(AppIdentifierPrefix)dev.muxpod.flutterMuxpod
+```
+
+If you change the Bundle Identifier (e.g., to `com.example.myapp`), you **must** update the `keychain-access-groups` value in **both** of the following files to match:
+
+- `macos/Runner/DebugProfile.entitlements`
+- `macos/Runner/Release.entitlements`
+
+Failing to do so will cause `-34018 errSecMissingEntitlement` errors at runtime when the app tries to access the keychain.
+
 ---
 
 ## License

--- a/macos/Runner.xcodeproj/project.pbxproj
+++ b/macos/Runner.xcodeproj/project.pbxproj
@@ -240,6 +240,9 @@
 						LastSwiftMigration = 1100;
 						ProvisioningStyle = Automatic;
 						SystemCapabilities = {
+							com.apple.Keychain = {
+								enabled = 1;
+							};
 							com.apple.Sandbox = {
 								enabled = 1;
 							};

--- a/macos/Runner/DebugProfile.entitlements
+++ b/macos/Runner/DebugProfile.entitlements
@@ -8,5 +8,7 @@
 	<true/>
 	<key>com.apple.security.network.server</key>
 	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
 </dict>
 </plist>

--- a/macos/Runner/DebugProfile.entitlements
+++ b/macos/Runner/DebugProfile.entitlements
@@ -6,6 +6,7 @@
 	<true/>
 	<key>com.apple.security.cs.allow-jit</key>
 	<true/>
+	<!-- Required by Flutter debug-mode hot reload. Not needed in release. -->
 	<key>com.apple.security.network.server</key>
 	<true/>
 	<key>com.apple.security.network.client</key>

--- a/macos/Runner/DebugProfile.entitlements
+++ b/macos/Runner/DebugProfile.entitlements
@@ -10,5 +10,9 @@
 	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
+	<key>keychain-access-groups</key>
+	<array>
+		<string>$(AppIdentifierPrefix)dev.muxpod.flutterMuxpod</string>
+	</array>
 </dict>
 </plist>

--- a/macos/Runner/Release.entitlements
+++ b/macos/Runner/Release.entitlements
@@ -4,5 +4,11 @@
 <dict>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
+	<key>keychain-access-groups</key>
+	<array>
+		<string>$(AppIdentifierPrefix)dev.muxpod.flutterMuxpod</string>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary

- Add `com.apple.security.network.client` to `DebugProfile.entitlements` so outbound TCP (SSH, font downloads) works under App Sandbox
- Add `keychain-access-groups` to both `DebugProfile.entitlements` and `Release.entitlements` to allow `flutter_secure_storage` to read/write Keychain items
- Enable the Keychain Sharing system capability in `project.pbxproj` to align the project file with the new entitlement
- Add a "Building on macOS" section to `README.md` explaining the required Xcode signing team setup

## Root cause

`flutter_secure_storage` v10 calls Keychain APIs that require the `keychain-access-groups` entitlement when running under macOS App Sandbox. On Apple Silicon, ad-hoc signing (`-`) cannot satisfy this entitlement, so any Keychain access fails at runtime with `errSecMissingEntitlement (-34018)`. The missing `network.client` entitlement also blocks all outbound TCP connections in sandbox builds.

Reference: https://github.com/juliansteenbakker/flutter_secure_storage/issues/804

## Fix

**Entitlements added:**

| Key | DebugProfile | Release |
|-----|:---:|:---:|
| `com.apple.security.network.client` | added | added |
| `keychain-access-groups` | added | added |
| `com.apple.security.cs.allow-jit` | already present | not added (release does not need JIT) |

**project.pbxproj:** `com.apple.Keychain = { enabled = 1; }` added to the Runner target's `SystemCapabilities` block.

**README:** New "Building on macOS" subsection instructs contributors to open the Xcode workspace and select a signing Team before building. A free Personal Team is sufficient for local builds.

## Manual test plan

- [x] On Apple Silicon Mac, open `macos/Runner.xcworkspace` in Xcode
- [x] Runner target → Signing & Capabilities → Automatically manage signing → pick a Personal Team
- [x] `flutter run -d macos`
- [x] Add a connection with password or SSH key — stored without error
- [x] Tap "Test Connection" — SSH connects successfully, no `-34018` in logs
- [x] Without a Team selected, the same build still fails with `-34018` (entitlements alone are not sufficient; a valid signing identity is required by Apple)