### PR TITLE
fix(special-keys-bar): clean up DirectInput IME composing path

### DIFF
--- a/lib/widgets/special_keys_bar.dart
+++ b/lib/widgets/special_keys_bar.dart
@@ -75,6 +75,16 @@ class _SpecialKeysBarState extends State<SpecialKeysBar> {
       );
     }
     _directInputController.addListener(_onDirectInputChanged);
+    // Reset composing state when the field loses focus so that IME teardown
+    // (e.g. app backgrounded, keyboard dismissed) cannot leave _isComposing
+    // stuck at true and permanently block hardware-key handling.
+    _directInputFocusNode.addListener(_onFocusChange);
+  }
+
+  void _onFocusChange() {
+    if (!_directInputFocusNode.hasFocus) {
+      _isComposing = false;
+    }
   }
 
   @override
@@ -83,6 +93,8 @@ class _SpecialKeysBarState extends State<SpecialKeysBar> {
     if (widget.directInputEnabled && !oldWidget.directInputEnabled) {
       _resetToSentinel();
     } else if (!widget.directInputEnabled && oldWidget.directInputEnabled) {
+      // DirectInput turned off: clear any stuck composing state.
+      _isComposing = false;
       _isResettingController = true;
       _directInputController.clear();
       _isResettingController = false;
@@ -91,6 +103,8 @@ class _SpecialKeysBarState extends State<SpecialKeysBar> {
 
   @override
   void dispose() {
+    _isComposing = false;
+    _directInputFocusNode.removeListener(_onFocusChange);
     _directInputController.removeListener(_onDirectInputChanged);
     _directInputController.dispose();
     _directInputFocusNode.dispose();

--- a/lib/widgets/special_keys_bar.dart
+++ b/lib/widgets/special_keys_bar.dart
@@ -52,11 +52,6 @@ class _SpecialKeysBarState extends State<SpecialKeysBar> {
   /// 現在IME変換中かどうか
   bool _isComposing = false;
 
-  /// IME composing中の最新テキスト（iOS重複検出用）
-  /// iOSが自動確定時にcomposingテキストより長い確定テキストを返す場合、
-  /// composingテキストを正とし余分な重複を除去する
-  String? _lastComposingText;
-
   /// DirectInputモードでBackspace検出のためのsentinel文字（ゼロ幅スペース）
   /// iOS/iPadOSではTextField空の状態でBackspace押下時にKeyDownEventが
   /// 生成されないため、常にsentinelを保持して削除検出でBackspaceを検知する

--- a/lib/widgets/special_keys_bar.dart
+++ b/lib/widgets/special_keys_bar.dart
@@ -131,6 +131,11 @@ class _SpecialKeysBarState extends State<SpecialKeysBar> {
       // Guards:
       //   - length == 1: only the first composing char (avoids accumulated repeats)
       //   - ASCII letter regex: don't intercept Korean (ㅊ) or other non-ASCII composing
+      //
+      // Calling _resetToSentinel() here does NOT cause an infinite listener
+      // loop: the sentinel value we write has a collapsed (empty) composing
+      // range, so the very next _onDirectInputChanged invocation sets
+      // _isComposing = false and exits this branch immediately.
       final composingText = text.replaceAll(_sentinel, '');
       if ((_ctrlPressed || _altPressed) && composingText.length == 1) {
         final char = composingText;

--- a/lib/widgets/special_keys_bar.dart
+++ b/lib/widgets/special_keys_bar.dart
@@ -109,9 +109,6 @@ class _SpecialKeysBarState extends State<SpecialKeysBar> {
     _isComposing = value.composing.isValid && !value.composing.isCollapsed;
 
     if (_isComposing) {
-      // Record composing text for iOS duplicate detection
-      _lastComposingText = text.replaceAll(_sentinel, '');
-
       // Samsung IME composing workaround:
       // Samsung (and some Android IMEs) treat English letters as composing,
       // so composing=false may NEVER arrive while the user keeps typing.
@@ -120,8 +117,9 @@ class _SpecialKeysBarState extends State<SpecialKeysBar> {
       // Guards:
       //   - length == 1: only the first composing char (avoids accumulated repeats)
       //   - ASCII letter regex: don't intercept Korean (ㅊ) or other non-ASCII composing
-      if ((_ctrlPressed || _altPressed) && _lastComposingText!.length == 1) {
-        final char = _lastComposingText!;
+      final composingText = text.replaceAll(_sentinel, '');
+      if ((_ctrlPressed || _altPressed) && composingText.length == 1) {
+        final char = composingText;
         if (RegExp(r'^[A-Za-z]$').hasMatch(char)) {
           if (widget.hapticFeedback) {
             HapticFeedback.lightImpact();
@@ -137,18 +135,18 @@ class _SpecialKeysBarState extends State<SpecialKeysBar> {
           }
           final prefix = modifiers.join('-');
           widget.onSpecialKeyPressed('$prefix-${char.toLowerCase()}');
-          _lastComposingText = null;
           _resetToSentinel();
           return;
         }
       }
 
+      // While composing: do nothing. Let Flutter manage the IME preview.
+      // Do not record snapshots, do not call onKeyPressed, do not reset sentinel.
       return;
     }
 
     // Sentinelが削除された = Backspaceが押された（iOS/iPadOS対応）
     if (text.isEmpty) {
-      _lastComposingText = null;
       _sendDirectBackspace();
       _resetToSentinel();
       return;
@@ -161,27 +159,16 @@ class _SpecialKeysBarState extends State<SpecialKeysBar> {
     if (actualText.isNotEmpty) {
       // 外付けキーボードの二重入力防止: _handleKeyEventで処理済みならスキップ
       if (_isRecentKeyEventHandled()) {
-        _lastComposingText = null;
         _resetToSentinel();
         return;
       }
-
-      // iOS重複検出: 確定テキストがcomposingテキストより長く、
-      // composingテキストで始まる場合、iOSの重複挿入とみなしcomposingテキストを使用
-      String textToSend = actualText;
-      if (_lastComposingText != null &&
-          actualText.length > _lastComposingText!.length &&
-          actualText.startsWith(_lastComposingText!)) {
-        textToSend = _lastComposingText!;
-      }
-      _lastComposingText = null;
 
       // Send modifier+key when CTRL/ALT is active (non-composing path)
       // This handles IMEs that commit without composing (e.g. Gboard English)
       // tmux format: C-c (Ctrl+C), M-a (Alt+A), C-M-x (Ctrl+Alt+X)
       if ((_ctrlPressed || _altPressed) &&
-          textToSend.length == 1 &&
-          RegExp(r'^[A-Za-z]$').hasMatch(textToSend)) {
+          actualText.length == 1 &&
+          RegExp(r'^[A-Za-z]$').hasMatch(actualText)) {
         if (widget.hapticFeedback) {
           HapticFeedback.lightImpact();
         }
@@ -195,9 +182,9 @@ class _SpecialKeysBarState extends State<SpecialKeysBar> {
           setState(() => _altPressed = false);
         }
         final prefix = modifiers.join('-');
-        widget.onSpecialKeyPressed('$prefix-${textToSend.toLowerCase()}');
+        widget.onSpecialKeyPressed('$prefix-${actualText.toLowerCase()}');
       } else {
-        widget.onKeyPressed(textToSend);
+        widget.onKeyPressed(actualText);
       }
 
       // 送信後にsentinelにリセット

--- a/test/widgets/special_keys_bar_ime_test.dart
+++ b/test/widgets/special_keys_bar_ime_test.dart
@@ -1,0 +1,199 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:flutter_muxpod/widgets/special_keys_bar.dart';
+
+/// Sentinel zero-width space used internally by SpecialKeysBar.
+const _sentinel = '​';
+
+/// Helper: build SpecialKeysBar inside a minimal MaterialApp with
+/// DirectInput enabled and collect key/special-key emissions.
+Future<({List<String> keys, List<String> specialKeys})> _buildBar(
+  WidgetTester tester,
+) async {
+  final keys = <String>[];
+  final specialKeys = <String>[];
+
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: SpecialKeysBar(
+          directInputEnabled: true,
+          hapticFeedback: false,
+          onKeyPressed: keys.add,
+          onSpecialKeyPressed: specialKeys.add,
+        ),
+      ),
+    ),
+  );
+
+  // Let the widget settle (initState sets the sentinel value).
+  await tester.pump();
+
+  return (keys: keys, specialKeys: specialKeys);
+}
+
+/// Simulate a TextEditingValue update as if the IME sent it.
+void _updateEditingValue(WidgetTester tester, TextEditingValue value) {
+  tester.testTextInput.updateEditingValue(value);
+}
+
+void main() {
+  setUpAll(() {
+    // Prevent google_fonts from hitting the network in tests.
+    GoogleFonts.config.allowRuntimeFetching = false;
+  });
+
+  group('SpecialKeysBar DirectInput IME handling', () {
+    testWidgets('compose then commit: onKeyPressed called once with committed text',
+        (tester) async {
+      final result = await _buildBar(tester);
+
+      // Find the TextField and give it focus.
+      final textField = find.byType(TextField);
+      expect(textField, findsOneWidget);
+      await tester.tap(textField);
+      await tester.pump();
+
+      // Step 1: Simulate composing — controller has composing range active.
+      // The IME is showing "あ" as a composing candidate.
+      _updateEditingValue(
+        tester,
+        TextEditingValue(
+          text: '${_sentinel}あ', // sentinel + "あ"
+          selection: const TextSelection.collapsed(offset: 2),
+          composing: const TextRange(start: 1, end: 2), // "あ" is composing
+        ),
+      );
+      await tester.pump();
+
+      // While composing, nothing should be sent.
+      expect(result.keys, isEmpty);
+      expect(result.specialKeys, isEmpty);
+
+      // Step 2: User selects a kanji — composing ends, committed text arrives.
+      // The controller now shows sentinel + "亜" with no composing range.
+      _updateEditingValue(
+        tester,
+        TextEditingValue(
+          text: '${_sentinel}亜', // sentinel + "亜"
+          selection: const TextSelection.collapsed(offset: 2),
+          composing: TextRange.empty, // composing committed
+        ),
+      );
+      await tester.pump();
+      // Sentinel reset is deferred to postFrameCallback.
+      await tester.pump();
+
+      // Exactly one emission with the committed kanji.
+      expect(result.keys, hasLength(1));
+      expect(result.keys.first, '亜'); // "亜"
+      expect(result.specialKeys, isEmpty);
+    });
+
+    testWidgets(
+        'partial-input continuation (no commit): onKeyPressed NOT called',
+        (tester) async {
+      final result = await _buildBar(tester);
+
+      final textField = find.byType(TextField);
+      await tester.tap(textField);
+      await tester.pump();
+
+      // Keep the composing range valid throughout multiple updates,
+      // simulating the user continuing to type without committing.
+      for (final composingChar in ['あ', 'い', 'う']) {
+        _updateEditingValue(
+          tester,
+          TextEditingValue(
+            text: '$_sentinel$composingChar',
+            selection: const TextSelection.collapsed(offset: 2),
+            composing: const TextRange(start: 1, end: 2),
+          ),
+        );
+        await tester.pump();
+      }
+
+      expect(result.keys, isEmpty);
+      expect(result.specialKeys, isEmpty);
+    });
+
+    testWidgets('backspace on empty buffer: BSpace emitted', (tester) async {
+      final result = await _buildBar(tester);
+
+      final textField = find.byType(TextField);
+      await tester.tap(textField);
+      await tester.pump();
+
+      // Simulate the sentinel being deleted (text becomes empty).
+      _updateEditingValue(
+        tester,
+        const TextEditingValue(
+          text: '', // sentinel removed → Backspace detected
+          selection: TextSelection.collapsed(offset: 0),
+          composing: TextRange.empty,
+        ),
+      );
+      await tester.pump();
+      await tester.pump();
+
+      expect(result.specialKeys, contains('BSpace'));
+      expect(result.keys, isEmpty);
+    });
+
+    testWidgets('plain text without IME: onKeyPressed called once', (tester) async {
+      final result = await _buildBar(tester);
+
+      final textField = find.byType(TextField);
+      await tester.tap(textField);
+      await tester.pump();
+
+      // Simulate typing "hello" with no composing range.
+      _updateEditingValue(
+        tester,
+        TextEditingValue(
+          text: '${_sentinel}hello',
+          selection: const TextSelection.collapsed(offset: 6),
+          composing: TextRange.empty,
+        ),
+      );
+      await tester.pump();
+      await tester.pump();
+
+      expect(result.keys, hasLength(1));
+      expect(result.keys.first, 'hello');
+      expect(result.specialKeys, isEmpty);
+    });
+
+    testWidgets('hardware Enter while composing: KeyEventResult.ignored',
+        (tester) async {
+      final result = await _buildBar(tester);
+
+      final textField = find.byType(TextField);
+      await tester.tap(textField);
+      await tester.pump();
+
+      // Start a composing session.
+      _updateEditingValue(
+        tester,
+        TextEditingValue(
+          text: '${_sentinel}あ',
+          selection: const TextSelection.collapsed(offset: 2),
+          composing: const TextRange(start: 1, end: 2),
+        ),
+      );
+      await tester.pump();
+
+      // Send a hardware Enter key while composing is active.
+      // The handler should return KeyEventResult.ignored, so the IME
+      // handles it (no Enter special-key emission from our code).
+      await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+      await tester.pump();
+
+      // No Enter should have been sent by SpecialKeysBar while composing.
+      expect(result.specialKeys.where((k) => k == 'Enter'), isEmpty);
+      expect(result.keys, isEmpty);
+    });
+  });
+}

--- a/test/widgets/special_keys_bar_ime_test.dart
+++ b/test/widgets/special_keys_bar_ime_test.dart
@@ -166,6 +166,54 @@ void main() {
       expect(result.specialKeys, isEmpty);
     });
 
+    // Regression: the old iOS-style duplicate-detection branch would compare the
+    // committed text against a stored composing snapshot and, when the committed
+    // text was longer and started with the snapshot, silently substitute the
+    // snapshot instead.  That branch was removed; this test pins the new
+    // behaviour: the full committed text must be forwarded as-is.
+    testWidgets(
+        'iOS-style commit longer than composing sends committed text once',
+        (tester) async {
+      final result = await _buildBar(tester);
+
+      final textField = find.byType(TextField);
+      expect(textField, findsOneWidget);
+      await tester.tap(textField);
+      await tester.pump();
+
+      // Step 1: composing 'a' (single ASCII letter, Samsung-style composing).
+      _updateEditingValue(
+        tester,
+        TextEditingValue(
+          text: '${_sentinel}a',
+          selection: const TextSelection.collapsed(offset: 2),
+          composing: const TextRange(start: 1, end: 2),
+        ),
+      );
+      await tester.pump();
+
+      // Nothing emitted while composing.
+      expect(result.keys, isEmpty);
+      expect(result.specialKeys, isEmpty);
+
+      // Step 2: IME commits '亜亜' — text is longer than the composing snapshot.
+      // Previously this would have been truncated to 'a'; now '亜亜' must be sent.
+      _updateEditingValue(
+        tester,
+        TextEditingValue(
+          text: '${_sentinel}亜亜',
+          selection: const TextSelection.collapsed(offset: 3),
+          composing: TextRange.empty,
+        ),
+      );
+      await tester.pump();
+      await tester.pump();
+
+      expect(result.keys, hasLength(1));
+      expect(result.keys.first, '亜亜');
+      expect(result.specialKeys, isEmpty);
+    });
+
     testWidgets('hardware Enter while composing: KeyEventResult.ignored',
         (tester) async {
       final result = await _buildBar(tester);


### PR DESCRIPTION
## Summary

- Remove the `_lastComposingText` field and the duplicate-detection branch that swapped the freshly committed text for an old composing snapshot on iOS.
- `_onDirectInputChanged` now returns early while composing is active — no snapshots recorded, no `onKeyPressed` called, sentinel not reset.
- On commit (composing collapses), the controller's current value is sent exactly once, then the sentinel is restored.

## Root cause

The over-clever iOS auto-commit detection at the original lines 176-182 compared the committed text against `_lastComposingText`. When the committed text was longer than the composing snapshot and started with it, the code replaced the committed text with the old snapshot — sending the wrong (stale) text. Combined with the snapshot being recorded on every composing update, partial composing text leaked across composition cycles and was duplicated in tmux.

## Fix description

1. **Dropped `_lastComposingText`** entirely. No more snapshot tracking.
2. **Early return while composing**: `_onDirectInputChanged` checks `value.composing.isValid && !value.composing.isCollapsed` and returns immediately when true. Flutter manages the IME preview; our code does nothing.
3. **Samsung IME workaround preserved**: the modifier+ASCII-letter interception inside the composing branch is kept intact (it now uses a local `composingText` variable instead of the removed field).
4. **On commit**: `actualText = text.replaceAll(_sentinel, '')` is the authoritative source. Sent once via `onKeyPressed` (or `onSpecialKeyPressed` for modifier combos), then sentinel is reset.
5. **`_handleKeyEvent` unchanged**: the existing `if (_isComposing) return KeyEventResult.ignored` guard at line ~346 is untouched.

## Manual test checklist

- [ ] Japanese kana → kanji conversion in DirectInput on iPad / Android: compose several kana, select kanji from candidate bar — only the selected kanji appears in tmux, not duplicated.
- [ ] Partial composing continuation: keep typing without committing (e.g. romaji input mid-word) — no premature text sent to tmux.
- [ ] Plain ASCII typing (no IME): "hello\n" in DirectInput — appears correctly in tmux.
- [ ] Backspace on empty buffer: cursor at sentinel position, press Backspace — BSpace event reaches tmux.
- [ ] Modifier shortcuts (CTRL+C, ALT+x) still work in DirectInput and via hardware keyboard.
- [ ] Hardware arrow/escape/tab keys still forwarded correctly.

Note: `flutter test` was not run locally as the Flutter SDK is not installed in the build environment. The test file is syntactically valid Dart and uses the standard `testWidgets` / `tester.testTextInput.updateEditingValue` pattern consistent with the existing widget tests in this repo.