### PR TITLE
fix(terminal): clear input buffer only on send, preserve draft on cancel

### DIFF
--- a/lib/screens/terminal/terminal_screen.dart
+++ b/lib/screens/terminal/terminal_screen.dart
@@ -110,34 +110,6 @@ class TerminalScreen extends ConsumerStatefulWidget {
 
   @override
   ConsumerState<TerminalScreen> createState() => _TerminalScreenState();
-
-  /// Returns the input dialog content widget for use in widget tests only.
-  ///
-  /// Provides a test seam so that [_InputDialogContent] — a private widget —
-  /// can be pumped in isolation without standing up the full [TerminalScreen]
-  /// and its SSH/tmux provider dependencies.
-  ///
-  /// Example usage in tests:
-  /// ```dart
-  /// final widget = TerminalScreen.buildInputDialogContentForTesting(
-  ///   initialValue: '',
-  ///   onValueChanged: (v) { ... },
-  ///   onSend: (v) async { ... },
-  /// );
-  /// await tester.pumpWidget(MaterialApp(home: Scaffold(body: widget)));
-  /// ```
-  @visibleForTesting
-  static Widget buildInputDialogContentForTesting({
-    String initialValue = '',
-    required void Function(String) onValueChanged,
-    required Future<void> Function(String) onSend,
-  }) {
-    return _InputDialogContent(
-      initialValue: initialValue,
-      onValueChanged: onValueChanged,
-      onSend: onSend,
-    );
-  }
 }
 
 class _TerminalScreenState extends ConsumerState<TerminalScreen>

--- a/lib/screens/terminal/terminal_screen.dart
+++ b/lib/screens/terminal/terminal_screen.dart
@@ -109,6 +109,34 @@ class TerminalScreen extends ConsumerStatefulWidget {
 
   @override
   ConsumerState<TerminalScreen> createState() => _TerminalScreenState();
+
+  /// Returns the input dialog content widget for use in widget tests only.
+  ///
+  /// Provides a test seam so that [_InputDialogContent] — a private widget —
+  /// can be pumped in isolation without standing up the full [TerminalScreen]
+  /// and its SSH/tmux provider dependencies.
+  ///
+  /// Example usage in tests:
+  /// ```dart
+  /// final widget = TerminalScreen.buildInputDialogContentForTesting(
+  ///   initialValue: '',
+  ///   onValueChanged: (v) { ... },
+  ///   onSend: (v) async { ... },
+  /// );
+  /// await tester.pumpWidget(MaterialApp(home: Scaffold(body: widget)));
+  /// ```
+  @visibleForTesting
+  static Widget buildInputDialogContentForTesting({
+    String initialValue = '',
+    required void Function(String) onValueChanged,
+    required Future<void> Function(String) onSend,
+  }) {
+    return _InputDialogContent(
+      initialValue: initialValue,
+      onValueChanged: onValueChanged,
+      onSend: onSend,
+    );
+  }
 }
 
 class _TerminalScreenState extends ConsumerState<TerminalScreen>
@@ -3125,7 +3153,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         },
       ),
     ).then((_) {
-      _savedCommandInput = '';
+      if (mounted) _savedCommandInput = '';
       _scrollToBottomKey.currentState?.show();
     });
   }

--- a/lib/screens/terminal/terminal_screen.dart
+++ b/lib/screens/terminal/terminal_screen.dart
@@ -3153,7 +3153,6 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         },
       ),
     ).then((_) {
-      if (mounted) _savedCommandInput = '';
       _scrollToBottomKey.currentState?.show();
     });
   }
@@ -3712,6 +3711,7 @@ class _InputDialogContentState extends State<_InputDialogContent> {
   late final FocusNode _focusNode;
   late final ScrollController _scrollController;
   bool _isSending = false;
+  bool _sent = false;
 
   @override
   void initState() {
@@ -3734,6 +3734,8 @@ class _InputDialogContentState extends State<_InputDialogContent> {
   }
 
   void _onTextChanged() {
+    // 送信後の後片付け通知（IMEのcomposing確定など）でバッファを上書きしない
+    if (_sent) return;
     widget.onValueChanged(_controller.text);
   }
 
@@ -3779,7 +3781,14 @@ class _InputDialogContentState extends State<_InputDialogContent> {
     if (_isSending) return;
     setState(() => _isSending = true);
     try {
+      // 送信開始と同時にラッチ。teardown時の再通知（pop→フォーカス喪失→IME確定）が
+      // 同期・非同期どちらで来てもバッファ書き戻しを抑制する。
+      _sent = true;
       await widget.onSend(_controller.text);
+    } catch (_) {
+      // 送信失敗。ドラフトを保持しトラッキングを継続する。
+      _sent = false;
+      rethrow;
     } finally {
       if (mounted) {
         setState(() => _isSending = false);

--- a/lib/screens/terminal/terminal_screen.dart
+++ b/lib/screens/terminal/terminal_screen.dart
@@ -3125,6 +3125,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         },
       ),
     ).then((_) {
+      _savedCommandInput = '';
       _scrollToBottomKey.currentState?.show();
     });
   }

--- a/test/widgets/input_dialog_clear_test.dart
+++ b/test/widgets/input_dialog_clear_test.dart
@@ -1,34 +1,29 @@
-// Widget tests verifying that the input dialog controller starts empty
-// whenever the dialog is opened after a previous session.
+// Widget tests for the command-input dialog (_InputDialogContent).
 //
-// Strategy: pump _InputDialogContent via the @visibleForTesting seam
-// TerminalScreen.buildInputDialogContentForTesting().  This avoids standing
-// up the full TerminalScreen with its SSH/tmux provider dependencies while
-// still exercising the real widget tree.
+// Semantics under test (PR #50, revised):
+//   - SEND path  : the input buffer is cleared. After a successful send the
+//                  host's saved draft becomes '' and stays '' — even if the
+//                  controller fires a late change notification during teardown
+//                  (IME composing-confirm on focus loss). The _sent latch
+//                  suppresses that re-notification.
+//   - CANCEL path: the draft is PRESERVED. Dismissing via cancel / swipe /
+//                  back keeps whatever the user typed, so reopening restores it.
 //
-// The tests mirror the dismissal paths added by PR #50:
-//   - cancel (Navigator.pop without sending)
-//   - send  (onSend callback fires, then Navigator.pop)
+// We model the host's _savedCommandInput with a local `saved` variable that
+// onValueChanged writes to (mirroring _showInputDialog) and that the send
+// callback clears (mirroring onSend's `_savedCommandInput = ''`). The dialog is
+// pumped in isolation through the @visibleForTesting seam
+// TerminalScreen.buildInputDialogContentForTesting(), avoiding the full
+// SSH/tmux provider stack.
 //
-// In both cases the host state resets _savedCommandInput to '' in the
-// .then((_) { if (mounted) _savedCommandInput = ''; }) callback, so the
-// *next* open receives initialValue: ''.  We verify that invariant by
-// reopening the dialog with initialValue: '' and asserting the TextField
-// starts empty.
+// NOTE: tester.enterText() fires the controller listener synchronously and does
+// NOT reproduce the real async focus-loss -> IME-confirm race. These tests
+// therefore verify the _sent latch *logic*, not the underlying platform race.
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_muxpod/screens/terminal/terminal_screen.dart';
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-/// Pumps [_InputDialogContent] inside a minimal navigator scaffold so that
-/// Cancel's Navigator.pop(context) resolves correctly.
-///
-/// [initialValue] simulates _savedCommandInput at open time.
-/// [onValueChanged] / [onSend] are forwarded verbatim.
 Widget _buildHarness({
   String initialValue = '',
   required void Function(String) onValueChanged,
@@ -45,12 +40,8 @@ Widget _buildHarness({
   );
 }
 
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
-
 void main() {
-  group('_InputDialogContent — controller starts empty on reopen', () {
+  group('_InputDialogContent — clear on send / keep on cancel', () {
     testWidgets('text field is pre-populated with initialValue', (tester) async {
       await tester.pumpWidget(
         _buildHarness(
@@ -64,7 +55,7 @@ void main() {
       final textField = find.byType(TextField);
       expect(textField, findsOneWidget);
       expect(
-        (tester.widget<TextField>(textField).controller)?.text,
+        tester.widget<TextField>(textField).controller?.text,
         'hello world',
         reason: 'initialValue must be reflected in the text field on open',
       );
@@ -72,7 +63,6 @@ void main() {
 
     testWidgets('text field is empty when initialValue is empty string',
         (tester) async {
-      // Simulates reopening after the host has reset _savedCommandInput = ''.
       await tester.pumpWidget(
         _buildHarness(
           initialValue: '',
@@ -82,10 +72,8 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      final textField = find.byType(TextField);
-      expect(textField, findsOneWidget);
       expect(
-        (tester.widget<TextField>(textField).controller)?.text,
+        tester.widget<TextField>(find.byType(TextField)).controller?.text,
         '',
         reason: 'text field must start empty when initialValue is empty',
       );
@@ -108,10 +96,10 @@ void main() {
 
       expect(captured, 'ls -la',
           reason: 'onValueChanged must track every keystroke so the host can '
-              'persist _savedCommandInput in real time');
+              'persist the draft in real time');
     });
 
-    testWidgets('onSend is called with the current text when Send is tapped',
+    testWidgets('onSend receives the current text when Execute is tapped',
         (tester) async {
       String? sentValue;
 
@@ -129,7 +117,6 @@ void main() {
       await tester.enterText(find.byType(TextField), 'echo hi');
       await tester.pump();
 
-      // Tap the Execute button (ElevatedButton labelled 'Execute').
       await tester.tap(find.widgetWithText(ElevatedButton, 'Execute'));
       await tester.pumpAndSettle();
 
@@ -137,66 +124,59 @@ void main() {
           reason: 'onSend must receive the full text the user typed');
     });
 
-    testWidgets(
-        'reopening with initialValue empty after cancel yields empty field',
+    // ---- CANCEL: draft is preserved -------------------------------------
+    testWidgets('cancel preserves the draft — reopen restores typed text',
         (tester) async {
-      // Round-trip test:
-      //   1. Open dialog with some pre-saved text (initialValue: 'draft').
-      //   2. Dismiss (simulate cancel — host resets _savedCommandInput to '').
-      //   3. Open dialog again with initialValue: '' — field must be empty.
-      //
-      // In production the bottom sheet is torn down and recreated, which gives
-      // _InputDialogContent a fresh State. We replicate that by pumping a
-      // blank widget between the two opens so Flutter disposes the old State.
+      // Model the host's _savedCommandInput.
+      var saved = '';
 
-      // First open: pre-populated.
       await tester.pumpWidget(
         _buildHarness(
-          initialValue: 'draft',
-          onValueChanged: (_) {},
+          initialValue: saved,
+          onValueChanged: (v) => saved = v,
           onSend: (_) async {},
         ),
       );
       await tester.pumpAndSettle();
 
-      expect(
-        (tester.widget<TextField>(find.byType(TextField)).controller)?.text,
-        'draft',
-      );
+      await tester.enterText(find.byType(TextField), 'draft me');
+      await tester.pump();
+      expect(saved, 'draft me');
 
-      // Tear down (simulate dialog dismiss — State is destroyed).
+      // Dismiss WITHOUT sending (cancel / swipe / back). State is destroyed,
+      // but the host keeps `saved` (the .then() no longer clears it).
       await tester.pumpWidget(const SizedBox.shrink());
       await tester.pumpAndSettle();
 
-      // Host has reset _savedCommandInput = ''. Reopen with empty initialValue.
+      // Reopen with the preserved draft.
       await tester.pumpWidget(
         _buildHarness(
-          initialValue: '',
-          onValueChanged: (_) {},
+          initialValue: saved,
+          onValueChanged: (v) => saved = v,
           onSend: (_) async {},
         ),
       );
       await tester.pumpAndSettle();
 
       expect(
-        (tester.widget<TextField>(find.byType(TextField)).controller)?.text,
-        '',
-        reason: 'after the host resets _savedCommandInput the next open must '
-            'show an empty field',
+        tester.widget<TextField>(find.byType(TextField)).controller?.text,
+        'draft me',
+        reason: 'cancel must preserve the draft so the next open restores it',
       );
     });
 
-    testWidgets('reopening with initialValue empty after send yields empty field',
+    // ---- SEND: buffer is cleared ----------------------------------------
+    testWidgets('send clears the draft — reopen yields empty field',
         (tester) async {
-      bool sendCalled = false;
+      var saved = '';
 
-      // First open: user types and sends.
       await tester.pumpWidget(
         _buildHarness(
-          initialValue: '',
-          onValueChanged: (_) {},
+          initialValue: saved,
+          onValueChanged: (v) => saved = v,
+          // Mirror host onSend: clear the draft. (No Navigator.pop here.)
           onSend: (_) async {
-            sendCalled = true;
+            saved = '';
           },
         ),
       );
@@ -204,30 +184,68 @@ void main() {
 
       await tester.enterText(find.byType(TextField), 'rm -rf /tmp/test');
       await tester.pump();
+      expect(saved, 'rm -rf /tmp/test');
 
       await tester.tap(find.widgetWithText(ElevatedButton, 'Execute'));
       await tester.pumpAndSettle();
+      expect(saved, '', reason: 'send must clear the host draft');
 
-      expect(sendCalled, isTrue);
-
-      // Tear down (simulate bottom sheet dismissal — State is destroyed).
+      // Tear down and reopen with the cleared draft.
       await tester.pumpWidget(const SizedBox.shrink());
       await tester.pumpAndSettle();
 
-      // Host has cleared _savedCommandInput = ''. Reopen with empty initialValue.
       await tester.pumpWidget(
         _buildHarness(
-          initialValue: '',
-          onValueChanged: (_) {},
+          initialValue: saved,
+          onValueChanged: (v) => saved = v,
           onSend: (_) async {},
         ),
       );
       await tester.pumpAndSettle();
 
       expect(
-        (tester.widget<TextField>(find.byType(TextField)).controller)?.text,
+        tester.widget<TextField>(find.byType(TextField)).controller?.text,
         '',
-        reason: 'text field must be empty on reopen after send + host reset',
+        reason: 'text field must be empty on reopen after send',
+      );
+    });
+
+    // ---- SEND latch: teardown re-notification must NOT resurrect draft ----
+    testWidgets(
+        'after send, a late controller notification does not resurrect the draft',
+        (tester) async {
+      var saved = '';
+
+      await tester.pumpWidget(
+        _buildHarness(
+          initialValue: saved,
+          onValueChanged: (v) => saved = v,
+          onSend: (_) async {
+            saved = '';
+          },
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(TextField), 'sent command');
+      await tester.pump();
+
+      await tester.tap(find.widgetWithText(ElevatedButton, 'Execute'));
+      await tester.pumpAndSettle();
+      expect(saved, '', reason: 'send cleared the draft');
+
+      // Simulate the teardown re-notification: the controller fires another
+      // change carrying the still-present sent text (as IME composing-confirm
+      // would on focus loss). The _sent latch must suppress onValueChanged so
+      // `saved` is NOT overwritten back to the sent command.
+      await tester.enterText(find.byType(TextField), 'sent command');
+      await tester.pump();
+
+      expect(
+        saved,
+        '',
+        reason: 'the _sent latch must ignore post-send notifications so the '
+            'cleared draft is not resurrected',
       );
     });
   });

--- a/test/widgets/input_dialog_clear_test.dart
+++ b/test/widgets/input_dialog_clear_test.dart
@@ -1,0 +1,110 @@
+// Tests that _savedCommandInput is cleared whenever the input dialog is
+// dismissed, regardless of whether the user sent text or cancelled.
+//
+// The fix adds `_savedCommandInput = ''` inside the `.then((_) { ... })`
+// callback of the showModalBottomSheet call in _showInputDialog(), so it
+// fires on every dismissal path (send, cancel, swipe-down, system back).
+//
+// Because _TerminalScreenState and _InputDialogContent are private classes,
+// full widget-pump integration tests would require a test-only seam.  These
+// unit tests instead verify the exact in-memory behaviour that _showInputDialog
+// relies on: a buffer variable is written by onValueChanged callbacks and is
+// reset to '' when the sheet future resolves.
+
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('input dialog buffer reset', () {
+    // Simulate the lifecycle of _savedCommandInput as used in
+    // _showInputDialog():
+    //
+    //   onValueChanged  -> updates buffer
+    //   .then((_) { … }) -> clears buffer unconditionally
+    //
+    // This mirrors what the fixed code does without needing access to the
+    // private state class.
+
+    test('buffer is empty after cancel (no send)', () async {
+      var savedCommandInput = '';
+
+      // Simulate typing into the dialog.
+      void onValueChanged(String value) {
+        savedCommandInput = value;
+      }
+
+      // Simulate the Future returned by showModalBottomSheet completing when
+      // the sheet is dismissed via cancel / swipe-down.
+      final completer = Completer<void>();
+      final sheetFuture = completer.future.then((_) {
+        // This is the fix: clear unconditionally on any dismissal.
+        savedCommandInput = '';
+      });
+
+      // User types something.
+      onValueChanged('hello world');
+      expect(savedCommandInput, 'hello world');
+
+      // Sheet is dismissed without sending (cancel / swipe-down).
+      completer.complete();
+      await sheetFuture;
+
+      expect(savedCommandInput, isEmpty,
+          reason: 'buffer must be empty after cancel so the next open starts '
+              'fresh');
+    });
+
+    test('buffer is empty after send', () async {
+      var savedCommandInput = '';
+
+      void onValueChanged(String value) {
+        savedCommandInput = value;
+      }
+
+      final completer = Completer<void>();
+      final sheetFuture = completer.future.then((_) {
+        savedCommandInput = '';
+      });
+
+      // User types and sends.
+      onValueChanged('ls -la');
+      expect(savedCommandInput, 'ls -la');
+
+      // onSend clears first (original behaviour kept for clarity), then
+      // Navigator.pop triggers sheet dismissal.
+      savedCommandInput = ''; // onSend path
+      completer.complete(); // sheet dismissed
+      await sheetFuture;
+
+      expect(savedCommandInput, isEmpty,
+          reason: 'buffer must be empty after send so the next open starts '
+              'fresh');
+    });
+
+    test('buffer is empty when dialog opens with empty initialValue', () {
+      // Asserts the precondition: after the fix, initialValue passed to
+      // _InputDialogContent on the *next* open will always be ''.
+      const initialValue = '';
+      expect(initialValue, isEmpty);
+    });
+
+    test('then callback runs even when onSend already cleared buffer', () async {
+      // Regression guard: double-clearing to '' is idempotent and must not
+      // cause any observable error.
+      var savedCommandInput = '';
+
+      final completer = Completer<void>();
+      final sheetFuture = completer.future.then((_) {
+        savedCommandInput = ''; // the fix
+      });
+
+      savedCommandInput = 'some input';
+      savedCommandInput = ''; // onSend cleared it first
+      completer.complete();
+      await sheetFuture;
+
+      expect(savedCommandInput, isEmpty);
+    });
+  });
+}

--- a/test/widgets/input_dialog_clear_test.dart
+++ b/test/widgets/input_dialog_clear_test.dart
@@ -142,8 +142,12 @@ void main() {
         (tester) async {
       // Round-trip test:
       //   1. Open dialog with some pre-saved text (initialValue: 'draft').
-      //   2. Simulate host clearing _savedCommandInput (initialValue: '').
-      //   3. Open dialog again — field must be empty.
+      //   2. Dismiss (simulate cancel — host resets _savedCommandInput to '').
+      //   3. Open dialog again with initialValue: '' — field must be empty.
+      //
+      // In production the bottom sheet is torn down and recreated, which gives
+      // _InputDialogContent a fresh State. We replicate that by pumping a
+      // blank widget between the two opens so Flutter disposes the old State.
 
       // First open: pre-populated.
       await tester.pumpWidget(
@@ -160,7 +164,11 @@ void main() {
         'draft',
       );
 
-      // Host resets _savedCommandInput (simulated by pumping with '').
+      // Tear down (simulate dialog dismiss — State is destroyed).
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pumpAndSettle();
+
+      // Host has reset _savedCommandInput = ''. Reopen with empty initialValue.
       await tester.pumpWidget(
         _buildHarness(
           initialValue: '',
@@ -202,7 +210,11 @@ void main() {
 
       expect(sendCalled, isTrue);
 
-      // Host clears _savedCommandInput then reopens dialog with ''.
+      // Tear down (simulate bottom sheet dismissal — State is destroyed).
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pumpAndSettle();
+
+      // Host has cleared _savedCommandInput = ''. Reopen with empty initialValue.
       await tester.pumpWidget(
         _buildHarness(
           initialValue: '',

--- a/test/widgets/input_dialog_clear_test.dart
+++ b/test/widgets/input_dialog_clear_test.dart
@@ -13,7 +13,7 @@
 // onValueChanged writes to (mirroring _showInputDialog) and that the send
 // callback clears (mirroring onSend's `_savedCommandInput = ''`). The dialog is
 // pumped in isolation through the @visibleForTesting seam
-// TerminalScreen.buildInputDialogContentForTesting(), avoiding the full
+// buildInputDialogContentForTesting(), avoiding the full
 // SSH/tmux provider stack.
 //
 // NOTE: tester.enterText() fires the controller listener synchronously and does
@@ -31,7 +31,7 @@ Widget _buildHarness({
 }) {
   return MaterialApp(
     home: Scaffold(
-      body: TerminalScreen.buildInputDialogContentForTesting(
+      body: buildInputDialogContentForTesting(
         initialValue: initialValue,
         onValueChanged: onValueChanged,
         onSend: onSend,

--- a/test/widgets/input_dialog_clear_test.dart
+++ b/test/widgets/input_dialog_clear_test.dart
@@ -1,110 +1,222 @@
-// Tests that _savedCommandInput is cleared whenever the input dialog is
-// dismissed, regardless of whether the user sent text or cancelled.
+// Widget tests verifying that the input dialog controller starts empty
+// whenever the dialog is opened after a previous session.
 //
-// The fix adds `_savedCommandInput = ''` inside the `.then((_) { ... })`
-// callback of the showModalBottomSheet call in _showInputDialog(), so it
-// fires on every dismissal path (send, cancel, swipe-down, system back).
+// Strategy: pump _InputDialogContent via the @visibleForTesting seam
+// TerminalScreen.buildInputDialogContentForTesting().  This avoids standing
+// up the full TerminalScreen with its SSH/tmux provider dependencies while
+// still exercising the real widget tree.
 //
-// Because _TerminalScreenState and _InputDialogContent are private classes,
-// full widget-pump integration tests would require a test-only seam.  These
-// unit tests instead verify the exact in-memory behaviour that _showInputDialog
-// relies on: a buffer variable is written by onValueChanged callbacks and is
-// reset to '' when the sheet future resolves.
+// The tests mirror the dismissal paths added by PR #50:
+//   - cancel (Navigator.pop without sending)
+//   - send  (onSend callback fires, then Navigator.pop)
+//
+// In both cases the host state resets _savedCommandInput to '' in the
+// .then((_) { if (mounted) _savedCommandInput = ''; }) callback, so the
+// *next* open receives initialValue: ''.  We verify that invariant by
+// reopening the dialog with initialValue: '' and asserting the TextField
+// starts empty.
 
-import 'dart:async';
-
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_muxpod/screens/terminal/terminal_screen.dart';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Pumps [_InputDialogContent] inside a minimal navigator scaffold so that
+/// Cancel's Navigator.pop(context) resolves correctly.
+///
+/// [initialValue] simulates _savedCommandInput at open time.
+/// [onValueChanged] / [onSend] are forwarded verbatim.
+Widget _buildHarness({
+  String initialValue = '',
+  required void Function(String) onValueChanged,
+  required Future<void> Function(String) onSend,
+}) {
+  return MaterialApp(
+    home: Scaffold(
+      body: TerminalScreen.buildInputDialogContentForTesting(
+        initialValue: initialValue,
+        onValueChanged: onValueChanged,
+        onSend: onSend,
+      ),
+    ),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
 
 void main() {
-  group('input dialog buffer reset', () {
-    // Simulate the lifecycle of _savedCommandInput as used in
-    // _showInputDialog():
-    //
-    //   onValueChanged  -> updates buffer
-    //   .then((_) { … }) -> clears buffer unconditionally
-    //
-    // This mirrors what the fixed code does without needing access to the
-    // private state class.
+  group('_InputDialogContent — controller starts empty on reopen', () {
+    testWidgets('text field is pre-populated with initialValue', (tester) async {
+      await tester.pumpWidget(
+        _buildHarness(
+          initialValue: 'hello world',
+          onValueChanged: (_) {},
+          onSend: (_) async {},
+        ),
+      );
+      await tester.pumpAndSettle();
 
-    test('buffer is empty after cancel (no send)', () async {
-      var savedCommandInput = '';
-
-      // Simulate typing into the dialog.
-      void onValueChanged(String value) {
-        savedCommandInput = value;
-      }
-
-      // Simulate the Future returned by showModalBottomSheet completing when
-      // the sheet is dismissed via cancel / swipe-down.
-      final completer = Completer<void>();
-      final sheetFuture = completer.future.then((_) {
-        // This is the fix: clear unconditionally on any dismissal.
-        savedCommandInput = '';
-      });
-
-      // User types something.
-      onValueChanged('hello world');
-      expect(savedCommandInput, 'hello world');
-
-      // Sheet is dismissed without sending (cancel / swipe-down).
-      completer.complete();
-      await sheetFuture;
-
-      expect(savedCommandInput, isEmpty,
-          reason: 'buffer must be empty after cancel so the next open starts '
-              'fresh');
+      final textField = find.byType(TextField);
+      expect(textField, findsOneWidget);
+      expect(
+        (tester.widget<TextField>(textField).controller)?.text,
+        'hello world',
+        reason: 'initialValue must be reflected in the text field on open',
+      );
     });
 
-    test('buffer is empty after send', () async {
-      var savedCommandInput = '';
+    testWidgets('text field is empty when initialValue is empty string',
+        (tester) async {
+      // Simulates reopening after the host has reset _savedCommandInput = ''.
+      await tester.pumpWidget(
+        _buildHarness(
+          initialValue: '',
+          onValueChanged: (_) {},
+          onSend: (_) async {},
+        ),
+      );
+      await tester.pumpAndSettle();
 
-      void onValueChanged(String value) {
-        savedCommandInput = value;
-      }
-
-      final completer = Completer<void>();
-      final sheetFuture = completer.future.then((_) {
-        savedCommandInput = '';
-      });
-
-      // User types and sends.
-      onValueChanged('ls -la');
-      expect(savedCommandInput, 'ls -la');
-
-      // onSend clears first (original behaviour kept for clarity), then
-      // Navigator.pop triggers sheet dismissal.
-      savedCommandInput = ''; // onSend path
-      completer.complete(); // sheet dismissed
-      await sheetFuture;
-
-      expect(savedCommandInput, isEmpty,
-          reason: 'buffer must be empty after send so the next open starts '
-              'fresh');
+      final textField = find.byType(TextField);
+      expect(textField, findsOneWidget);
+      expect(
+        (tester.widget<TextField>(textField).controller)?.text,
+        '',
+        reason: 'text field must start empty when initialValue is empty',
+      );
     });
 
-    test('buffer is empty when dialog opens with empty initialValue', () {
-      // Asserts the precondition: after the fix, initialValue passed to
-      // _InputDialogContent on the *next* open will always be ''.
-      const initialValue = '';
-      expect(initialValue, isEmpty);
+    testWidgets('onValueChanged fires as user types', (tester) async {
+      String captured = '';
+
+      await tester.pumpWidget(
+        _buildHarness(
+          initialValue: '',
+          onValueChanged: (v) => captured = v,
+          onSend: (_) async {},
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(TextField), 'ls -la');
+      await tester.pump();
+
+      expect(captured, 'ls -la',
+          reason: 'onValueChanged must track every keystroke so the host can '
+              'persist _savedCommandInput in real time');
     });
 
-    test('then callback runs even when onSend already cleared buffer', () async {
-      // Regression guard: double-clearing to '' is idempotent and must not
-      // cause any observable error.
-      var savedCommandInput = '';
+    testWidgets('onSend is called with the current text when Send is tapped',
+        (tester) async {
+      String? sentValue;
 
-      final completer = Completer<void>();
-      final sheetFuture = completer.future.then((_) {
-        savedCommandInput = ''; // the fix
-      });
+      await tester.pumpWidget(
+        _buildHarness(
+          initialValue: '',
+          onValueChanged: (_) {},
+          onSend: (v) async {
+            sentValue = v;
+          },
+        ),
+      );
+      await tester.pumpAndSettle();
 
-      savedCommandInput = 'some input';
-      savedCommandInput = ''; // onSend cleared it first
-      completer.complete();
-      await sheetFuture;
+      await tester.enterText(find.byType(TextField), 'echo hi');
+      await tester.pump();
 
-      expect(savedCommandInput, isEmpty);
+      // Tap the Execute button (ElevatedButton labelled 'Execute').
+      await tester.tap(find.widgetWithText(ElevatedButton, 'Execute'));
+      await tester.pumpAndSettle();
+
+      expect(sentValue, 'echo hi',
+          reason: 'onSend must receive the full text the user typed');
+    });
+
+    testWidgets(
+        'reopening with initialValue empty after cancel yields empty field',
+        (tester) async {
+      // Round-trip test:
+      //   1. Open dialog with some pre-saved text (initialValue: 'draft').
+      //   2. Simulate host clearing _savedCommandInput (initialValue: '').
+      //   3. Open dialog again — field must be empty.
+
+      // First open: pre-populated.
+      await tester.pumpWidget(
+        _buildHarness(
+          initialValue: 'draft',
+          onValueChanged: (_) {},
+          onSend: (_) async {},
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(
+        (tester.widget<TextField>(find.byType(TextField)).controller)?.text,
+        'draft',
+      );
+
+      // Host resets _savedCommandInput (simulated by pumping with '').
+      await tester.pumpWidget(
+        _buildHarness(
+          initialValue: '',
+          onValueChanged: (_) {},
+          onSend: (_) async {},
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(
+        (tester.widget<TextField>(find.byType(TextField)).controller)?.text,
+        '',
+        reason: 'after the host resets _savedCommandInput the next open must '
+            'show an empty field',
+      );
+    });
+
+    testWidgets('reopening with initialValue empty after send yields empty field',
+        (tester) async {
+      bool sendCalled = false;
+
+      // First open: user types and sends.
+      await tester.pumpWidget(
+        _buildHarness(
+          initialValue: '',
+          onValueChanged: (_) {},
+          onSend: (_) async {
+            sendCalled = true;
+          },
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(TextField), 'rm -rf /tmp/test');
+      await tester.pump();
+
+      await tester.tap(find.widgetWithText(ElevatedButton, 'Execute'));
+      await tester.pumpAndSettle();
+
+      expect(sendCalled, isTrue);
+
+      // Host clears _savedCommandInput then reopens dialog with ''.
+      await tester.pumpWidget(
+        _buildHarness(
+          initialValue: '',
+          onValueChanged: (_) {},
+          onSend: (_) async {},
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(
+        (tester.widget<TextField>(find.byType(TextField)).controller)?.text,
+        '',
+        reason: 'text field must be empty on reopen after send + host reset',
+      );
     });
   });
 }


### PR DESCRIPTION
## Summary

After a successful **send**, the command-input dialog occasionally reopened pre-filled with the **just-sent** command. It's a timing race on the send path; this PR fixes it with a `_sent` latch. Cancel / swipe-down / system back continue to **preserve the draft** (unchanged — that's the existing intended behavior).

## Root cause (send path)

On send, `onSend` clears `_savedCommandInput = ''` and then calls `Navigator.pop`. The pop unfocuses the field; if an IME composing region is open it is finalized on unfocus, `_controller` notifies its listeners, and `_onTextChanged` fires **after** the clear — writing the still-present `_controller.text` (the sent command) back into `_savedCommandInput`. The listener is only removed in `dispose()` (after the pop animation), so there's a window. It's intermittent because it depends on whether that notification lands in the unfocus→dispose window: reproduces reliably with a Japanese IME, rarely with plain ASCII.

## Fix

- Add a `_sent` latch in `_InputDialogContentState`, set the instant send starts (**before** the `await`, so a synchronous *or* asynchronous teardown notification is covered). `_onTextChanged` early-returns while `_sent` is true, so post-send notifications can't repopulate the buffer.
- On a failed send the latch resets to `false` (rethrown), so the draft is kept and tracking resumes.

```dart
bool _sent = false;

void _onTextChanged() {
  if (_sent) return;
  widget.onValueChanged(_controller.text);
}

Future<void> _handleSend() async {
  if (_isSending) return;
  setState(() => _isSending = true);
  try {
    _sent = true;
    await widget.onSend(_controller.text);
  } catch (_) {
    _sent = false;
    rethrow;
  } finally {
    if (mounted) setState(() => _isSending = false);
  }
}
```

## Relationship to #44

Complementary, and they fix different bugs. #44 gates the send *trigger* (Enter no longer sends while composing), which makes this bug *rarer* — at send→pop time there's usually no open composition left to finalize. But it doesn't remove the underlying race; the `_sent` latch closes it deterministically, regardless of IME timing. This branch has been **merged up to current `main`** (which includes #44), and the duplicate `buildInputDialogContentForTesting` test seam was reconciled down to the single top-level helper.

## Semantics

| Dismissal path | Draft |
|---|---|
| Send (Execute / Enter) | cleared |
| Cancel / swipe-down / system back | preserved |

## Tests

`test/widgets/input_dialog_clear_test.dart`, via the top-level `@visibleForTesting buildInputDialogContentForTesting` seam, modeling the host's `_savedCommandInput` with a local variable:

- pre-populated from `initialValue` / empty when `''`
- `onValueChanged` tracks each keystroke
- `onSend` receives the typed text on Execute
- **cancel → draft preserved** on reopen
- **send → empty field** on reopen
- **post-send late notification does not resurrect the draft** (exercises the `_sent` latch)

> `tester.enterText()` fires the listener synchronously, so these cover the latch *logic*, not the underlying async focus-loss → IME-confirm race.

## Verification

Verified locally on Flutter 3.38.6 / Dart 3.10.7:

- `flutter analyze` — no new issues on the changed files.
- `flutter test test/widgets/input_dialog_clear_test.dart` — **7/7 pass**.
- `flutter test test/widgets/input_dialog_test.dart` (#44) — **3/3 pass**.
- Full suite: **279 pass / 10 fail**. The 10 failures are all in `test/providers/terminal_display_provider_test.dart`, are pre-existing and unrelated to this change (this PR's diff touches only `terminal_screen.dart` and `input_dialog_clear_test.dart`), and are being addressed on a separate branch.