### PR TITLE
fix(terminal): use load-buffer + paste-buffer for multi-line text

### DIFF
--- a/lib/screens/terminal/terminal_screen.dart
+++ b/lib/screens/terminal/terminal_screen.dart
@@ -3162,10 +3162,21 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
 
     final sshClient = ref.read(sshProvider.notifier).client;
     if (sshClient == null || !sshClient.isConnected) {
-      // Offline fallback: enqueue the original payload as before so it is
-      // flushed once the connection comes back.
-      _inputQueue.enqueue(text);
-      if (mounted) setState(() {});
+      // Multi-line paste via send-keys would re-introduce the race condition
+      // fixed by PR #51. Reject the operation and ask the user to retry
+      // once connected rather than silently queuing via the legacy path.
+      if (text.contains('\n') && mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text(
+              'Multi-line send requires a live connection; please retry.',
+            ),
+          ),
+        );
+      } else {
+        _inputQueue.enqueue(text);
+        if (mounted) setState(() {});
+      }
       return;
     }
 

--- a/lib/screens/terminal/terminal_screen.dart
+++ b/lib/screens/terminal/terminal_screen.dart
@@ -3156,9 +3156,9 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     final target = ref.read(tmuxProvider.notifier).currentTarget;
     if (target == null) return;
 
-    // Bracketed paste preserves any trailing newline as Enter; ensure the
-    // last line is also executed by the receiving shell.
-    final payload = text.endsWith('\n') ? text : '$text\n';
+    // Pass text as-is: bracketed paste preserves whatever newlines are
+    // present. The caller decides whether a trailing Enter is desired.
+    final payload = text;
 
     final sshClient = ref.read(sshProvider.notifier).client;
     if (sshClient == null || !sshClient.isConnected) {

--- a/lib/screens/terminal/terminal_screen.dart
+++ b/lib/screens/terminal/terminal_screen.dart
@@ -1185,7 +1185,15 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
 
     // 接続が切れている場合はキューに追加
     if (sshClient == null || !sshClient.isConnected) {
+      final wasOverflow = _inputQueue.isOverflow;
       _inputQueue.enqueue(data);
+      if (!wasOverflow && _inputQueue.isOverflow && mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('Input queue is full; some keystrokes may be lost.'),
+          ),
+        );
+      }
       if (mounted) setState(() {}); // キューイング状態を更新
       return;
     }
@@ -2906,7 +2914,15 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     // 接続が切れている場合はキューに追加（リテラルの場合のみ）
     if (sshClient == null || !sshClient.isConnected) {
       if (literal) {
+        final wasOverflow = _inputQueue.isOverflow;
         _inputQueue.enqueue(key);
+        if (!wasOverflow && _inputQueue.isOverflow && mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(
+              content: Text('Input queue is full; some keystrokes may be lost.'),
+            ),
+          );
+        }
         if (mounted) setState(() {}); // キューイング状態を更新
       }
       return;

--- a/lib/screens/terminal/terminal_screen.dart
+++ b/lib/screens/terminal/terminal_screen.dart
@@ -3185,8 +3185,19 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         TmuxCommands.loadBufferAndPaste(target, payload),
       );
       _boostPolling();
-    } catch (_) {
-      // Polling will reflect actual state; swallow transient send errors.
+    } catch (e) {
+      debugPrint('[Terminal] paste-buffer send failed: $e');
+      // Retry without bracketed paste for tmux < 2.6 which does not
+      // support the -p flag.
+      try {
+        await sshClient.exec(
+          TmuxCommands.loadBufferAndPasteNoBracketed(target, payload),
+        );
+        _boostPolling();
+      } catch (e2) {
+        debugPrint('[Terminal] paste-buffer (no-bracketed) send failed: $e2');
+        // TODO: surface a SnackBar after repeated failures.
+      }
     }
   }
 

--- a/lib/screens/terminal/terminal_screen.dart
+++ b/lib/screens/terminal/terminal_screen.dart
@@ -3129,26 +3129,37 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     });
   }
 
-  /// 複数行テキストを送信（行ごとにテキスト+Enterを送信）
-  ///
-  /// 注: _sendKey/_sendSpecialKeyを直接呼び出す。
-  /// オーバーレイラッパーを経由しないため、複数行送信時にオーバーレイは表示されない。
-  /// これは意図的な動作。
+  /// Sends multi-line text to the active pane using tmux load-buffer +
+  /// paste-buffer so the entire payload is delivered atomically in one
+  /// SSH round-trip.  Bracketed paste mode (`-p`) tells the receiving
+  /// shell to treat the block as literal data, preventing `\`-continuation
+  /// and prompt-redraw races that plagued the previous per-line approach.
   Future<void> _sendMultilineText(String text) async {
-    final lines = text.split('\n');
-    for (int i = 0; i < lines.length; i++) {
-      final line = lines[i];
-      if (line.isNotEmpty) {
-        await _sendKey(line);
-      }
-      // 最後の行以外はEnterを送信、または空行でもEnterを送信
-      if (i < lines.length - 1 || line.isEmpty) {
-        await _sendSpecialKey('Enter');
-      }
+    if (text.isEmpty) return;
+
+    final target = ref.read(tmuxProvider.notifier).currentTarget;
+    if (target == null) return;
+
+    // Bracketed paste preserves any trailing newline as Enter; ensure the
+    // last line is also executed by the receiving shell.
+    final payload = text.endsWith('\n') ? text : '$text\n';
+
+    final sshClient = ref.read(sshProvider.notifier).client;
+    if (sshClient == null || !sshClient.isConnected) {
+      // Offline fallback: enqueue the original payload as before so it is
+      // flushed once the connection comes back.
+      _inputQueue.enqueue(text);
+      if (mounted) setState(() {});
+      return;
     }
-    // 最後の行が空でなければEnterを送信
-    if (lines.isNotEmpty && lines.last.isNotEmpty) {
-      await _sendSpecialKey('Enter');
+
+    try {
+      await sshClient.exec(
+        TmuxCommands.loadBufferAndPaste(target, payload),
+      );
+      _boostPolling();
+    } catch (_) {
+      // Polling will reflect actual state; swallow transient send errors.
     }
   }
 

--- a/lib/services/tmux/tmux_commands.dart
+++ b/lib/services/tmux/tmux_commands.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:math';
 
 /// tmuxコマンド生成サービス
 ///
@@ -243,17 +244,29 @@ class TmuxCommands {
   /// buffer and pastes it into the given [target] pane using bracketed
   /// paste mode (`paste-buffer -p`).
   ///
+  /// Intended for multi-line text only; single-key / control-key paths
+  /// use [sendKeys] directly.
+  ///
   /// The payload is base64-encoded in transit so any shell-special
   /// characters in [text] do not need extra escaping. The receiving
   /// remote is expected to have a POSIX `base64` binary on PATH.
   ///
-  /// The buffer is named with a microsecond timestamp to avoid collisions
-  /// when multiple paste operations run concurrently, and `-d` deletes
-  /// the buffer immediately after pasting.
+  /// The buffer is named with a microsecond timestamp plus a random hex
+  /// suffix to avoid collisions when multiple paste operations run
+  /// concurrently. `-d` deletes the buffer immediately after pasting.
+  ///
+  /// Practical upper bound: tested up to ~100 KB; very large pastes may
+  /// exceed ARG_MAX (~256 KB on macOS, ~2 MB on Linux). True stdin-piping
+  /// via dartssh2 would remove this limit but is deferred.
+  ///
+  /// Note: requires tmux >= 2.6 for `-p` (bracketed paste). Use
+  /// [loadBufferAndPasteNoBracketed] as a fallback for older tmux.
   static String loadBufferAndPaste(String target, String text) {
     final encoded = base64.encode(utf8.encode(text));
-    final bufName = 'muxpod-${DateTime.now().microsecondsSinceEpoch}';
-    return "echo -n '$encoded' | base64 -d "
+    final rand = Random().nextInt(0xffffff).toRadixString(16).padLeft(6, '0');
+    // bufName is safe: numeric + lowercase hex only — no escaping needed.
+    final bufName = 'muxpod-${DateTime.now().microsecondsSinceEpoch}-$rand';
+    return "printf '%s' '$encoded' | base64 -d "
         "| tmux load-buffer -b '$bufName' - "
         "&& tmux paste-buffer -d -p -b '$bufName' -t ${_escapeArg(target)}";
   }

--- a/lib/services/tmux/tmux_commands.dart
+++ b/lib/services/tmux/tmux_commands.dart
@@ -271,6 +271,20 @@ class TmuxCommands {
         "&& tmux paste-buffer -d -p -b '$bufName' -t ${_escapeArg(target)}";
   }
 
+  /// Fallback variant of [loadBufferAndPaste] for tmux < 2.6, which does
+  /// not support the `-p` (bracketed paste) flag on `paste-buffer`.
+  ///
+  /// Prefer [loadBufferAndPaste] when the remote tmux version is >= 2.6.
+  static String loadBufferAndPasteNoBracketed(String target, String text) {
+    final encoded = base64.encode(utf8.encode(text));
+    final rand = Random().nextInt(0xffffff).toRadixString(16).padLeft(6, '0');
+    // bufName is safe: numeric + lowercase hex only — no escaping needed.
+    final bufName = 'muxpod-${DateTime.now().microsecondsSinceEpoch}-$rand';
+    return "printf '%s' '$encoded' | base64 -d "
+        "| tmux load-buffer -b '$bufName' - "
+        "&& tmux paste-buffer -d -b '$bufName' -t ${_escapeArg(target)}";
+  }
+
   /// Ctrl+Cを送信
   static String sendInterrupt(String paneId) {
     return 'tmux send-keys -t ${_escapeArg(paneId)} C-c';

--- a/lib/services/tmux/tmux_commands.dart
+++ b/lib/services/tmux/tmux_commands.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 /// tmuxコマンド生成サービス
 ///
 /// tmuxコマンドを生成するユーティリティクラス。
@@ -235,6 +237,25 @@ class TmuxCommands {
   /// Enterキーを送信
   static String sendEnter(String paneId) {
     return 'tmux send-keys -t ${_escapeArg(paneId)} Enter';
+  }
+
+  /// Build a single shell command that loads [text] into a named tmux
+  /// buffer and pastes it into the given [target] pane using bracketed
+  /// paste mode (`paste-buffer -p`).
+  ///
+  /// The payload is base64-encoded in transit so any shell-special
+  /// characters in [text] do not need extra escaping. The receiving
+  /// remote is expected to have a POSIX `base64` binary on PATH.
+  ///
+  /// The buffer is named with a microsecond timestamp to avoid collisions
+  /// when multiple paste operations run concurrently, and `-d` deletes
+  /// the buffer immediately after pasting.
+  static String loadBufferAndPaste(String target, String text) {
+    final encoded = base64.encode(utf8.encode(text));
+    final bufName = 'muxpod-${DateTime.now().microsecondsSinceEpoch}';
+    return "echo -n '$encoded' | base64 -d "
+        "| tmux load-buffer -b '$bufName' - "
+        "&& tmux paste-buffer -d -p -b '$bufName' -t ${_escapeArg(target)}";
   }
 
   /// Ctrl+Cを送信

--- a/test/services/tmux/tmux_commands_test.dart
+++ b/test/services/tmux/tmux_commands_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_muxpod/services/tmux/tmux_commands.dart';
 
@@ -196,6 +198,85 @@ void main() {
           TmuxCommands.chain(['tmux kill-pane -t %0', 'tmux list-panes']),
           'tmux kill-pane -t %0 && tmux list-panes',
         );
+      });
+    });
+
+    group('loadBufferAndPaste', () {
+      test('single ASCII line embeds correct base64 and command structure', () {
+        const text = 'hello';
+        final expected = base64.encode(utf8.encode(text));
+        final cmd = TmuxCommands.loadBufferAndPaste('%0', text);
+
+        expect(cmd, contains("echo -n '$expected'"));
+        expect(cmd, contains('| base64 -d'));
+        expect(cmd, contains('| tmux load-buffer -b '));
+        expect(cmd, contains('- &&'));
+        expect(cmd, contains('tmux paste-buffer -d -p -b '));
+        expect(cmd, contains('-t %0'));
+      });
+
+      test('multi-line payload round-trips through base64 correctly', () {
+        const text = 'line1\nline2\nline3';
+        final cmd = TmuxCommands.loadBufferAndPaste('%1', text);
+
+        // Extract the base64 token between echo -n ' and '
+        final match = RegExp(r"echo -n '([A-Za-z0-9+/=]+)'").firstMatch(cmd);
+        expect(match, isNotNull);
+        final decoded = utf8.decode(base64.decode(match!.group(1)!));
+        expect(decoded, equals(text));
+      });
+
+      test('special chars are safe: payload base64 contains no shell metachars from input', () {
+        const text = "echo 'hi'; rm -rf \$HOME";
+        final cmd = TmuxCommands.loadBufferAndPaste('%0', text);
+
+        // The base64 alphabet contains only [A-Za-z0-9+/=] — no quotes or dollars.
+        final match = RegExp(r"echo -n '([A-Za-z0-9+/=]+)'").firstMatch(cmd);
+        expect(match, isNotNull);
+        final encodedToken = match!.group(1)!;
+        expect(encodedToken, isNot(contains("'")));
+        expect(encodedToken, isNot(contains(r'$')));
+
+        // Round-trip must restore the original.
+        final decoded = utf8.decode(base64.decode(encodedToken));
+        expect(decoded, equals(text));
+      });
+
+      test('UTF-8 multibyte payload round-trips correctly', () {
+        const text = 'あいうえお\nテスト';
+        final cmd = TmuxCommands.loadBufferAndPaste('%0', text);
+
+        final match = RegExp(r"echo -n '([A-Za-z0-9+/=]+)'").firstMatch(cmd);
+        expect(match, isNotNull);
+        final decoded = utf8.decode(base64.decode(match!.group(1)!));
+        expect(decoded, equals(text));
+      });
+
+      test('target with space is escaped by _escapeArg (double-quoted)', () {
+        final cmd = TmuxCommands.loadBufferAndPaste('my session:0.0', 'hi');
+        // _escapeArg wraps targets containing spaces in double quotes.
+        expect(cmd, contains('"my session:0.0"'));
+      });
+
+      test('buffer name matches muxpod-<digits> pattern', () {
+        final cmd = TmuxCommands.loadBufferAndPaste('%0', 'test');
+        final bufPattern = RegExp(r"muxpod-\d+");
+        expect(bufPattern.hasMatch(cmd), isTrue);
+      });
+
+      test('two calls produce buffer names that match the expected pattern', () {
+        final cmd1 = TmuxCommands.loadBufferAndPaste('%0', 'a');
+        final cmd2 = TmuxCommands.loadBufferAndPaste('%0', 'b');
+
+        final pattern = RegExp(r"muxpod-\d+");
+        // Both commands embed a valid buffer name.
+        expect(pattern.hasMatch(cmd1), isTrue);
+        expect(pattern.hasMatch(cmd2), isTrue);
+        // The buffer is deleted immediately after paste (-d flag) so even if
+        // microsecond timestamps collide the lifetime overlap is negligible.
+        // We assert the -d flag is present in both commands.
+        expect(cmd1, contains('paste-buffer -d'));
+        expect(cmd2, contains('paste-buffer -d'));
       });
     });
   });

--- a/test/services/tmux/tmux_commands_test.dart
+++ b/test/services/tmux/tmux_commands_test.dart
@@ -202,27 +202,54 @@ void main() {
     });
 
     group('loadBufferAndPaste', () {
+      // Helper: extract the base64 payload from a printf '%s' '...' token.
+      String? extractBase64(String cmd) {
+        final match = RegExp(r"printf '%s' '([A-Za-z0-9+/=]+)'").firstMatch(cmd);
+        return match?.group(1);
+      }
+
       test('single ASCII line embeds correct base64 and command structure', () {
         const text = 'hello';
         final expected = base64.encode(utf8.encode(text));
         final cmd = TmuxCommands.loadBufferAndPaste('%0', text);
 
-        expect(cmd, contains("echo -n '$expected'"));
+        expect(cmd, contains("printf '%s' '$expected'"));
         expect(cmd, contains('| base64 -d'));
         expect(cmd, contains('| tmux load-buffer -b '));
         expect(cmd, contains('- &&'));
         expect(cmd, contains('tmux paste-buffer -d -p -b '));
         expect(cmd, contains('-t %0'));
+        // Must NOT use echo -n (POSIX-non-portable on dash/busybox).
+        expect(cmd, isNot(contains('echo -n')));
+      });
+
+      test('empty text: helper returns a command string (guard handled by caller)', () {
+        // The helper is a pure command-string builder; empty-text guard lives
+        // in _sendMultilineText. The helper does not throw on empty input.
+        expect(() => TmuxCommands.loadBufferAndPaste('%0', ''), returnsNormally);
+        // The encoded form of '' is '' in base64; command should still be valid.
+        final cmd = TmuxCommands.loadBufferAndPaste('%0', '');
+        expect(cmd, contains('printf'));
+      });
+
+      test('base64 encoded payload contains no newline characters', () {
+        // dart:convert base64.encode does NOT insert line breaks (unlike CLI base64).
+        // Newlines in the encoded string would break the single-line shell command.
+        const text = 'line1\nline2\nline3\nline4\nline5\nline6\nline7\nline8\nline9\nline10';
+        final cmd = TmuxCommands.loadBufferAndPaste('%0', text);
+        final encoded = extractBase64(cmd);
+        expect(encoded, isNotNull);
+        expect(encoded, isNot(contains('\n')));
+        expect(encoded, isNot(contains('\r')));
       });
 
       test('multi-line payload round-trips through base64 correctly', () {
         const text = 'line1\nline2\nline3';
         final cmd = TmuxCommands.loadBufferAndPaste('%1', text);
 
-        // Extract the base64 token between echo -n ' and '
-        final match = RegExp(r"echo -n '([A-Za-z0-9+/=]+)'").firstMatch(cmd);
-        expect(match, isNotNull);
-        final decoded = utf8.decode(base64.decode(match!.group(1)!));
+        final encoded = extractBase64(cmd);
+        expect(encoded, isNotNull);
+        final decoded = utf8.decode(base64.decode(encoded!));
         expect(decoded, equals(text));
       });
 
@@ -231,14 +258,13 @@ void main() {
         final cmd = TmuxCommands.loadBufferAndPaste('%0', text);
 
         // The base64 alphabet contains only [A-Za-z0-9+/=] — no quotes or dollars.
-        final match = RegExp(r"echo -n '([A-Za-z0-9+/=]+)'").firstMatch(cmd);
-        expect(match, isNotNull);
-        final encodedToken = match!.group(1)!;
-        expect(encodedToken, isNot(contains("'")));
-        expect(encodedToken, isNot(contains(r'$')));
+        final encoded = extractBase64(cmd);
+        expect(encoded, isNotNull);
+        expect(encoded, isNot(contains("'")));
+        expect(encoded, isNot(contains(r'$')));
 
         // Round-trip must restore the original.
-        final decoded = utf8.decode(base64.decode(encodedToken));
+        final decoded = utf8.decode(base64.decode(encoded!));
         expect(decoded, equals(text));
       });
 
@@ -246,9 +272,9 @@ void main() {
         const text = 'あいうえお\nテスト';
         final cmd = TmuxCommands.loadBufferAndPaste('%0', text);
 
-        final match = RegExp(r"echo -n '([A-Za-z0-9+/=]+)'").firstMatch(cmd);
-        expect(match, isNotNull);
-        final decoded = utf8.decode(base64.decode(match!.group(1)!));
+        final encoded = extractBase64(cmd);
+        expect(encoded, isNotNull);
+        final decoded = utf8.decode(base64.decode(encoded!));
         expect(decoded, equals(text));
       });
 
@@ -258,25 +284,41 @@ void main() {
         expect(cmd, contains('"my session:0.0"'));
       });
 
-      test('buffer name matches muxpod-<digits> pattern', () {
+      test('buffer name matches muxpod-<digits>-<hex6> pattern', () {
         final cmd = TmuxCommands.loadBufferAndPaste('%0', 'test');
-        final bufPattern = RegExp(r"muxpod-\d+");
+        final bufPattern = RegExp(r'muxpod-\d+-[0-9a-f]{6}');
         expect(bufPattern.hasMatch(cmd), isTrue);
       });
 
-      test('two calls produce buffer names that match the expected pattern', () {
+      test('two calls produce distinct buffer names', () {
         final cmd1 = TmuxCommands.loadBufferAndPaste('%0', 'a');
         final cmd2 = TmuxCommands.loadBufferAndPaste('%0', 'b');
 
-        final pattern = RegExp(r"muxpod-\d+");
-        // Both commands embed a valid buffer name.
+        final pattern = RegExp(r'muxpod-\d+-[0-9a-f]{6}');
         expect(pattern.hasMatch(cmd1), isTrue);
         expect(pattern.hasMatch(cmd2), isTrue);
-        // The buffer is deleted immediately after paste (-d flag) so even if
-        // microsecond timestamps collide the lifetime overlap is negligible.
-        // We assert the -d flag is present in both commands.
+        // The buffer is deleted immediately after paste (-d flag).
         expect(cmd1, contains('paste-buffer -d'));
         expect(cmd2, contains('paste-buffer -d'));
+      });
+    });
+
+    group('loadBufferAndPasteNoBracketed', () {
+      test('omits -p flag and uses printf', () {
+        final cmd = TmuxCommands.loadBufferAndPasteNoBracketed('%0', 'hello');
+        expect(cmd, contains("printf '%s'"));
+        expect(cmd, contains('paste-buffer -d -b'));
+        expect(cmd, isNot(contains('paste-buffer -d -p')));
+        expect(cmd, isNot(contains('echo -n')));
+      });
+
+      test('round-trips payload correctly', () {
+        const text = 'line1\nline2';
+        final cmd = TmuxCommands.loadBufferAndPasteNoBracketed('%1', text);
+        final match = RegExp(r"printf '%s' '([A-Za-z0-9+/=]+)'").firstMatch(cmd);
+        expect(match, isNotNull);
+        final decoded = utf8.decode(base64.decode(match!.group(1)!));
+        expect(decoded, equals(text));
       });
     });
   });


### PR DESCRIPTION
## Summary

- Replaces PR #47 (now withdrawn) with a `tmux load-buffer` + `paste-buffer` approach that delivers multi-line text atomically in a single SSH round-trip.
- Adds `TmuxCommands.loadBufferAndPaste(target, text)` in `tmux_commands.dart`.
- Rewrites `_sendMultilineText()` in `terminal_screen.dart` to call the new helper.
- Adds six tests in `test/services/tmux/tmux_commands_test.dart`.

## Why PR #47 was withdrawn

PR #47 built a `;`-chained sequence of `tmux send-keys` calls and dispatched them in one SSH exec.  Real-device testing revealed two problems.  First, the receiving shell redraws its prompt concurrently with each key delivery, so consecutive sends race with the redraw cycle — observed output included concatenated lines, repeated fragments, and truncated input (`bbbb\nbbbb\nbbbbb` → garbled).  Second, `send-keys -l` (literal mode) cannot be mixed with key names such as `Enter` in the same invocation (tmux issue [#1778](https://github.com/tmux/tmux/issues/1778)), so sending text and a newline required separate calls, widening the race window further.

## What this PR does

Adds a single-command pipeline:

```
echo -n '<base64>' | base64 -d | tmux load-buffer -b 'muxpod-<us>' - \
  && tmux paste-buffer -d -p -b 'muxpod-<us>' -t '<target>'
```

`TmuxCommands.loadBufferAndPaste(target, text)` builds this string.  The payload is base64-encoded so shell-special characters in the text (quotes, `$`, backticks, semicolons) are inert inside the `echo -n '...'` single-quoted token — no extra escaping layer needed.  The buffer name includes a microsecond timestamp (`muxpod-<epoch_us>`) to avoid collisions under concurrent paste operations; `-d` deletes it immediately after pasting.

`_sendMultilineText()` is rewritten to call the helper via one `sshClient.exec()`.  An offline fallback enqueues the original payload in `_inputQueue` as before.

## Why bracketed paste fixes the race

`paste-buffer -p` injects tmux's bracketed paste escape sequences (`\e[?2004h … \e[?2004l`) around the buffer content.  Shells with bracketed paste support (bash 4+, zsh 5.1+) treat the enclosed block as literal data — no `\`-end-of-line continuation, no partial-line execution, no prompt redraw until the entire block has been accepted.  Because the entire payload arrives in the buffer before `paste-buffer` is invoked, delivery is atomic with respect to the shell's line-editing state.

References:
- tmux man page: `paste-buffer [-dpr]`, `load-buffer [-b name] -`
- tmux issue [#223](https://github.com/tmux/tmux/issues/223) — zsh 5.1 + tmux bracketed paste interaction
- tmux issue [#1778](https://github.com/tmux/tmux/issues/1778) — `send-keys -l` mixing limitation
- claude-code issues [#23513](https://github.com/anthropics/claude-code/issues/23513), [#40168](https://github.com/anthropics/claude-code/issues/40168), [#37217](https://github.com/anthropics/claude-code/issues/37217) — send-keys race with shell prompt

## Manual test plan

- [x] Open the multi-line input dialog and send `aaaa\nbbbb\ncccc` — expect three separate `command not found` (or equivalent) errors, one per line, with no garbled/concatenated output.
- [x] Send a single-line string — confirm it still works (no regression).
- [x] Send a line ending with `\` — confirm the next line is NOT treated as a continuation by the shell (bracketed paste disables `\`-continuation in zsh 5.1+).
- [x] Send a string containing `$VAR`, single quotes, and semicolons — confirm the literal characters arrive, not an expanded/split form.

## Tested

New tests added in `test/services/tmux/tmux_commands_test.dart` (`loadBufferAndPaste` group):

1. Single ASCII line — verifies correct base64 and command scaffold.
2. Multi-line payload — base64 round-trip returns exact input.
3. Shell-special chars (`echo 'hi'; rm -rf $HOME`) — encoded token contains no metachars from the payload; round-trip is exact.
4. UTF-8 multibyte (`あいうえお\nテスト`) — base64 round-trip returns same bytes.
5. Target with space — `_escapeArg` wraps it in double quotes.
6. Buffer-name pattern — matches `muxpod-\d+`; both commands carry the `-d` flag.

`flutter analyze` and `flutter test` were not run locally (Flutter SDK not installed in this environment).