### PR TITLE
fix(test): repair settings screen tests on main

### DIFF
--- a/test/screens/settings_screen_test.dart
+++ b/test/screens/settings_screen_test.dart
@@ -9,6 +9,12 @@ Widget _buildApp() {
   );
 }
 
+/// Scrolls until [finder] is visible in the first Scrollable of the tree.
+Future<void> scrollUntilFound(WidgetTester tester, Finder finder) async {
+  final scrollable = find.byType(Scrollable).first;
+  await tester.scrollUntilVisible(finder, 200, scrollable: scrollable);
+}
+
 void main() {
   group('SettingsScreen', () {
     testWidgets('displays Settings title', (tester) async {
@@ -30,8 +36,7 @@ void main() {
       await tester.pumpAndSettle();
 
       // Haptic Feedback is in the Behavior section - may need scroll
-      final scrollable = find.byType(Scrollable).first;
-      await tester.scrollUntilVisible(find.text('Haptic Feedback'), 200, scrollable: scrollable);
+      await scrollUntilFound(tester, find.text('Haptic Feedback'));
       expect(find.text('Haptic Feedback'), findsOneWidget);
     });
 
@@ -39,23 +44,22 @@ void main() {
       await tester.pumpWidget(_buildApp());
       await tester.pumpAndSettle();
 
-      final finder = find.text('Keep Screen On');
-      await tester.ensureVisible(finder);
-      expect(finder, findsOneWidget);
+      await scrollUntilFound(tester, find.text('Keep Screen On'));
+      expect(find.text('Keep Screen On'), findsOneWidget);
     });
 
     testWidgets('behavior toggles are interactive', (tester) async {
       await tester.pumpWidget(_buildApp());
       await tester.pumpAndSettle();
 
-      await tester.ensureVisible(find.text('Haptic Feedback'));
+      await scrollUntilFound(tester, find.text('Haptic Feedback'));
       final hapticSwitch = find.ancestor(
         of: find.text('Haptic Feedback'),
         matching: find.byType(SwitchListTile),
       );
       expect(hapticSwitch, findsOneWidget);
 
-      await tester.ensureVisible(find.text('Keep Screen On'));
+      await scrollUntilFound(tester, find.text('Keep Screen On'));
       final keepScreenSwitch = find.ancestor(
         of: find.text('Keep Screen On'),
         matching: find.byType(SwitchListTile),
@@ -67,7 +71,7 @@ void main() {
       await tester.pumpWidget(_buildApp());
       await tester.pumpAndSettle();
 
-      await tester.ensureVisible(find.text('Source Code'));
+      await scrollUntilFound(tester, find.text('Source Code'));
       expect(find.text('Source Code'), findsOneWidget);
       expect(find.text('github.com/moezakura/mux-pod'), findsOneWidget);
     });
@@ -76,24 +80,24 @@ void main() {
       await tester.pumpWidget(_buildApp());
       await tester.pumpAndSettle();
 
-      // Image Transfer section header
-      await tester.ensureVisible(find.text('Image Transfer'));
-      expect(find.text('Image Transfer'), findsOneWidget);
+      // Image Transfer section header (rendered in uppercase by _SectionHeader)
+      await scrollUntilFound(tester, find.text('IMAGE TRANSFER'));
+      expect(find.text('IMAGE TRANSFER'), findsOneWidget);
 
       // Individual settings
-      await tester.ensureVisible(find.text('Remote Path'));
+      await scrollUntilFound(tester, find.text('Remote Path'));
       expect(find.text('Remote Path'), findsOneWidget);
 
-      await tester.ensureVisible(find.text('Output Format'));
+      await scrollUntilFound(tester, find.text('Output Format'));
       expect(find.text('Output Format'), findsOneWidget);
 
-      await tester.ensureVisible(find.text('Path Format'));
+      await scrollUntilFound(tester, find.text('Path Format'));
       expect(find.text('Path Format'), findsOneWidget);
 
-      await tester.ensureVisible(find.text('Auto Enter'));
+      await scrollUntilFound(tester, find.text('Auto Enter'));
       expect(find.text('Auto Enter'), findsOneWidget);
 
-      await tester.ensureVisible(find.text('Bracketed Paste'));
+      await scrollUntilFound(tester, find.text('Bracketed Paste'));
       expect(find.text('Bracketed Paste'), findsOneWidget);
     });
   });


### PR DESCRIPTION
## Failing tests

- `SettingsScreen behavior toggles are interactive`
- `SettingsScreen displays Image Transfer settings`
- `SettingsScreen displays Keep Screen On toggle`
- `SettingsScreen displays Source Code link`

## Root cause — UI drift

**1. `ensureVisible()` cannot scroll SliverList items into existence**

The settings screen uses a `CustomScrollView` with a `SliverList`. Items below the fold are not yet laid out in the widget tree. `ensureVisible()` calls `element` on the finder before scrolling, which throws `Bad state: No element` because the widget does not exist until after scrolling.

The passing test (`displays Haptic Feedback toggle`) already used `scrollUntilVisible()`, which polls while dragging — the correct approach for sliver-backed lists.

**2. Section header text is uppercased at render time**

`_SectionHeader` applies `title.toUpperCase()` in its `build()` method. The test searched for `'Image Transfer'` but the actual `Text` widget contains `'IMAGE TRANSFER'`, so `scrollUntilVisible` exhausted its drag budget without finding the node.

## Fix

- Replaced all `tester.ensureVisible(find.text(...))` calls with a shared `scrollUntilFound()` helper that wraps `tester.scrollUntilVisible()`.
- Updated the section-header finder to `find.text('IMAGE TRANSFER')` to match the rendered text.
- No production code was modified.

## Local test result

```
00:00 +1: SettingsScreen displays Settings title
00:00 +2: SettingsScreen displays Adjust Mode setting
00:00 +3: SettingsScreen displays Haptic Feedback toggle
00:01 +4: SettingsScreen displays Keep Screen On toggle
00:01 +5: SettingsScreen behavior toggles are interactive
00:01 +6: SettingsScreen displays Source Code link
00:01 +7: SettingsScreen displays Image Transfer settings
00:01 +7: All tests passed!
```