### PR TITLE
fix(test): repair RSA key generation tests on main

### DIFF
--- a/test/services/keychain/ssh_key_service_test.dart
+++ b/test/services/keychain/ssh_key_service_test.dart
@@ -48,19 +48,27 @@ void main() {
       expect(keyPair.publicKeyString, startsWith('ssh-rsa '));
     });
 
-    test('generates valid RSA-3072 key pair', () async {
-      final keyPair = await service.generateRsa(bits: 3072);
+    test(
+      'generates valid RSA-3072 key pair',
+      () async {
+        final keyPair = await service.generateRsa(bits: 3072);
 
-      expect(keyPair.type, equals('rsa-3072'));
-      expect(keyPair.fingerprint, startsWith('SHA256:'));
-    });
+        expect(keyPair.type, equals('rsa-3072'));
+        expect(keyPair.fingerprint, startsWith('SHA256:'));
+      },
+      timeout: const Timeout(Duration(minutes: 2)),
+    );
 
-    test('generates valid RSA-4096 key pair', () async {
-      final keyPair = await service.generateRsa(bits: 4096);
+    test(
+      'generates valid RSA-4096 key pair',
+      () async {
+        final keyPair = await service.generateRsa(bits: 4096);
 
-      expect(keyPair.type, equals('rsa-4096'));
-      expect(keyPair.fingerprint, startsWith('SHA256:'));
-    });
+        expect(keyPair.type, equals('rsa-4096'));
+        expect(keyPair.fingerprint, startsWith('SHA256:'));
+      },
+      timeout: const Timeout(Duration(minutes: 2)),
+    );
 
     test('generates RSA key pair with comment', () async {
       const comment = 'test@example.com';


### PR DESCRIPTION
## Summary

- RSA-3072 and RSA-4096 key generation tests in `T014 RSA Key Generation` failed on CI due to the default 30-second `flutter test` timeout being exceeded on slow runners.
- Pure-Dart RSA key generation via `pointycastle` is CPU-bound; larger key sizes can take 10-60+ seconds on resource-constrained CI hosts.
- Added `timeout: const Timeout(Duration(minutes: 2))` to both slow tests so they have adequate time to complete without being a false negative.

## Root cause

`pointycastle`'s `RSAKeyGenerator` runs entirely in the Dart VM (no native code) and iterates until it finds prime numbers of the required bit length. On a 2-core GitHub Actions runner (ubuntu-latest), 4096-bit generation can take 30-90 seconds — enough to trip the default timeout silently.

## What was skipped

Nothing skipped. RSA-3072 and RSA-4096 both run and pass; they just needed more time headroom. No production code was changed.

## Test plan

- [x] `flutter test test/services/keychain/ssh_key_service_test.dart` passes locally (24/24 tests, ~8s total)
- [x] RSA-3072 and RSA-4096 tests complete in ~3s on a developer machine; the 2-minute cap is conservative enough for CI