### PR TITLE
fix(test): repair terminal_display_provider tests on main

### DIFF
--- a/lib/providers/settings_provider.dart
+++ b/lib/providers/settings_provider.dart
@@ -195,6 +195,8 @@ class SettingsNotifier extends Notifier<AppSettings> {
     final prefs = await SharedPreferences.getInstance();
     await SettingsMigrationRunner.run(prefs);
 
+    if (!ref.mounted) return;
+
     state = AppSettings(
       darkMode: prefs.getBool(_darkModeKey) ?? true,
       fontSize: prefs.getDouble(_fontSizeKey) ?? 14.0,

--- a/test/providers/terminal_display_provider_test.dart
+++ b/test/providers/terminal_display_provider_test.dart
@@ -1,12 +1,43 @@
+import 'dart:async';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:flutter_muxpod/providers/terminal_display_provider.dart';
 import 'package:flutter_muxpod/providers/settings_provider.dart';
+import 'package:flutter_muxpod/services/terminal/font_calculator.dart';
 import 'package:flutter_muxpod/services/tmux/tmux_parser.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
+
+  // Warm the FontCalculator char-width cache once before all tests run.
+  //
+  // The first call to FontCalculator.measureCharWidthRatio triggers a
+  // google_fonts background HTTP task (loadFontIfNecessary). In the test
+  // environment all HTTP requests return 400, so that task always fails.
+  // By warming the cache here — and draining the error via a separate Zone —
+  // all subsequent calls in individual tests hit the cache and never launch
+  // another HTTP request. This prevents the async error from bleeding across
+  // test boundaries and hitting "Ref used after disposed".
+  setUpAll(() async {
+    SharedPreferences.setMockInitialValues({});
+    // Populate the cache synchronously; the async HTTP part will fail but
+    // we swallow it so it does not propagate into setUpAll.
+    bool fontErrorSeen = false;
+    await runZonedGuarded(
+      () async {
+        FontCalculator.measureCharWidthRatio('JetBrains Mono');
+        await Future<void>.delayed(const Duration(milliseconds: 200));
+      },
+      (error, stack) {
+        // Suppress the expected "Failed to load font" error from google_fonts.
+        if (!fontErrorSeen) {
+          fontErrorSeen = true;
+        }
+      },
+    );
+  });
 
   group('TerminalDisplayState', () {
     test('has correct default values', () {
@@ -99,13 +130,24 @@ void main() {
   group('TerminalDisplayNotifier', () {
     late ProviderContainer container;
 
-    setUp(() {
-      // Mock SharedPreferences
+    setUp(() async {
+      // Provide an empty SharedPreferences so _loadSettings completes fast
+      // and deterministically without hitting real platform channels.
       SharedPreferences.setMockInitialValues({});
       container = ProviderContainer();
+      // Eagerly initialize settingsProvider and drain the async _loadSettings
+      // call so it finishes before any test body runs. Without this, the
+      // in-flight Future can outlive the container and hit
+      // "Cannot use Ref after disposed".
+      container.read(settingsProvider);
+      await Future<void>.delayed(Duration.zero);
     });
 
-    tearDown(() {
+    tearDown(() async {
+      // Drain any remaining microtasks before disposing so that any still-
+      // running async work in the providers can observe ref.mounted == false
+      // and bail out cleanly instead of throwing after disposal.
+      await Future<void>.delayed(Duration.zero);
       container.dispose();
     });
 


### PR DESCRIPTION
## Failing tests repaired

- `TerminalDisplayNotifier endZoom clamps font size to max`
- `TerminalDisplayNotifier endZoom clamps font size to min`
- `TerminalDisplayNotifier endZoom finalizes font size and resets zoom state`
- `TerminalDisplayNotifier onSettingsChanged triggers recalculation`
- `TerminalDisplayNotifier updatePane resets horizontal scroll offset`
- `TerminalDisplayNotifier updatePane resets zoom state`
- `TerminalDisplayNotifier updatePane updates pane dimensions`
- `TerminalDisplayNotifier updateScreenWidth does nothing if width unchanged`
- `TerminalDisplayNotifier updateScreenWidth updates screen width`

## Root cause

Two independent async-lifetime issues caused all 9 tests to fail. First, `SettingsNotifier.build()` calls `_loadSettings()` fire-and-forget; when the test disposes the `ProviderContainer` before that async chain completes, Riverpod throws `Cannot use Ref after disposed`. Second, the first call to `FontCalculator.measureCharWidthRatio` triggers `google_fonts`' background `loadFontIfNecessary` HTTP task; in the test environment every HTTP request returns 400, so that task always errors — and because it was launched inside a `ProviderContainer` that had already been disposed, the error surfaced as a test failure on the subsequent test boundary.

## Fix

**Production change** (`lib/providers/settings_provider.dart`): add `if (!ref.mounted) return;` before the first `state =` write inside `_loadSettings()`, after all async gaps. This is the fix recommended verbatim in the Riverpod error message itself.

**Test change** (`test/providers/terminal_display_provider_test.dart`):
- `setUp` / `tearDown` made `async`; each side adds a `await Future.delayed(Duration.zero)` to drain pending microtasks before the container is disposed.
- `setUp` eagerly reads `settingsProvider` so the `_loadSettings` Future is submitted to the event loop before the test body runs and the `ref.mounted` guard can short-circuit it on dispose.
- `setUpAll` warms `FontCalculator`'s char-width cache inside a `runZonedGuarded` zone that suppresses the expected google_fonts HTTP-400 error, ensuring the cache is populated before any `ProviderContainer` is created and no further HTTP tasks are launched during individual tests.

## Local test result

```
00:00 +20: All tests passed!
```

All 20 tests in `test/providers/terminal_display_provider_test.dart` pass (7 `TerminalDisplayState` + 13 `TerminalDisplayNotifier`).