### PR TITLE
feat(terminal): add Page Up and Page Down keys

### DIFF
--- a/lib/widgets/special_keys_bar.dart
+++ b/lib/widgets/special_keys_bar.dart
@@ -553,6 +553,10 @@ class _SpecialKeysBarState extends State<SpecialKeysBar> {
       padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 4),
       child: Row(
         children: [
+          _buildNavigationKeyButton('PgUp', 'PPage'),
+          const SizedBox(width: 2),
+          _buildNavigationKeyButton('PgDn', 'NPage'),
+          const SizedBox(width: 2),
           // 矢印キー横並び: 左・上・下・右
           _buildArrowButton(Icons.arrow_left, 'Left'),
           const SizedBox(width: 2),
@@ -877,6 +881,38 @@ class _SpecialKeysBarState extends State<SpecialKeysBar> {
     );
   }
 
+  Widget _buildNavigationKeyButton(String label, String tmuxKey) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final colorScheme = Theme.of(context).colorScheme;
+    return GestureDetector(
+      onTapDown: (_) {
+        if (widget.hapticFeedback) {
+          HapticFeedback.lightImpact();
+        }
+      },
+      onTap: () => _sendSpecialKey(tmuxKey),
+      child: Container(
+        width: 36,
+        height: 36,
+        decoration: BoxDecoration(
+          color: isDark ? DesignColors.keyBackground : DesignColors.keyBackgroundLight,
+          borderRadius: BorderRadius.circular(4),
+          border: Border.all(color: colorScheme.outline.withValues(alpha: 0.2)),
+        ),
+        child: Center(
+          child: Text(
+            label,
+            style: GoogleFonts.jetBrainsMono(
+              fontSize: 8,
+              fontWeight: FontWeight.w700,
+              color: colorScheme.onSurface,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
   /// 画像転送ボタン
   Widget _buildImageTransferButton() {
     final isDark = Theme.of(context).brightness == Brightness.dark;
@@ -948,37 +984,23 @@ class _SpecialKeysBarState extends State<SpecialKeysBar> {
           borderRadius: BorderRadius.circular(4),
           border: Border.all(color: DesignColors.primary.withValues(alpha: 0.2)),
         ),
-        padding: const EdgeInsets.symmetric(horizontal: 12),
+        padding: const EdgeInsets.symmetric(horizontal: 8),
         child: Row(
           children: [
             Icon(
               Icons.keyboard,
-              size: 16,
+              size: 15,
               color: DesignColors.primary.withValues(alpha: 0.7),
             ),
-            const SizedBox(width: 8),
+            const SizedBox(width: 6),
             Expanded(
               child: Text(
-                'Input...',
+                'Cmd',
                 style: GoogleFonts.jetBrainsMono(
                   fontSize: 12,
                   color: DesignColors.primary.withValues(alpha: 0.5),
                 ),
-              ),
-            ),
-            Container(
-              padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
-              decoration: BoxDecoration(
-                color: DesignColors.primary.withValues(alpha: 0.1),
-                borderRadius: BorderRadius.circular(4),
-                border: Border.all(color: DesignColors.primary.withValues(alpha: 0.1)),
-              ),
-              child: Text(
-                'cmd',
-                style: GoogleFonts.jetBrainsMono(
-                  fontSize: 10,
-                  color: DesignColors.primary,
-                ),
+                overflow: TextOverflow.ellipsis,
               ),
             ),
           ],

--- a/lib/widgets/special_keys_bar.dart
+++ b/lib/widgets/special_keys_bar.dart
@@ -522,24 +522,27 @@ class _SpecialKeysBarState extends State<SpecialKeysBar> {
             ],
           ),
           child: Center(
-            child: Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Icon(
-                  Icons.keyboard_return,
-                  size: 12,
-                  color: DesignColors.primary,
-                ),
-                const SizedBox(width: 2),
-                Text(
-                  'RET',
-                  style: GoogleFonts.jetBrainsMono(
-                    fontSize: 9,
-                    fontWeight: FontWeight.w700,
+            child: FittedBox(
+              fit: BoxFit.scaleDown,
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(
+                    Icons.keyboard_return,
+                    size: 12,
                     color: DesignColors.primary,
                   ),
-                ),
-              ],
+                  const SizedBox(width: 2),
+                  Text(
+                    'RET',
+                    style: GoogleFonts.jetBrainsMono(
+                      fontSize: 9,
+                      fontWeight: FontWeight.w700,
+                      color: DesignColors.primary,
+                    ),
+                  ),
+                ],
+              ),
             ),
           ),
         ),
@@ -549,49 +552,60 @@ class _SpecialKeysBarState extends State<SpecialKeysBar> {
 
   /// 下部の矢印キー + Inputボタン行
   Widget _buildArrowKeysRow() {
+    if (widget.directInputEnabled) {
+      return SingleChildScrollView(
+        scrollDirection: Axis.horizontal,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 4),
+          child: Row(
+            children: [
+              ..._buildNavigationControls(),
+              const SizedBox(width: 8),
+              _buildNumberKeyButton('1'),
+              const SizedBox(width: 2),
+              _buildNumberKeyButton('2'),
+              const SizedBox(width: 2),
+              _buildNumberKeyButton('3'),
+              const SizedBox(width: 2),
+              _buildNumberKeyButton('4'),
+            ],
+          ),
+        ),
+      );
+    }
+
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 4),
       child: Row(
         children: [
-          _buildNavigationKeyButton('PgUp', 'PPage'),
-          const SizedBox(width: 2),
-          _buildNavigationKeyButton('PgDn', 'NPage'),
-          const SizedBox(width: 2),
-          // 矢印キー横並び: 左・上・下・右
-          _buildArrowButton(Icons.arrow_left, 'Left'),
-          const SizedBox(width: 2),
-          _buildArrowButton(Icons.arrow_drop_up, 'Up'),
-          const SizedBox(width: 2),
-          _buildArrowButton(Icons.arrow_drop_down, 'Down'),
-          const SizedBox(width: 2),
-          _buildArrowButton(Icons.arrow_right, 'Right'),
-          const SizedBox(width: 8),
-          // 画像転送ボタン
-          if (widget.onImagePickRequested != null) ...[
-            _buildImageTransferButton(),
-            const SizedBox(width: 2),
-          ],
-          // DirectInputモードトグルボタン
-          _buildDirectInputToggle(),
-          // DirectInput有効時: 数字キー(1-4)を右寄せで表示
-          if (widget.directInputEnabled) ...[
-            const Spacer(),
-            _buildNumberKeyButton('1'),
-            const SizedBox(width: 2),
-            _buildNumberKeyButton('2'),
-            const SizedBox(width: 2),
-            _buildNumberKeyButton('3'),
-            const SizedBox(width: 2),
-            _buildNumberKeyButton('4'),
-          ],
-          // DirectInput無効時: Inputボタンを表示
-          if (!widget.directInputEnabled) ...[
-            const SizedBox(width: 4),
-            Expanded(child: _buildInputButton()),
-          ],
+          ..._buildNavigationControls(),
+          const SizedBox(width: 4),
+          Expanded(child: _buildInputButton()),
         ],
       ),
     );
+  }
+
+  List<Widget> _buildNavigationControls() {
+    return [
+      _buildNavigationKeyButton('PgUp', 'PPage'),
+      const SizedBox(width: 2),
+      _buildNavigationKeyButton('PgDn', 'NPage'),
+      const SizedBox(width: 2),
+      _buildArrowButton(Icons.arrow_left, 'Left'),
+      const SizedBox(width: 2),
+      _buildArrowButton(Icons.arrow_drop_up, 'Up'),
+      const SizedBox(width: 2),
+      _buildArrowButton(Icons.arrow_drop_down, 'Down'),
+      const SizedBox(width: 2),
+      _buildArrowButton(Icons.arrow_right, 'Right'),
+      const SizedBox(width: 8),
+      if (widget.onImagePickRequested != null) ...[
+        _buildImageTransferButton(),
+        const SizedBox(width: 2),
+      ],
+      _buildDirectInputToggle(),
+    ];
   }
 
   /// DirectInput専用行（入力フィールドのみ）
@@ -985,25 +999,29 @@ class _SpecialKeysBarState extends State<SpecialKeysBar> {
           border: Border.all(color: DesignColors.primary.withValues(alpha: 0.2)),
         ),
         padding: const EdgeInsets.symmetric(horizontal: 8),
-        child: Row(
-          children: [
-            Icon(
-              Icons.keyboard,
-              size: 15,
-              color: DesignColors.primary.withValues(alpha: 0.7),
-            ),
-            const SizedBox(width: 6),
-            Expanded(
-              child: Text(
-                'Cmd',
-                style: GoogleFonts.jetBrainsMono(
-                  fontSize: 12,
-                  color: DesignColors.primary.withValues(alpha: 0.5),
+        child: Center(
+          child: FittedBox(
+            fit: BoxFit.scaleDown,
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Icon(
+                  Icons.keyboard,
+                  size: 15,
+                  color: DesignColors.primary.withValues(alpha: 0.7),
                 ),
-                overflow: TextOverflow.ellipsis,
-              ),
+                const SizedBox(width: 6),
+                Text(
+                  // "Cmd" keeps the non-direct toolbar compact enough for fixed nav keys.
+                  'Cmd',
+                  style: GoogleFonts.jetBrainsMono(
+                    fontSize: 12,
+                    color: DesignColors.primary.withValues(alpha: 0.5),
+                  ),
+                ),
+              ],
             ),
-          ],
+          ),
         ),
       ),
     );

--- a/test/widgets/special_keys_bar_test.dart
+++ b/test/widgets/special_keys_bar_test.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_muxpod/widgets/special_keys_bar.dart';
+
+void main() {
+  Widget buildWidget({
+    required bool directInputEnabled,
+    VoidCallback? onImagePickRequested,
+  }) {
+    return MaterialApp(
+      home: Scaffold(
+        body: Align(
+          alignment: Alignment.bottomCenter,
+          child: SizedBox(
+            width: 320,
+            child: SpecialKeysBar(
+              onKeyPressed: (_) {},
+              onSpecialKeyPressed: (_) {},
+              onInputTap: () {},
+              directInputEnabled: directInputEnabled,
+              onDirectInputToggle: () {},
+              onImagePickRequested: onImagePickRequested,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  testWidgets('direct input toolbar does not overflow at narrow phone width', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(320, 640));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    await tester.pumpWidget(
+      buildWidget(directInputEnabled: true, onImagePickRequested: () {}),
+    );
+    await tester.pump();
+
+    expect(tester.takeException(), isNull);
+    expect(find.byType(SingleChildScrollView), findsOneWidget);
+    expect(find.text('PgUp'), findsOneWidget);
+    expect(find.text('4'), findsOneWidget);
+  });
+
+  testWidgets('command input label stays compact in non-direct toolbar', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(320, 640));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    await tester.pumpWidget(buildWidget(directInputEnabled: false));
+    await tester.pump();
+
+    expect(tester.takeException(), isNull);
+    expect(find.text('Cmd'), findsOneWidget);
+    expect(find.text('Input...'), findsNothing);
+  });
+}


### PR DESCRIPTION
Adds PgUp and PgDn buttons to the mobile special keys bar.

These send tmux `PPage` and `NPage`, matching the existing hardware keyboard Page Up/Page Down mapping. This makes terminal scrollback navigation usable on Android without relying on text selection or gesture scrolling.

Tested:
- Android debug APK on physical phone
- `dart analyze lib/widgets/special_keys_bar.dart`
- `flutter build apk --debug`