### PR TITLE
ci: pin the Flutter version for the runner via MISE_FLUTTER_VERSION

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -25,6 +25,12 @@ jobs:
       # fastlane / CocoaPods は UTF-8 ロケールを要求する
       LANG: en_US.UTF-8
       LC_ALL: en_US.UTF-8
+      # リポジトリの .mise.toml は flutter = "3.38.6-stable" を指定しているが、
+      # これは古い mise (asdf プラグイン) 向けの表記。ビルドマシンの
+      # mise 2026.7.x はここから URL を組み立てる際に -stable を二重に付けて
+      # しまい 404 になる。ローカル開発環境では動作している表記なので
+      # .mise.toml は変更せず、CI 側でのみバージョンを上書きする。
+      MISE_FLUTTER_VERSION: '3.38.6'
       FASTLANE_SKIP_UPDATE_CHECK: '1'
       FASTLANE_HIDE_CHANGELOG: '1'
       # xcodebuild のログを CI 向けに抑制する

--- a/docs/ci-testflight.md
+++ b/docs/ci-testflight.md
@@ -40,9 +40,20 @@ CI の実行に sudo は不要。
 ### 注意点
 
 - **Flutter のバージョン指定**: リポジトリの `.mise.toml` は
-  `flutter = "3.38.6-stable"` だが、macOS ではこの表記だと mise が
-  `-stable` を二重に付与して 404 になる。ビルドマシンには
-  `flutter@3.38.6` として導入してある。
+  `flutter = "3.38.6-stable"` を指定しているが、これは古い mise
+  (asdf プラグイン方式) 向けの表記。ビルドマシンの mise 2026.7.x は
+  ここから URL を組み立てる際に `-stable` を二重に付けてしまい 404 になる。
+
+  ```
+  flutter_macos_arm64_3.38.6-stable-stable.zip  ← 存在しない
+  ```
+
+  ローカル開発環境 (mise 2024.9.x) では現在の表記で動作しているため
+  `.mise.toml` は変更せず、workflow の `MISE_FLUTTER_VERSION: '3.38.6'` で
+  CI 側だけ上書きしている。環境変数は設定ファイルより優先される。
+
+  将来ローカルの mise を更新した際は `.mise.toml` を `3.38.6` に直し、
+  この上書きを削除してよい。
 - **libyaml**: macOS には libyaml のヘッダが無いため、mise の Ruby ビルドで
   psych が入らない。`~/.local` に libyaml 0.2.5 を自前ビルドし、
   `RUBY_CONFIGURE_OPTS=--with-libyaml-dir=$HOME/.local` で解決している。


### PR DESCRIPTION
## Problem

The first TestFlight run ([30196939335](https://github.com/moezakura/mux-pod/actions/runs/30196939335)) failed at the toolchain check:

```
mise ERROR Failed to install http:flutter@3.38.6-stable:
HTTP status client error (404 Not Found) for url
(https://storage.googleapis.com/flutter_infra_release/releases/stable/macos/flutter_macos_arm64_3.38.6-stable-stable.zip)
```

Note the doubled `-stable-stable` in the filename.

## Cause

The mise shim picks up the repository's `.mise.toml`, which pins `flutter = "3.38.6-stable"`. That notation targets the older asdf-plugin flavour of mise. The build machine runs mise 2026.7.x, whose flutter backend appends `-stable` itself when composing the download URL, producing a filename that does not exist.

This is a mise version difference, not a platform difference:

| Machine | mise | Works with `3.38.6-stable` |
|---|---|---|
| Local dev | 2024.9.3 | yes |
| Build machine | 2026.7.13 | no |

## Fix

Leave `.mise.toml` untouched — the current notation demonstrably works on the local development machine — and override the version for CI only with `MISE_FLUTTER_VERSION: '3.38.6'`. Environment variables take precedence over config files in mise.

Once the local mise is upgraded, `.mise.toml` can be changed to `3.38.6` and this override removed. That is noted in the docs.

## Test plan

- [x] Workflow YAML parses
- [x] Verified in the runner's own checkout directory (`~/actions-runner/_work/mux-pod/mux-pod`) that with `MISE_FLUTTER_VERSION=3.38.6` the shim resolves Flutter 3.38.6 / Dart 3.10.7, and that ruby 3.3.12, pod 1.17.0, bundler 2.5.22 and fastlane 2.237.0 still resolve
- [ ] Re-run the workflow after merge

Only the toolchain check ran before the previous failure, so the steps after it are still unverified.