### PR TITLE
ci: set CODE_SIGN_IDENTITY explicitly when archiving

### DIFF
--- a/docs/ci-testflight.md
+++ b/docs/ci-testflight.md
@@ -94,6 +94,20 @@ CI では実行ごとに使い捨ての keychain を作り、そこへ証明書�
 `ios/Runner.xcodeproj` は自動署名のままにしてあり、手動署名の設定は
 ビルド時に `xcargs` で上書きしている。
 
+`CODE_SIGN_IDENTITY` は素の形と sdk 条件付きの形の両方を渡す必要がある。
+プロジェクトが `"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer"` を
+持っており、素の形だけではこの条件付き指定に負けて開発用証明書を探しに行き、
+次のエラーになる。
+
+```
+error: No signing certificate "iOS Development" found:
+No "iOS Development" signing certificate matching team ID "MUBKJR7U7A"
+with a private key was found. (in target 'Runner' from project 'Runner')
+```
+
+証明書名は match が `sigh_<bundle-id>_appstore_certificate-name` という
+環境変数に入れてくれるので、それを使う。
+
 ## GitHub Secrets
 
 | Secret | 内容 |

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -76,7 +76,16 @@ platform :ios do
         "--dart-define=GIT_REF=#{git_ref.shellescape}",
       ].join(" "))
 
+      # match が keychain に入れた証明書のコモンネーム。
+      # 例: "Apple Distribution: Furukawa Masaki (MUBKJR7U7A)"
+      signing_identity = ENV["sigh_#{APP_IDENTIFIER}_appstore_certificate-name"] || "Apple Distribution"
+
       # pbxproj は自動署名のままなので、手動署名の設定はビルド時に上書きする。
+      #
+      # CODE_SIGN_IDENTITY は素の形と sdk 条件付きの形の両方を指定する。
+      # プロジェクト側が "CODE_SIGN_IDENTITY[sdk=iphoneos*] = iPhone Developer" を
+      # 持っており、素の形だけではこの条件付き指定に負けて開発用証明書を
+      # 探しにいってしまうため。
       build_app(
         workspace:        "Runner.xcworkspace",
         scheme:           "Runner",
@@ -85,11 +94,13 @@ platform :ios do
         clean:            true,
         output_directory: File.join(FLUTTER_ROOT, "build", "ios", "ipa"),
         output_name:      "MuxPod.ipa",
-        xcargs: [
+        xcargs: Shellwords.join([
           "CODE_SIGN_STYLE=Manual",
           "DEVELOPMENT_TEAM=#{TEAM_ID}",
-          "PROVISIONING_PROFILE_SPECIFIER=#{PROFILE_NAME.shellescape}",
-        ].join(" "),
+          "PROVISIONING_PROFILE_SPECIFIER=#{PROFILE_NAME}",
+          "CODE_SIGN_IDENTITY=#{signing_identity}",
+          "CODE_SIGN_IDENTITY[sdk=iphoneos*]=#{signing_identity}",
+        ]),
         export_team_id: TEAM_ID,
         export_options: {
           signingStyle: "manual",


### PR DESCRIPTION
## Progress since #65

Run [30197050063](https://github.com/moezakura/mux-pod/actions/runs/30197050063) got much further. `match` worked:

```
🔓  Successfully decrypted certificates repo
Successfully generated 3JR6QH8XK9 which was imported to the local machine.
Successfully installed certificate 3JR6QH8XK9
No existing profiles found, that match the certificates you have installed locally!
Creating a new provisioning profile for you
Successfully downloaded provisioning profile...
🔒  Successfully encrypted certificates repo
All required keys, certificates and provisioning profiles are installed 🙌
```

`moezakura/muxpod-certificates` now holds the encrypted assets:

```
certs/distribution/3JR6QH8XK9.cer
certs/distribution/3JR6QH8XK9.p12
profiles/appstore/AppStore_si.mox.mux-pod.mobileprovision
```

## Problem

`gym` then failed:

```
error: No signing certificate "iOS Development" found:
No "iOS Development" signing certificate matching team ID "MUBKJR7U7A"
with a private key was found. (in target 'Runner' from project 'Runner')
```

## Cause

The xcargs were passed correctly — the log shows the archive command:

```
xcodebuild -workspace Runner.xcworkspace -scheme Runner -configuration Release \
  -destination 'generic/platform=iOS' -archivePath ... \
  CODE_SIGN_STYLE=Manual DEVELOPMENT_TEAM=MUBKJR7U7A \
  PROVISIONING_PROFILE_SPECIFIER=match\ AppStore\ si.mox.mux-pod clean archive
```

`CODE_SIGN_IDENTITY` was simply never set, so xcodebuild used the project's value. `ios/Runner.xcodeproj` sets it in the sdk-conditional form at project level (lines 443, 567, 624):

```
"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
```

which Xcode 26 resolves to a development identity — and only distribution certificates are in the throwaway keychain.

## Fix

Pass `CODE_SIGN_IDENTITY` in both the plain and the sdk-conditional form. A plain command-line assignment does not reliably win against a conditional assignment in the project, so both are needed.

The certificate name is read from `sigh_<bundle-id>_appstore_certificate-name`, which match exports, instead of being hardcoded. From the run log it resolves to:

```
Apple Distribution: Furukawa Masaki (MUBKJR7U7A)
```

Also switched xcargs to `Shellwords.join` rather than escaping each value by hand.

## Test plan

- [x] Fastfile syntax check (`ruby -c`)
- [x] Verified the generated xcargs string
- [ ] Re-run the workflow after merge

Everything after the archive step — export, and the TestFlight upload itself — is still unverified.