### PR TITLE
ci: apply manual signing to the Runner target only

### DIFF
--- a/docs/ci-testflight.md
+++ b/docs/ci-testflight.md
@@ -91,19 +91,35 @@ write 権限）でアクセスする。GitHub Secrets に PAT を置く必要は
 CI では実行ごとに使い捨ての keychain を作り、そこへ証明書を取り込んでから
 ビルドし、終了時に削除する（ログインキーチェーンは解錠されていないため）。
 
-`ios/Runner.xcodeproj` は自動署名のままにしてあり、手動署名の設定は
-ビルド時に `xcargs` で上書きしている。
+`ios/Runner.xcodeproj` はリポジトリ上では自動署名のままにしてある。
+手動署名の設定は `update_code_signing_settings` で **Runner ターゲットの
+Release 構成にだけ** 書き込む。CI の checkout は毎回作り直されるので
+pbxproj への書き込みは残らない。
 
-`CODE_SIGN_IDENTITY` は素の形と sdk 条件付きの形の両方を渡す必要がある。
-プロジェクトが `"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer"` を
-持っており、素の形だけではこの条件付き指定に負けて開発用証明書を探しに行き、
-次のエラーになる。
+### なぜ xcargs ではないのか
+
+`xcodebuild` のコマンドライン引数は全ターゲットに適用される。
+`PROVISIONING_PROFILE_SPECIFIER` をそこで渡すと、プロファイルを受け付けない
+Pods のフレームワークターゲットが軒並み失敗する。
+
+```
+error: Pods-Runner does not support provisioning profiles, but provisioning
+profile match AppStore si.mox.mux-pod has been manually specified.
+```
+
+### CODE_SIGN_IDENTITY を 2 回書く理由
+
+プロジェクトレベルに `"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer"`
+があり、素の形だけを書いてもこの条件付き指定が残って開発用証明書を探しに行く。
 
 ```
 error: No signing certificate "iOS Development" found:
 No "iOS Development" signing certificate matching team ID "MUBKJR7U7A"
 with a private key was found. (in target 'Runner' from project 'Runner')
 ```
+
+そのため `update_code_signing_settings` を `sdk: nil` と
+`sdk: "iphoneos*"` の 2 回呼んで両方の形を書き込んでいる。
 
 証明書名は match が `sigh_<bundle-id>_appstore_certificate-name` という
 環境変数に入れてくれるので、それを使う。

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -80,12 +80,34 @@ platform :ios do
       # 例: "Apple Distribution: Furukawa Masaki (MUBKJR7U7A)"
       signing_identity = ENV["sigh_#{APP_IDENTIFIER}_appstore_certificate-name"] || "Apple Distribution"
 
-      # pbxproj は自動署名のままなので、手動署名の設定はビルド時に上書きする。
+      # 手動署名の設定は Runner ターゲットの Release 構成にだけ書き込む。
       #
-      # CODE_SIGN_IDENTITY は素の形と sdk 条件付きの形の両方を指定する。
-      # プロジェクト側が "CODE_SIGN_IDENTITY[sdk=iphoneos*] = iPhone Developer" を
-      # 持っており、素の形だけではこの条件付き指定に負けて開発用証明書を
+      # xcodebuild のコマンドライン引数 (xcargs) は全ターゲットに適用されるため、
+      # そちらで指定すると Pods 側のフレームワークターゲットが
+      #   "Pods-Runner does not support provisioning profiles"
+      # で失敗する。プロファイルを受け付けるのは Runner だけ。
+      #
+      # CODE_SIGN_IDENTITY は素の形と sdk 条件付きの形の両方を書き込む。
+      # プロジェクトレベルに "CODE_SIGN_IDENTITY[sdk=iphoneos*] = iPhone Developer"
+      # があり、素の形だけではこの条件付き指定が残って開発用証明書を
       # 探しにいってしまうため。
+      #
+      # pbxproj を書き換えるが、CI の checkout は毎回作り直されるので影響はない。
+      # ローカルでこのレーンを実行した場合は差分が残るので注意。
+      [nil, "iphoneos*"].each do |sdk|
+        update_code_signing_settings(
+          path:                  "Runner.xcodeproj",
+          use_automatic_signing: false,
+          sdk:                   sdk,
+          team_id:               TEAM_ID,
+          code_sign_identity:    signing_identity,
+          profile_name:          PROFILE_NAME,
+          bundle_identifier:     APP_IDENTIFIER,
+          targets:               ["Runner"],
+          build_configurations:  ["Release"],
+        )
+      end
+
       build_app(
         workspace:        "Runner.xcworkspace",
         scheme:           "Runner",
@@ -94,14 +116,7 @@ platform :ios do
         clean:            true,
         output_directory: File.join(FLUTTER_ROOT, "build", "ios", "ipa"),
         output_name:      "MuxPod.ipa",
-        xcargs: Shellwords.join([
-          "CODE_SIGN_STYLE=Manual",
-          "DEVELOPMENT_TEAM=#{TEAM_ID}",
-          "PROVISIONING_PROFILE_SPECIFIER=#{PROFILE_NAME}",
-          "CODE_SIGN_IDENTITY=#{signing_identity}",
-          "CODE_SIGN_IDENTITY[sdk=iphoneos*]=#{signing_identity}",
-        ]),
-        export_team_id: TEAM_ID,
+        export_team_id:   TEAM_ID,
         export_options: {
           signingStyle: "manual",
           teamID:       TEAM_ID,


### PR DESCRIPTION
## Progress since #66

Run [30197182901](https://github.com/moezakura/mux-pod/actions/runs/30197182901): the Runner target no longer looks for a development certificate, so #66 did its job. The archive now fails one step later, on the Pods project.

## Problem

```
error: Pods-Runner does not support provisioning profiles, but provisioning profile
match AppStore si.mox.mux-pod has been manually specified.
Set the provisioning profile value to "Automatic" in the build settings editor.
(in target 'Pods-Runner' from project 'Pods')
```

The same error appears for `SDWebImage`, `SDWebImageWebPCoder` and `url_launcher_ios`.

## Cause

`xcodebuild` command-line build settings apply to **every** target in the build. The Pods framework targets do not accept a provisioning profile — only the app target does — so passing `PROVISIONING_PROFILE_SPECIFIER` through xcargs breaks them.

## Fix

Write the signing settings into the Runner target's Release configuration with `update_code_signing_settings`, and drop the signing xcargs entirely.

```ruby
[nil, "iphoneos*"].each do |sdk|
  update_code_signing_settings(
    path:                  "Runner.xcodeproj",
    use_automatic_signing: false,
    sdk:                   sdk,
    team_id:               TEAM_ID,
    code_sign_identity:    signing_identity,
    profile_name:          PROFILE_NAME,
    bundle_identifier:     APP_IDENTIFIER,
    targets:               ["Runner"],
    build_configurations:  ["Release"],
  )
end
```

The action is called twice — with and without `sdk: "iphoneos*"` — so both forms of `CODE_SIGN_IDENTITY` are written and the project-level conditional assignment from #66 cannot win.

This modifies `ios/Runner.xcodeproj/project.pbxproj`. That is fine on CI because `actions/checkout` recreates the working tree on every run, and the file in the repository stays on automatic signing so local development is unaffected. Running the lane locally will leave the file dirty; there is a comment saying so.

## Test plan

- [x] Fastfile syntax check (`ruby -c`)
- [x] Confirmed `update_code_signing_settings` accepts `sdk`, `targets`, `build_configurations`, `code_sign_identity` and `profile_name` in fastlane 2.237.0
- [ ] Re-run the workflow after merge

The archive has never completed, so everything from the Dart AOT compile onward — export, IPA creation and the TestFlight upload — remains unverified.