### PR TITLE
feat: Remote UI tab for AI agent control (Claude Code / Codex / Droid)

### DIFF
--- a/lib/providers/remote_ui_chat_provider.dart
+++ b/lib/providers/remote_ui_chat_provider.dart
@@ -1,0 +1,494 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../services/agent/agent_registry.dart';
+import '../services/agent/agent_types.dart';
+import '../services/agent/headless/chat_event.dart';
+import '../services/agent/headless/chat_session_store.dart';
+import '../services/agent/headless/headless_agent_session.dart';
+import '../services/ssh/connection_credentials.dart';
+import '../services/ssh/ssh_client.dart';
+import 'connection_provider.dart';
+import 'remote_ui_provider.dart';
+
+/// State for the Remote UI chat: the selected agent, the configuration
+/// applied to the next headless run, session history, and the live
+/// streaming response.
+class RemoteUiChatState {
+  /// Agent the chat runs on.
+  final AgentKind agentKind;
+
+  /// Configuration applied to the next headless run (the chips' state
+  /// when no live pane agent is detected).
+  final AgentConfig pendingConfig;
+
+  /// Stored sessions for the current (connection, agent) pair.
+  final List<ChatSessionRecord> sessions;
+
+  /// Currently open session id, null on the empty "New chat" screen.
+  final String? activeSessionId;
+
+  /// Messages of the active session, chronological.
+  final List<ChatMessageRecord> messages;
+
+  /// Accumulating assistant text of the in-flight run.
+  final String streamingText;
+
+  /// True while a headless run is streaming.
+  final bool isStreaming;
+
+  /// Workspace/Worktree toggle: when true, prompts run in a dedicated
+  /// git worktree instead of the base working directory.
+  final bool worktreeMode;
+
+  /// Last error message, if any.
+  final String? error;
+
+  const RemoteUiChatState({
+    this.agentKind = AgentKind.claudeCode,
+    this.pendingConfig = const AgentConfig(),
+    this.sessions = const [],
+    this.activeSessionId,
+    this.messages = const [],
+    this.streamingText = '',
+    this.isStreaming = false,
+    this.worktreeMode = false,
+    this.error,
+  });
+
+  static const _unset = Object();
+
+  RemoteUiChatState copyWith({
+    AgentKind? agentKind,
+    AgentConfig? pendingConfig,
+    List<ChatSessionRecord>? sessions,
+    Object? activeSessionId = _unset,
+    List<ChatMessageRecord>? messages,
+    String? streamingText,
+    bool? isStreaming,
+    bool? worktreeMode,
+    Object? error = _unset,
+  }) {
+    return RemoteUiChatState(
+      agentKind: agentKind ?? this.agentKind,
+      pendingConfig: pendingConfig ?? this.pendingConfig,
+      sessions: sessions ?? this.sessions,
+      activeSessionId: activeSessionId == _unset
+          ? this.activeSessionId
+          : activeSessionId as String?,
+      messages: messages ?? this.messages,
+      streamingText: streamingText ?? this.streamingText,
+      isStreaming: isStreaming ?? this.isStreaming,
+      worktreeMode: worktreeMode ?? this.worktreeMode,
+      error: error == _unset ? this.error : error as String?,
+    );
+  }
+}
+
+/// Drives the Remote UI chat: session history plus headless streaming
+/// runs over a dedicated SSH connection.
+///
+/// This connection is separate from `remoteUiProvider`'s control
+/// connection because `SshClient.execStream` holds the exec lock for the
+/// whole stream lifetime.
+class RemoteUiChatNotifier extends Notifier<RemoteUiChatState> {
+  final ChatSessionStore _store = ChatSessionStore();
+  SshClient? _chatClient;
+  String? _chatClientConnectionId;
+  HeadlessAgentSession? _session;
+  StreamSubscription<ChatEvent>? _eventSub;
+
+  /// Synchronous re-entrancy guard for [send]: `isStreaming` is only set
+  /// after the first await, so a rapid double-tap could otherwise slip
+  /// through the state check.
+  bool _sendInProgress = false;
+
+  @override
+  RemoteUiChatState build() {
+    ref.onDispose(() {
+      unawaited(_eventSub?.cancel());
+      unawaited(_session?.dispose());
+      unawaited(_chatClient?.disconnect());
+    });
+    return const RemoteUiChatState();
+  }
+
+  /// Capabilities of the currently selected chat agent.
+  AgentCapabilities get capabilities => AgentRegistry.adapters
+      .firstWhere((a) => a.kind == state.agentKind)
+      .capabilities;
+
+  /// Selects the chat agent, resets the pending configuration to its
+  /// supported defaults, and loads its session history.
+  Future<void> selectAgent(AgentKind kind) async {
+    if (kind == state.agentKind) return;
+    await cancel();
+    state = state.copyWith(
+      agentKind: kind,
+      pendingConfig: const AgentConfig(),
+      activeSessionId: null,
+      messages: const [],
+      streamingText: '',
+      error: null,
+    );
+    await loadSessions();
+  }
+
+  /// Loads the stored sessions for the current (connection, agent) pair.
+  Future<void> loadSessions() async {
+    final connectionId = ref.read(remoteUiProvider).connectionId;
+    if (connectionId == null) return;
+    final sessions = await _store.load(connectionId, state.agentKind);
+    state = state.copyWith(sessions: sessions);
+  }
+
+  /// Starts a new empty chat (the "New chat" screen).
+  ///
+  /// Cancels any in-flight run first so its events cannot leak into the
+  /// fresh conversation.
+  Future<void> newSession() async {
+    await cancel();
+    state = state.copyWith(
+      activeSessionId: null,
+      messages: const [],
+      streamingText: '',
+      error: null,
+    );
+  }
+
+  /// Opens a stored session and shows its messages.
+  ///
+  /// Cancels any in-flight run first so its completion cannot append the
+  /// previous conversation's reply to the newly opened session.
+  Future<void> openSession(String sessionId) async {
+    final session =
+        state.sessions.where((s) => s.id == sessionId).firstOrNull;
+    if (session == null) return;
+    await cancel();
+    state = state.copyWith(
+      activeSessionId: sessionId,
+      messages: session.messages,
+      streamingText: '',
+      error: null,
+    );
+  }
+
+  /// Updates the model used by the next headless run.
+  void setModel(String? model) {
+    state = state.copyWith(
+      pendingConfig: state.pendingConfig.copyWith(model: model),
+    );
+  }
+
+  /// Updates the reasoning effort used by the next headless run.
+  void setIntelligence(UnifiedIntelligence? level) {
+    state = state.copyWith(
+      pendingConfig: state.pendingConfig.copyWith(intelligence: level),
+    );
+  }
+
+  /// Updates the autonomy level used by the next headless run.
+  void setPermission(UnifiedPermission? level) {
+    state = state.copyWith(
+      pendingConfig: state.pendingConfig.copyWith(permission: level),
+    );
+  }
+
+  /// Toggles plan/spec mode for the next headless run.
+  void setPlanMode(bool enabled) {
+    state = state.copyWith(
+      pendingConfig: state.pendingConfig.copyWith(planModeActive: enabled),
+    );
+  }
+
+  /// Switches between Workspace and Worktree mode.
+  void setWorktreeMode(bool worktree) {
+    state = state.copyWith(worktreeMode: worktree);
+  }
+
+  /// Sends [text] to the agent, streaming the response into state.
+  ///
+  /// Creates a stored session on the first message. Follow-up messages
+  /// resume the agent-side session when one was captured.
+  Future<void> send(String text) async {
+    final prompt = text.trim();
+    if (prompt.isEmpty || state.isStreaming || _sendInProgress) return;
+    _sendInProgress = true;
+    try {
+      await _send(prompt);
+    } finally {
+      _sendInProgress = false;
+    }
+  }
+
+  Future<void> _send(String prompt) async {
+    final connectionId = ref.read(remoteUiProvider).connectionId;
+    if (connectionId == null) {
+      state = state.copyWith(error: 'Select a server first');
+      return;
+    }
+
+    final client = await _ensureChatClient(connectionId);
+    if (client == null) return;
+
+    // Ensure an active stored session.
+    var activeId = state.activeSessionId;
+    if (activeId == null) {
+      final created = await _store.createSession(
+        connectionId,
+        state.agentKind,
+      );
+      activeId = created.id;
+      state = state.copyWith(
+        activeSessionId: activeId,
+        sessions: [created, ...state.sessions],
+      );
+    }
+
+    final userMessage = ChatMessageRecord(
+      role: ChatRole.user,
+      text: prompt,
+      timestamp: DateTime.now(),
+    );
+    await _store.addMessage(
+      connectionId,
+      state.agentKind,
+      activeId,
+      userMessage,
+    );
+    state = state.copyWith(
+      messages: [...state.messages, userMessage],
+      streamingText: '',
+      isStreaming: true,
+      error: null,
+    );
+
+    final activeSession =
+        state.sessions.where((s) => s.id == activeId).firstOrNull;
+
+    final workingDirectory = await _resolveWorkingDirectory(client);
+    final config = state.pendingConfig;
+    final session = HeadlessAgentSession(
+      ssh: client,
+      kind: state.agentKind,
+      model: config.model,
+      intelligence: config.intelligence,
+      permission: config.permission,
+      planMode: config.planModeActive,
+      workingDirectory: workingDirectory,
+      resumeSessionId: activeSession?.remoteSessionId,
+    );
+    // Release the previous run's listener/session before overwriting;
+    // otherwise each completed run leaks a broadcast subscription.
+    await _eventSub?.cancel();
+    await _session?.dispose();
+    _session = session;
+
+    final buffer = StringBuffer();
+    _eventSub = session.events.listen(
+      (event) {
+        switch (event) {
+          case TextDelta(:final text):
+            buffer.write(text);
+            state = state.copyWith(streamingText: buffer.toString());
+          case SessionStarted(:final sessionId):
+            unawaited(
+              _store.setRemoteSessionId(
+                connectionId,
+                state.agentKind,
+                activeId!,
+                sessionId,
+              ),
+            );
+          case RunCompleted():
+            unawaited(_finishRun(connectionId, activeId!, buffer.toString()));
+          case RunFailed(:final message):
+            unawaited(
+              _finishRun(connectionId, activeId!, buffer.toString(),
+                  error: message),
+            );
+          case ThinkingDelta():
+          case ToolCallStarted():
+          case ApprovalRequested():
+          case UsageUpdated():
+            // Surfaced in a later iteration; the run continues.
+            break;
+        }
+      },
+    );
+
+    try {
+      if (session.sessionId == null) {
+        await session.start(prompt);
+      } else {
+        await session.send(prompt);
+      }
+    } on Object catch (e) {
+      await _finishRun(connectionId, activeId, buffer.toString(),
+          error: '$e');
+    }
+  }
+
+  /// Cancels the in-flight run, keeping the partial response.
+  ///
+  /// Also finalizes the streaming state: `HeadlessAgentSession.cancel`
+  /// suppresses the terminal event, so without this the UI would stay in
+  /// the streaming state forever and the composer would dead-lock.
+  Future<void> cancel() async {
+    if (!state.isStreaming) return;
+    await _session?.cancel();
+    await _eventSub?.cancel();
+    _eventSub = null;
+    final connectionId = ref.read(remoteUiProvider).connectionId;
+    final sessionId = state.activeSessionId;
+    if (connectionId != null && sessionId != null) {
+      await _finishRun(connectionId, sessionId, state.streamingText);
+    } else {
+      state = state.copyWith(isStreaming: false, streamingText: '');
+    }
+  }
+
+  /// Clears the current error after the UI has shown it.
+  void clearError() {
+    state = state.copyWith(error: null);
+  }
+
+  /// Deletes the chat history for the current (connection, agent) pair.
+  Future<void> clearHistory() async {
+    await cancel();
+    final connectionId = ref.read(remoteUiProvider).connectionId;
+    if (connectionId == null) return;
+    await _store.clear(connectionId, state.agentKind);
+    state = state.copyWith(
+      sessions: const [],
+      activeSessionId: null,
+      messages: const [],
+      streamingText: '',
+    );
+  }
+
+  Future<void> _finishRun(
+    String connectionId,
+    String sessionId,
+    String assistantText, {
+    String? error,
+  }) async {
+    if (!state.isStreaming) return;
+    final trimmed = assistantText.trim();
+    ChatMessageRecord? assistantMessage;
+    if (trimmed.isNotEmpty) {
+      assistantMessage = ChatMessageRecord(
+        role: ChatRole.assistant,
+        text: trimmed,
+        timestamp: DateTime.now(),
+      );
+      await _store.addMessage(
+        connectionId,
+        state.agentKind,
+        sessionId,
+        assistantMessage,
+      );
+    }
+    final sessions = await _store.load(connectionId, state.agentKind);
+    // The user may have switched sessions while the run was in flight;
+    // only append to the visible message list when the finished run still
+    // belongs to the active session (the store write above already landed
+    // under the correct session id).
+    final stillActive = state.activeSessionId == sessionId;
+    state = state.copyWith(
+      messages: stillActive && assistantMessage != null
+          ? [...state.messages, assistantMessage]
+          : state.messages,
+      sessions: sessions,
+      streamingText: '',
+      isStreaming: false,
+      error: error,
+    );
+  }
+
+  /// Connects (or reuses) the dedicated chat SSH connection.
+  Future<SshClient?> _ensureChatClient(String connectionId) async {
+    final existing = _chatClient;
+    if (existing != null &&
+        existing.isConnected &&
+        _chatClientConnectionId == connectionId) {
+      return existing;
+    }
+
+    if (existing != null) await existing.disconnect();
+    _chatClient = null;
+    _chatClientConnectionId = null;
+
+    final connection =
+        ref.read(connectionsProvider.notifier).getById(connectionId);
+    if (connection == null) {
+      state = state.copyWith(error: 'Unknown connection');
+      return null;
+    }
+
+    final client = SshClient();
+    try {
+      final options = await ConnectionCredentials.resolve(
+        connectionId: connection.id,
+        authMethod: connection.authMethod,
+        keyId: connection.keyId,
+        tmuxPath: connection.tmuxPath,
+      );
+      await client.connect(
+        host: connection.host,
+        port: connection.port,
+        username: connection.username,
+        options: options,
+        lightweight: true,
+      );
+      _chatClient = client;
+      _chatClientConnectionId = connectionId;
+      return client;
+    } on Object catch (e) {
+      await client.disconnect();
+      state = state.copyWith(isStreaming: false, error: '$e');
+      return null;
+    }
+  }
+
+  /// Base directory for headless runs: the detected agent pane's
+  /// directory when known, otherwise the remote home directory.
+  ///
+  /// In worktree mode a dedicated git worktree is created under
+  /// `.muxpod-worktrees/` next to the repository root; returns null
+  /// (remote default) when the base directory is not a git repository.
+  Future<String?> _resolveWorkingDirectory(SshClient client) async {
+    final base = ref.read(remoteUiProvider).agentPanePath;
+    if (!state.worktreeMode) return base;
+
+    final sessionSuffix = (state.activeSessionId ?? 'chat')
+        .replaceAll(RegExp('[^a-zA-Z0-9-]'), '')
+        .substring(0, 8);
+    final script = base != null
+        ? "cd '${base.replaceAll("'", r"'\''")}' && "
+            'top=\$(git rev-parse --show-toplevel 2>/dev/null) && '
+            'wt="\$top/.muxpod-worktrees/$sessionSuffix" && '
+            '(git -C "\$top" worktree add --detach "\$wt" HEAD '
+            '2>/dev/null || true) && '
+            'test -d "\$wt" && printf %s "\$wt"'
+        : '';
+    if (script.isEmpty) return null;
+
+    try {
+      final result = await client.execWithExitCode(script);
+      if (result.exitCode == 0 && result.stdout.trim().isNotEmpty) {
+        return result.stdout.trim();
+      }
+    } on Object {
+      // Fall through to the base directory.
+    }
+    return base;
+  }
+}
+
+/// Provider for the Remote UI chat.
+final remoteUiChatProvider =
+    NotifierProvider<RemoteUiChatNotifier, RemoteUiChatState>(
+  RemoteUiChatNotifier.new,
+);

--- a/lib/providers/remote_ui_provider.dart
+++ b/lib/providers/remote_ui_provider.dart
@@ -1,0 +1,286 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../services/agent/agent_adapter.dart';
+import '../services/agent/agent_registry.dart';
+import '../services/agent/agent_types.dart';
+import '../services/ssh/connection_credentials.dart';
+import '../services/ssh/ssh_client.dart';
+import '../services/tmux/tmux_commands.dart';
+import '../services/tmux/tmux_parser.dart';
+import 'connection_provider.dart';
+
+/// State for the Remote UI tab: which server is connected, which agent
+/// (if any) was detected in its tmux panes, and the agent's last known
+/// configuration.
+class RemoteUiState {
+  /// Selected server connection id, null when nothing is selected.
+  final String? connectionId;
+
+  /// True while the dedicated SSH connection is being established.
+  final bool isConnecting;
+
+  /// True when the dedicated SSH connection is ready.
+  final bool isConnected;
+
+  /// Adapter of the agent detected in a tmux pane, null when no known
+  /// agent runs on the connected server.
+  final AgentAdapter? agent;
+
+  /// tmux pane id the detected agent runs in.
+  final String? agentPaneId;
+
+  /// Working directory of the agent pane (`pane_current_path`).
+  final String? agentPanePath;
+
+  /// Last known agent configuration.
+  final AgentConfig config;
+
+  /// True while a config read/apply operation is in flight.
+  final bool isBusy;
+
+  /// Last error message, if any.
+  final String? error;
+
+  /// Last confirmation message from an apply operation.
+  final String? notice;
+
+  const RemoteUiState({
+    this.connectionId,
+    this.isConnecting = false,
+    this.isConnected = false,
+    this.agent,
+    this.agentPaneId,
+    this.agentPanePath,
+    this.config = const AgentConfig(),
+    this.isBusy = false,
+    this.error,
+    this.notice,
+  });
+
+  static const _unset = Object();
+
+  RemoteUiState copyWith({
+    Object? connectionId = _unset,
+    bool? isConnecting,
+    bool? isConnected,
+    Object? agent = _unset,
+    Object? agentPaneId = _unset,
+    Object? agentPanePath = _unset,
+    AgentConfig? config,
+    bool? isBusy,
+    Object? error = _unset,
+    Object? notice = _unset,
+  }) {
+    return RemoteUiState(
+      connectionId: connectionId == _unset
+          ? this.connectionId
+          : connectionId as String?,
+      isConnecting: isConnecting ?? this.isConnecting,
+      isConnected: isConnected ?? this.isConnected,
+      agent: agent == _unset ? this.agent : agent as AgentAdapter?,
+      agentPaneId:
+          agentPaneId == _unset ? this.agentPaneId : agentPaneId as String?,
+      agentPanePath: agentPanePath == _unset
+          ? this.agentPanePath
+          : agentPanePath as String?,
+      config: config ?? this.config,
+      isBusy: isBusy ?? this.isBusy,
+      error: error == _unset ? this.error : error as String?,
+      notice: notice == _unset ? this.notice : notice as String?,
+    );
+  }
+}
+
+/// Manages the Remote UI tab's dedicated SSH connection and live-pane
+/// agent control.
+///
+/// The tab owns its own [SshClient] (separate from the terminal screen's
+/// global `sshProvider`) so that long-running chat streams and config
+/// operations never block terminal input.
+class RemoteUiNotifier extends Notifier<RemoteUiState> {
+  SshClient? _client;
+
+  @override
+  RemoteUiState build() {
+    ref.onDispose(() {
+      unawaited(_client?.disconnect());
+    });
+    return const RemoteUiState();
+  }
+
+  /// The dedicated SSH connection used by the Remote UI tab, null until
+  /// [selectServer] succeeds.
+  SshClient? get client => _client;
+
+  /// Connects to the server [connectionId] and detects running agents.
+  Future<void> selectServer(String connectionId) async {
+    final connection = ref.read(connectionsProvider.notifier).getById(connectionId);
+    if (connection == null) return;
+
+    state = state.copyWith(
+      isConnecting: true,
+      isConnected: false,
+      error: null,
+      notice: null,
+    );
+
+    final previous = _client;
+    _client = null;
+    if (previous != null) await previous.disconnect();
+
+    final client = SshClient();
+    try {
+      final options = await ConnectionCredentials.resolve(
+        connectionId: connection.id,
+        authMethod: connection.authMethod,
+        keyId: connection.keyId,
+        tmuxPath: connection.tmuxPath,
+      );
+
+      await client.connect(
+        host: connection.host,
+        port: connection.port,
+        username: connection.username,
+        options: options,
+      );
+
+      _client = client;
+      state = state.copyWith(
+        connectionId: connectionId,
+        isConnecting: false,
+        isConnected: true,
+      );
+      await refresh();
+    } on Object catch (e) {
+      await client.disconnect();
+      state = state.copyWith(
+        isConnecting: false,
+        isConnected: false,
+        agent: null,
+        agentPaneId: null,
+        agentPanePath: null,
+        error: '$e',
+      );
+    }
+  }
+
+  /// Disconnects from the current server and clears detection state.
+  Future<void> disconnect() async {
+    final client = _client;
+    _client = null;
+    if (client != null) await client.disconnect();
+    state = const RemoteUiState();
+  }
+
+  /// Re-scans the server's tmux panes for a known agent and re-reads its
+  /// configuration.
+  Future<void> refresh() async {
+    final client = _client;
+    if (client == null || !client.isConnected) return;
+
+    state = state.copyWith(isBusy: true, error: null);
+    try {
+      final output = await client.execPersistent(TmuxCommands.listAllPanes());
+      final sessions = TmuxParser.parseFullTree(output);
+
+      AgentAdapter? found;
+      String? paneId;
+      String? panePath;
+      for (final session in sessions) {
+        for (final window in session.windows) {
+          for (final pane in window.panes) {
+            final adapter = AgentRegistry.detect(pane.currentCommand);
+            if (adapter != null) {
+              found = adapter;
+              paneId = pane.id;
+              panePath = pane.currentPath;
+              break;
+            }
+          }
+          if (found != null) break;
+        }
+        if (found != null) break;
+      }
+
+      var config = const AgentConfig();
+      if (found != null) {
+        config = await found.readConfig(
+          AgentContext(
+            ssh: client,
+            paneId: paneId!,
+            paneWorkingDirectory: panePath,
+          ),
+        );
+      }
+
+      state = state.copyWith(
+        agent: found,
+        agentPaneId: paneId,
+        agentPanePath: panePath,
+        config: config,
+        isBusy: false,
+      );
+    } on Object catch (e) {
+      state = state.copyWith(isBusy: false, error: '$e');
+    }
+  }
+
+  /// Applies a model switch to the detected live-pane agent.
+  Future<void> applyModel(String model) =>
+      _apply((adapter, context) => adapter.applyModel(context, model));
+
+  /// Applies a reasoning-effort change to the detected live-pane agent.
+  Future<void> applyIntelligence(UnifiedIntelligence level) =>
+      _apply((adapter, context) => adapter.applyIntelligence(context, level));
+
+  /// Applies an autonomy/permission change to the detected live-pane
+  /// agent.
+  Future<void> applyPermission(UnifiedPermission level) =>
+      _apply((adapter, context) => adapter.applyPermission(context, level));
+
+  /// Toggles plan/spec mode on the detected live-pane agent.
+  Future<void> setPlanMode(bool enabled) =>
+      _apply((adapter, context) => adapter.setPlanMode(context, enabled));
+
+  /// Clears the current notice/error after the UI has shown it.
+  void clearMessages() {
+    state = state.copyWith(error: null, notice: null);
+  }
+
+  Future<void> _apply(
+    Future<String> Function(AgentAdapter adapter, AgentContext context)
+        action,
+  ) async {
+    final adapter = state.agent;
+    final client = _client;
+    final paneId = state.agentPaneId;
+    if (adapter == null || client == null || paneId == null) return;
+
+    state = state.copyWith(isBusy: true, error: null, notice: null);
+    final context = AgentContext(
+      ssh: client,
+      paneId: paneId,
+      paneWorkingDirectory: state.agentPanePath,
+    );
+    try {
+      final message = await action(adapter, context);
+      // Re-read the effective config best effort; a failed re-read must
+      // not mask the successful apply.
+      var config = state.config;
+      try {
+        config = await adapter.readConfig(context);
+      } on Object {
+        // Keep the previous snapshot.
+      }
+      state = state.copyWith(isBusy: false, notice: message, config: config);
+    } on Object catch (e) {
+      state = state.copyWith(isBusy: false, error: '$e');
+    }
+  }
+}
+
+/// Provider for the Remote UI tab.
+final remoteUiProvider =
+    NotifierProvider<RemoteUiNotifier, RemoteUiState>(RemoteUiNotifier.new);

--- a/lib/screens/connections/connections_screen.dart
+++ b/lib/screens/connections/connections_screen.dart
@@ -7,6 +7,7 @@ import 'package:google_fonts/google_fonts.dart';
 import '../../providers/active_session_provider.dart';
 import '../../providers/connection_provider.dart';
 import '../home_screen.dart';
+import '../home_tab_index.dart';
 import '../../services/keychain/secure_storage.dart';
 import '../../services/ssh/ssh_client.dart';
 import '../../services/tmux/tmux_commands.dart';
@@ -133,8 +134,7 @@ class ConnectionsScreen extends ConsumerWidget {
   }
 
   void _openSettings(BuildContext context, WidgetRef ref) {
-    // 設定タブ（インデックス3）に切り替え
-    ref.read(currentTabProvider.notifier).setTab(3);
+    ref.read(currentTabProvider.notifier).setTab(HomeTabIndex.settings);
   }
 
   void _showSortDialog(BuildContext context, WidgetRef ref) {

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -12,14 +12,17 @@ import 'connections/connections_screen.dart';
 import 'dashboard/dashboard_screen.dart';
 import 'keys/keys_screen.dart';
 import 'notifications/notification_panes_screen.dart';
+import 'remote_ui/remote_ui_screen.dart';
 import 'settings/settings_screen.dart';
 import 'terminal/terminal_screen.dart';
+import 'home_tab_index.dart';
 
 /// 現在のタブインデックス Notifier
-/// タブ順序: 0=Servers, 1=Keys, 2=Dashboard, 3=Notify, 4=Settings
+/// タブ順序:
+/// 0=Servers, 1=Keys, 2=Dashboard, 3=Remote UI, 4=Notify, 5=Settings
 class CurrentTabNotifier extends Notifier<int> {
   @override
-  int build() => 2; // Dashboard（中央）をデフォルトに
+  int build() => HomeTabIndex.dashboard; // Dashboard（中央）をデフォルトに
 
   void setTab(int index) => state = index;
 }
@@ -29,7 +32,7 @@ final currentTabProvider = NotifierProvider<CurrentTabNotifier, int>(
 );
 
 /// ホーム画面（Bottom Navigation付き）
-/// タブ順序: Servers | Keys | [Dashboard] | Notify | Settings
+/// タブ順序: Servers | Keys | [Dashboard] | Remote UI | Notify | Settings
 class HomeScreen extends ConsumerWidget {
   const HomeScreen({super.key});
 
@@ -44,8 +47,9 @@ class HomeScreen extends ConsumerWidget {
           ConnectionsScreen(),        // 0: Servers
           KeysScreen(),               // 1: Keys
           DashboardScreen(),          // 2: Dashboard（中央）
-          NotificationPanesScreen(),  // 3: Alerts
-          SettingsScreen(),           // 4: Settings
+          RemoteUiScreen(),           // 3: Remote UI
+          NotificationPanesScreen(),  // 4: Alerts
+          SettingsScreen(),           // 5: Settings
         ],
       ),
       bottomNavigationBar: _buildBottomNavigationBar(context, ref, currentTab),
@@ -77,46 +81,64 @@ class HomeScreen extends ConsumerWidget {
             children: [
               // 通常のナビゲーションアイテム（5つ均等配置）
               Row(
-                mainAxisAlignment: MainAxisAlignment.spaceAround,
                 crossAxisAlignment: CrossAxisAlignment.end,
                 children: [
                   // Servers（左端）
-                  _buildNavItem(
-                    context,
-                    ref,
-                    index: 0,
-                    icon: Icons.dns,
-                    label: 'Servers',
-                    isSelected: currentTab == 0,
+                  Expanded(
+                    child: _buildNavItem(
+                      context,
+                      ref,
+                      index: HomeTabIndex.servers,
+                      icon: Icons.dns,
+                      label: 'Servers',
+                      isSelected: currentTab == HomeTabIndex.servers,
+                    ),
                   ),
                   // Keys（左寄り）
-                  _buildNavItem(
-                    context,
-                    ref,
-                    index: 1,
-                    icon: Icons.key,
-                    label: 'Keys',
-                    isSelected: currentTab == 1,
+                  Expanded(
+                    child: _buildNavItem(
+                      context,
+                      ref,
+                      index: HomeTabIndex.keys,
+                      icon: Icons.key,
+                      label: 'Keys',
+                      isSelected: currentTab == HomeTabIndex.keys,
+                    ),
                   ),
                   // 中央スペーサー（Dashboardボタンの場所）
                   const SizedBox(width: 64),
-                  // Notify（右寄り）
-                  _buildNavItem(
-                    context,
-                    ref,
-                    index: 3,
-                    icon: Icons.notifications_outlined,
-                    label: 'Notify',
-                    isSelected: currentTab == 3,
+                  // Remote UI（右寄り1）
+                  Expanded(
+                    child: _buildNavItem(
+                      context,
+                      ref,
+                      index: HomeTabIndex.remoteUi,
+                      icon: Icons.chat_bubble_outline,
+                      label: 'Remote UI',
+                      isSelected: currentTab == HomeTabIndex.remoteUi,
+                    ),
+                  ),
+                  // Notify（右寄り2）
+                  Expanded(
+                    child: _buildNavItem(
+                      context,
+                      ref,
+                      index: HomeTabIndex.notifications,
+                      icon: Icons.notifications_outlined,
+                      label: 'Notify',
+                      isSelected: currentTab == HomeTabIndex.notifications,
+                    ),
                   ),
                   // Settings（右端）
-                  _buildNavItem(
-                    context,
-                    ref,
-                    index: 4,
-                    icon: Icons.settings,
-                    label: 'Settings',
-                    isSelected: currentTab == 4,
+                  Expanded(
+                    child: _buildNavItem(
+                      context,
+                      ref,
+                      index: HomeTabIndex.settings,
+                      icon: Icons.settings,
+                      label: 'Settings',
+                      isSelected: currentTab == HomeTabIndex.settings,
+                    ),
                   ),
                 ],
               ),
@@ -205,7 +227,9 @@ class HomeScreen extends ConsumerWidget {
       onTap: () => ref.read(currentTabProvider.notifier).setTab(index),
       behavior: HitTestBehavior.opaque,
       child: SizedBox(
-        width: 56,
+        // No fixed width: the parent Row wraps items in Expanded so the
+        // bar fits narrow screens (foldables, split-screen) without
+        // overflowing now that there are six tabs.
         child: Padding(
           padding: const EdgeInsets.only(bottom: 8),
           child: Column(
@@ -350,7 +374,7 @@ class _TerminalTabState extends ConsumerState<_TerminalTab> {
             Icons.settings,
             color: isDark ? DesignColors.textSecondary : DesignColors.textSecondaryLight,
           ),
-          onPressed: () => ref.read(currentTabProvider.notifier).setTab(3),
+          onPressed: () => ref.read(currentTabProvider.notifier).setTab(HomeTabIndex.settings),
           tooltip: 'Settings',
         ),
         const SizedBox(width: 8),

--- a/lib/screens/home_tab_index.dart
+++ b/lib/screens/home_tab_index.dart
@@ -1,0 +1,13 @@
+/// Home screen tab indices.
+///
+/// Keep all cross-screen tab switches using these constants instead of
+/// hard-coded integers. This avoids breakage when tabs are reordered or
+/// new tabs (like Remote UI) are added.
+abstract final class HomeTabIndex {
+  static const int servers = 0;
+  static const int keys = 1;
+  static const int dashboard = 2;
+  static const int remoteUi = 3;
+  static const int notifications = 4;
+  static const int settings = 5;
+}

--- a/lib/screens/keys/keys_screen.dart
+++ b/lib/screens/keys/keys_screen.dart
@@ -6,6 +6,7 @@ import 'package:google_fonts/google_fonts.dart';
 import '../../providers/key_provider.dart';
 import '../../theme/design_colors.dart';
 import '../home_screen.dart';
+import '../home_tab_index.dart';
 import 'key_generate_screen.dart';
 import 'key_import_screen.dart';
 import 'widgets/key_tile.dart';
@@ -66,7 +67,7 @@ class KeysScreen extends ConsumerWidget {
             Icons.settings,
             color: isDark ? DesignColors.textSecondary : DesignColors.textSecondaryLight,
           ),
-          onPressed: () => ref.read(currentTabProvider.notifier).setTab(3),
+          onPressed: () => ref.read(currentTabProvider.notifier).setTab(HomeTabIndex.settings),
           tooltip: 'Settings',
         ),
         const SizedBox(width: 8),

--- a/lib/screens/remote_ui/remote_ui_model_intelligence_sheet.dart
+++ b/lib/screens/remote_ui/remote_ui_model_intelligence_sheet.dart
@@ -1,0 +1,151 @@
+import 'package:flutter/material.dart';
+
+import '../../services/agent/agent_types.dart';
+import 'remote_ui_model_picker_sheet.dart';
+
+/// The values chosen in [RemoteUiModelIntelligenceSheet].
+///
+/// Null fields mean "agent default" (shown as `Auto` in the UI); the
+/// caller decides how to apply them (live-pane apply vs. pending chat
+/// configuration).
+class RemoteUiModelIntelligenceSelection {
+  /// Chosen model id, null for the agent default.
+  final String? model;
+
+  /// Chosen reasoning effort, null when the agent has no effort control
+  /// or none was chosen.
+  final UnifiedIntelligence? intelligence;
+
+  const RemoteUiModelIntelligenceSelection({this.model, this.intelligence});
+}
+
+/// Bottom sheet combining the reasoning-effort options with an entry
+/// point to the model picker.
+class RemoteUiModelIntelligenceSheet {
+  RemoteUiModelIntelligenceSheet._();
+
+  /// Shows the sheet.
+  ///
+  /// [intelligenceLevels] lists the selectable effort levels (from the
+  /// agent's capabilities); when empty the Intelligence section is
+  /// hidden. [availableModels] is forwarded to [RemoteUiModelPickerSheet]
+  /// (empty means free-text model entry).
+  static Future<RemoteUiModelIntelligenceSelection?> show(
+    BuildContext context, {
+    required String? selectedModel,
+    required UnifiedIntelligence? selectedIntelligence,
+    List<UnifiedIntelligence> intelligenceLevels = const [],
+    List<String> availableModels = const [],
+  }) {
+    return showModalBottomSheet<RemoteUiModelIntelligenceSelection>(
+      context: context,
+      isScrollControlled: true,
+      showDragHandle: true,
+      builder: (context) => _RemoteUiModelIntelligenceSheetContent(
+        selectedModel: selectedModel,
+        selectedIntelligence: selectedIntelligence,
+        intelligenceLevels: intelligenceLevels,
+        availableModels: availableModels,
+      ),
+    );
+  }
+}
+
+class _RemoteUiModelIntelligenceSheetContent extends StatefulWidget {
+  final String? selectedModel;
+  final UnifiedIntelligence? selectedIntelligence;
+  final List<UnifiedIntelligence> intelligenceLevels;
+  final List<String> availableModels;
+
+  const _RemoteUiModelIntelligenceSheetContent({
+    required this.selectedModel,
+    required this.selectedIntelligence,
+    required this.intelligenceLevels,
+    required this.availableModels,
+  });
+
+  @override
+  State<_RemoteUiModelIntelligenceSheetContent> createState() =>
+      _RemoteUiModelIntelligenceSheetContentState();
+}
+
+class _RemoteUiModelIntelligenceSheetContentState
+    extends State<_RemoteUiModelIntelligenceSheetContent> {
+  String? _model;
+  UnifiedIntelligence? _intelligence;
+
+  @override
+  void initState() {
+    super.initState();
+    _model = widget.selectedModel;
+    _intelligence = widget.selectedIntelligence;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final levels = widget.intelligenceLevels;
+    return SafeArea(
+      child: ListView(
+        shrinkWrap: true,
+        padding: const EdgeInsets.only(bottom: 8),
+        children: [
+          if (levels.isNotEmpty) ...[
+            const Padding(
+              padding: EdgeInsets.fromLTRB(16, 6, 16, 8),
+              child: Text(
+                'Intelligence',
+                style: TextStyle(fontSize: 16, fontWeight: FontWeight.w700),
+              ),
+            ),
+            for (final level in levels)
+              ListTile(
+                title: Text(level.label),
+                trailing:
+                    level == _intelligence ? const Icon(Icons.check) : null,
+                onTap: () => Navigator.pop(
+                  context,
+                  RemoteUiModelIntelligenceSelection(
+                    model: _model,
+                    intelligence: level,
+                  ),
+                ),
+              ),
+            const Divider(height: 1),
+          ],
+          const Padding(
+            padding: EdgeInsets.fromLTRB(16, 14, 16, 8),
+            child: Text(
+              'Model',
+              style: TextStyle(fontSize: 16, fontWeight: FontWeight.w700),
+            ),
+          ),
+          ListTile(
+            title: const Text('Model'),
+            subtitle: Text(_model ?? 'Auto'),
+            trailing: const Icon(Icons.chevron_right),
+            onTap: _pickModel,
+          ),
+          const SizedBox(height: 8),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _pickModel() async {
+    final model = await RemoteUiModelPickerSheet.show(
+      context,
+      selectedModel: _model,
+      availableModels: widget.availableModels,
+    );
+    if (!mounted || model == null) return;
+    // Pop this sheet too so the model choice is applied immediately
+    // instead of being lost when the sheet is dismissed later.
+    Navigator.pop(
+      context,
+      RemoteUiModelIntelligenceSelection(
+        model: model,
+        intelligence: _intelligence,
+      ),
+    );
+  }
+}

--- a/lib/screens/remote_ui/remote_ui_model_picker_sheet.dart
+++ b/lib/screens/remote_ui/remote_ui_model_picker_sheet.dart
@@ -1,0 +1,135 @@
+import 'package:flutter/material.dart';
+
+/// Bottom sheet picking the model id for an agent.
+///
+/// With a non-empty `availableModels` list the options are shown with a
+/// checkmark on the current selection. An empty list means the agent
+/// accepts free-text model ids (see `AgentCapabilities.availableModels`),
+/// so a text field is shown instead.
+class RemoteUiModelPickerSheet {
+  RemoteUiModelPickerSheet._();
+
+  /// Shows the sheet and returns the chosen model id, or null when the
+  /// sheet is dismissed without a choice.
+  static Future<String?> show(
+    BuildContext context, {
+    required String? selectedModel,
+    List<String> availableModels = const [],
+  }) {
+    return showModalBottomSheet<String>(
+      context: context,
+      showDragHandle: true,
+      isScrollControlled: true,
+      builder: (context) => availableModels.isEmpty
+          ? _FreeTextModelPicker(initialModel: selectedModel)
+          : _ModelListPicker(
+              selectedModel: selectedModel,
+              availableModels: availableModels,
+            ),
+    );
+  }
+}
+
+class _ModelListPicker extends StatelessWidget {
+  final String? selectedModel;
+  final List<String> availableModels;
+
+  const _ModelListPicker({
+    required this.selectedModel,
+    required this.availableModels,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: ListView(
+        shrinkWrap: true,
+        children: [
+          const Padding(
+            padding: EdgeInsets.fromLTRB(16, 6, 16, 8),
+            child: Text(
+              'Model',
+              style: TextStyle(fontSize: 16, fontWeight: FontWeight.w700),
+            ),
+          ),
+          for (final model in availableModels)
+            ListTile(
+              title: Text(model),
+              trailing:
+                  model == selectedModel ? const Icon(Icons.check) : null,
+              onTap: () => Navigator.pop(context, model),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _FreeTextModelPicker extends StatefulWidget {
+  final String? initialModel;
+
+  const _FreeTextModelPicker({required this.initialModel});
+
+  @override
+  State<_FreeTextModelPicker> createState() => _FreeTextModelPickerState();
+}
+
+class _FreeTextModelPickerState extends State<_FreeTextModelPicker> {
+  late final TextEditingController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = TextEditingController(text: widget.initialModel);
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _submit() {
+    final value = _controller.text.trim();
+    if (value.isEmpty) return;
+    Navigator.pop(context, value);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: Padding(
+        // Lift the field above the software keyboard.
+        padding: EdgeInsets.only(
+          bottom: MediaQuery.viewInsetsOf(context).bottom,
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Padding(
+              padding: EdgeInsets.fromLTRB(16, 6, 16, 8),
+              child: Text(
+                'Model',
+                style: TextStyle(fontSize: 16, fontWeight: FontWeight.w700),
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+              child: TextField(
+                controller: _controller,
+                autofocus: true,
+                textInputAction: TextInputAction.done,
+                decoration: const InputDecoration(
+                  hintText: 'Model id or name',
+                  isDense: true,
+                ),
+                onSubmitted: (_) => _submit(),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/remote_ui/remote_ui_permission_sheet.dart
+++ b/lib/screens/remote_ui/remote_ui_permission_sheet.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+
+import '../../services/agent/agent_types.dart';
+
+/// Bottom sheet picking the agent's autonomy/permission level.
+class RemoteUiPermissionSheet {
+  RemoteUiPermissionSheet._();
+
+  /// Shows the sheet with [permissions] (from the agent's capabilities)
+  /// and returns the chosen level, or null when the sheet is dismissed.
+  static Future<UnifiedPermission?> show(
+    BuildContext context, {
+    required UnifiedPermission? selected,
+    required List<UnifiedPermission> permissions,
+  }) {
+    return showModalBottomSheet<UnifiedPermission>(
+      context: context,
+      isScrollControlled: true,
+      showDragHandle: true,
+      builder: (context) => SafeArea(
+        child: ListView(
+          shrinkWrap: true,
+          padding: const EdgeInsets.only(bottom: 8),
+          children: [
+            const Padding(
+              padding: EdgeInsets.fromLTRB(16, 6, 16, 8),
+              child: Text(
+                'Permissions',
+                style: TextStyle(fontSize: 16, fontWeight: FontWeight.w700),
+              ),
+            ),
+            for (final permission in permissions)
+              ListTile(
+                title: Text(permission.label),
+                subtitle: Text(permission.description),
+                trailing:
+                    permission == selected ? const Icon(Icons.check) : null,
+                onTap: () => Navigator.pop(context, permission),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/remote_ui/remote_ui_plus_menu_sheet.dart
+++ b/lib/screens/remote_ui/remote_ui_plus_menu_sheet.dart
@@ -1,0 +1,91 @@
+import 'package:flutter/material.dart';
+
+/// The composer's "+" menu: photo upload and plan mode.
+///
+/// Actions are delivered through callbacks (instead of a result object)
+/// so a plan-mode toggle applies even when the sheet is dismissed by a
+/// barrier tap afterwards.
+class RemoteUiPlusMenuSheet {
+  RemoteUiPlusMenuSheet._();
+
+  /// Shows the menu.
+  ///
+  /// [planModeSupported] disables the plan-mode switch with an
+  /// explanation when the current agent has no plan/spec mode.
+  /// [onUploadPhoto] runs after the sheet has closed.
+  static Future<void> show(
+    BuildContext context, {
+    required bool planModeEnabled,
+    required bool planModeSupported,
+    required ValueChanged<bool> onPlanModeChanged,
+    required VoidCallback onUploadPhoto,
+  }) {
+    return showModalBottomSheet<void>(
+      context: context,
+      showDragHandle: true,
+      builder: (context) => _RemoteUiPlusMenuSheetContent(
+        planModeEnabled: planModeEnabled,
+        planModeSupported: planModeSupported,
+        onPlanModeChanged: onPlanModeChanged,
+        onUploadPhoto: onUploadPhoto,
+      ),
+    );
+  }
+}
+
+class _RemoteUiPlusMenuSheetContent extends StatefulWidget {
+  final bool planModeEnabled;
+  final bool planModeSupported;
+  final ValueChanged<bool> onPlanModeChanged;
+  final VoidCallback onUploadPhoto;
+
+  const _RemoteUiPlusMenuSheetContent({
+    required this.planModeEnabled,
+    required this.planModeSupported,
+    required this.onPlanModeChanged,
+    required this.onUploadPhoto,
+  });
+
+  @override
+  State<_RemoteUiPlusMenuSheetContent> createState() =>
+      _RemoteUiPlusMenuSheetContentState();
+}
+
+class _RemoteUiPlusMenuSheetContentState
+    extends State<_RemoteUiPlusMenuSheetContent> {
+  late bool _planModeEnabled = widget.planModeEnabled;
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: ListView(
+        shrinkWrap: true,
+        padding: const EdgeInsets.only(bottom: 8),
+        children: [
+          ListTile(
+            leading: const Icon(Icons.photo_outlined),
+            title: const Text('Upload photo'),
+            onTap: () {
+              Navigator.pop(context);
+              widget.onUploadPhoto();
+            },
+          ),
+          SwitchListTile(
+            secondary: const Icon(Icons.rule_folder_outlined),
+            title: const Text('Plan mode'),
+            subtitle: widget.planModeSupported
+                ? null
+                : const Text('Not supported by this agent'),
+            value: _planModeEnabled,
+            onChanged: widget.planModeSupported
+                ? (value) {
+                    setState(() => _planModeEnabled = value);
+                    widget.onPlanModeChanged(value);
+                  }
+                : null,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/remote_ui/remote_ui_screen.dart
+++ b/lib/screens/remote_ui/remote_ui_screen.dart
@@ -1,0 +1,941 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:image_picker/image_picker.dart';
+
+import '../../providers/connection_provider.dart';
+import '../../providers/remote_ui_chat_provider.dart';
+import '../../providers/remote_ui_provider.dart';
+import '../../services/agent/agent_types.dart';
+import '../../services/agent/headless/chat_session_store.dart';
+import '../../services/sftp/sftp_service.dart';
+import '../../theme/design_colors.dart';
+import 'remote_ui_model_intelligence_sheet.dart';
+import 'remote_ui_permission_sheet.dart';
+import 'remote_ui_plus_menu_sheet.dart';
+import 'remote_ui_sessions_sheet.dart';
+
+/// Remote UI tab: a Codex-app-style chat screen that controls AI CLI
+/// agents (Claude Code, Codex CLI, Factory Droid) over SSH.
+///
+/// The screen is dual-mode:
+///
+/// - Live-pane mode: an agent process was detected in a tmux pane of the
+///   connected server (`RemoteUiState.agent` != null). The chips show the
+///   live agent configuration and apply changes through
+///   [remoteUiProvider].
+/// - Chat mode: no agent process detected. An agent picker chooses the
+///   headless agent and the chips edit
+///   `RemoteUiChatState.pendingConfig`; the options come from the
+///   selected agent's capabilities.
+///
+/// The composer always talks to the headless chat path
+/// ([remoteUiChatProvider]).
+class RemoteUiScreen extends ConsumerStatefulWidget {
+  const RemoteUiScreen({super.key});
+
+  @override
+  ConsumerState<RemoteUiScreen> createState() => _RemoteUiScreenState();
+}
+
+class _RemoteUiScreenState extends ConsumerState<RemoteUiScreen> {
+  static const _modelChipKey = Key('remote_ui.model_chip');
+  static const _permissionChipKey = Key('remote_ui.permission_chip');
+  static const _plusButtonKey = Key('remote_ui.plus_button');
+  static const _sendButtonKey = Key('remote_ui.send_button');
+  static const _stopButtonKey = Key('remote_ui.stop_button');
+  static const _composerKey = Key('remote_ui.composer');
+  static const _agentPickerKey = Key('remote_ui.agent_picker');
+  static const _historyButtonKey = Key('remote_ui.history_button');
+  static const _newChatButtonKey = Key('remote_ui.new_chat_button');
+  static const _messageListKey = Key('remote_ui.message_list');
+  static const _streamingBubbleKey = Key('remote_ui.streaming_bubble');
+
+  /// Maximum length of the session title derived from the first user
+  /// message (mirrors `ChatSessionStore`'s title truncation).
+  static const _titleMaxLength = 40;
+
+  final _composerController = TextEditingController();
+  final _scrollController = ScrollController();
+  final _imagePicker = ImagePicker();
+  final _sftpService = SftpService();
+
+  @override
+  void dispose() {
+    _composerController.dispose();
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // Live-pane confirmations/errors.
+    ref.listen<RemoteUiState>(remoteUiProvider, (prev, next) {
+      final notice = next.notice;
+      final error = next.error;
+      if (!mounted) return;
+      if (notice != null && notice.isNotEmpty && notice != prev?.notice) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(notice)),
+        );
+        ref.read(remoteUiProvider.notifier).clearMessages();
+      } else if (error != null && error.isNotEmpty && error != prev?.error) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(error)),
+        );
+        ref.read(remoteUiProvider.notifier).clearMessages();
+      }
+    });
+
+    // Chat errors and auto-scroll on new content.
+    ref.listen<RemoteUiChatState>(remoteUiChatProvider, (prev, next) {
+      final error = next.error;
+      if (mounted && error != null && error.isNotEmpty && error != prev?.error) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(error)),
+        );
+        ref.read(remoteUiChatProvider.notifier).clearError();
+      }
+      if (next.messages.length != prev?.messages.length ||
+          next.streamingText != prev?.streamingText) {
+        _scrollToBottom();
+      }
+    });
+
+    final remote = ref.watch(remoteUiProvider);
+    final chat = ref.watch(remoteUiChatProvider);
+    final chatNotifier = ref.read(remoteUiChatProvider.notifier);
+    final connections = ref.watch(connectionsProvider).connections;
+
+    final liveAgent = remote.agent;
+    final isLiveMode = liveAgent != null;
+    final capabilities =
+        isLiveMode ? liveAgent.capabilities : chatNotifier.capabilities;
+    final effectiveConfig = isLiveMode ? remote.config : chat.pendingConfig;
+
+    final targetLabel = connections
+            .where((c) => c.id == remote.connectionId)
+            .firstOrNull
+            ?.name ??
+        'Select a server';
+
+    final hasChatContent = chat.messages.isNotEmpty ||
+        chat.streamingText.isNotEmpty ||
+        chat.isStreaming;
+
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final border = isDark ? DesignColors.borderDark : DesignColors.borderLight;
+
+    return Scaffold(
+      body: SafeArea(
+        child: Column(
+          children: [
+            _buildAppBarRow(context, chat),
+            Expanded(
+              child: hasChatContent
+                  ? _buildMessageList(context, chat)
+                  : _buildEmptyState(
+                      context,
+                      remote: remote,
+                      chat: chat,
+                      isLiveMode: isLiveMode,
+                      targetLabel: targetLabel,
+                    ),
+            ),
+            _buildComposer(
+              context,
+              chat: chat,
+              config: effectiveConfig,
+              showPermissionChip: capabilities.permissionLevels.isNotEmpty,
+              borderColor: border,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  // ===== App-bar row (sessions) =====
+
+  Widget _buildAppBarRow(BuildContext context, RemoteUiChatState chat) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 4),
+      child: Row(
+        children: [
+          IconButton(
+            key: _historyButtonKey,
+            icon: const Icon(Icons.history),
+            tooltip: 'Chat history',
+            onPressed: _openSessionsSheet,
+          ),
+          Expanded(
+            child: Text(
+              _sessionTitle(chat),
+              style: Theme.of(context).textTheme.titleMedium,
+              textAlign: TextAlign.center,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+          IconButton(
+            key: _newChatButtonKey,
+            icon: const Icon(Icons.add),
+            tooltip: 'New chat',
+            onPressed: () =>
+                ref.read(remoteUiChatProvider.notifier).newSession(),
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// Title shown in the app-bar row: the stored session title when
+  /// known, otherwise the first user message, otherwise "New chat".
+  String _sessionTitle(RemoteUiChatState chat) {
+    final activeId = chat.activeSessionId;
+    if (activeId != null) {
+      final session =
+          chat.sessions.where((s) => s.id == activeId).firstOrNull;
+      if (session != null && session.title.isNotEmpty) return session.title;
+    }
+    final firstUser =
+        chat.messages.where((m) => m.role == ChatRole.user).firstOrNull;
+    if (firstUser != null) {
+      final firstLine = firstUser.text.trim().split('\n').first;
+      if (firstLine.isNotEmpty) {
+        return firstLine.length <= _titleMaxLength
+            ? firstLine
+            : '${firstLine.substring(0, _titleMaxLength)}…';
+      }
+    }
+    return 'New chat';
+  }
+
+  Future<void> _openSessionsSheet() async {
+    final chat = ref.read(remoteUiChatProvider);
+    await RemoteUiSessionsSheet.show(
+      context,
+      sessions: chat.sessions,
+      activeSessionId: chat.activeSessionId,
+      onOpenSession: (sessionId) =>
+          ref.read(remoteUiChatProvider.notifier).openSession(sessionId),
+      onClearHistory: _confirmClearHistory,
+    );
+  }
+
+  Future<void> _confirmClearHistory() async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: const Text('Clear history?'),
+        content: const Text(
+          'This deletes all chat sessions for this server and agent.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(dialogContext, false),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(dialogContext, true),
+            style: TextButton.styleFrom(foregroundColor: DesignColors.error),
+            child: const Text('Clear'),
+          ),
+        ],
+      ),
+    );
+    if (!mounted || confirmed != true) return;
+    await ref.read(remoteUiChatProvider.notifier).clearHistory();
+  }
+
+  // ===== Empty state ("Let's work on …") =====
+
+  Widget _buildEmptyState(
+    BuildContext context, {
+    required RemoteUiState remote,
+    required RemoteUiChatState chat,
+    required bool isLiveMode,
+    required String targetLabel,
+  }) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final textMuted =
+        isDark ? DesignColors.textMuted : DesignColors.textMutedLight;
+
+    final String infoText;
+    if (isLiveMode) {
+      infoText = 'Detected: ${remote.agent!.kind.displayName} '
+          '(pane ${remote.agentPaneId ?? '-'})';
+    } else if (remote.connectionId == null) {
+      infoText = 'Connect to a server to control Codex, Claude, or Droid.';
+    } else {
+      infoText = 'No agent process detected in tmux panes. Chat runs '
+          '${chat.agentKind.displayName} headlessly on this server.';
+    }
+
+    return SingleChildScrollView(
+      padding: const EdgeInsets.fromLTRB(24, 24, 24, 24),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          const SizedBox(height: 40),
+          Text(
+            "Let's work on",
+            style: Theme.of(context).textTheme.headlineMedium?.copyWith(
+                  fontWeight: FontWeight.w700,
+                  letterSpacing: -0.5,
+                ),
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 12),
+          _TargetPickerRow(
+            label: targetLabel,
+            onTap: _pickServer,
+          ),
+          const SizedBox(height: 18),
+          SegmentedButton<bool>(
+            segments: const [
+              ButtonSegment(value: false, label: Text('Workspace')),
+              ButtonSegment(value: true, label: Text('Worktree')),
+            ],
+            selected: {chat.worktreeMode},
+            showSelectedIcon: false,
+            onSelectionChanged: (selection) => ref
+                .read(remoteUiChatProvider.notifier)
+                .setWorktreeMode(selection.first),
+          ),
+          // Chat mode only: pick which agent the headless chat runs on.
+          if (!isLiveMode) ...[
+            const SizedBox(height: 18),
+            _TargetPickerRow(
+              key: _agentPickerKey,
+              label: chat.agentKind.displayName,
+              icon: Icons.smart_toy_outlined,
+              onTap: _openAgentPicker,
+            ),
+          ],
+          const SizedBox(height: 56),
+          Text(
+            infoText,
+            style:
+                Theme.of(context).textTheme.bodyMedium?.copyWith(color: textMuted),
+            textAlign: TextAlign.center,
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _pickServer() async {
+    final selected = await _showServerPicker(context);
+    if (selected == null || !mounted) return;
+    final previousConnectionId = ref.read(remoteUiProvider).connectionId;
+    await ref.read(remoteUiProvider.notifier).selectServer(selected.id);
+    if (!mounted) return;
+    // Sessions are stored per (connection, agent): switching servers must
+    // drop the previous server's active session (its id is unknown to the
+    // new server's store, so messages would silently fail to persist),
+    // then load the new server's history.
+    if (previousConnectionId != selected.id) {
+      await ref.read(remoteUiChatProvider.notifier).newSession();
+    }
+    await ref.read(remoteUiChatProvider.notifier).loadSessions();
+  }
+
+  Future<void> _openAgentPicker() async {
+    final currentKind = ref.read(remoteUiChatProvider).agentKind;
+    final selected = await showModalBottomSheet<AgentKind>(
+      context: context,
+      showDragHandle: true,
+      builder: (sheetContext) => SafeArea(
+        child: ListView(
+          shrinkWrap: true,
+          children: [
+            const Padding(
+              padding: EdgeInsets.fromLTRB(16, 6, 16, 8),
+              child: Text(
+                'Agent',
+                style: TextStyle(fontSize: 16, fontWeight: FontWeight.w700),
+              ),
+            ),
+            for (final kind in AgentKind.values)
+              ListTile(
+                title: Text(kind.displayName),
+                trailing:
+                    kind == currentKind ? const Icon(Icons.check) : null,
+                onTap: () => Navigator.pop(sheetContext, kind),
+              ),
+          ],
+        ),
+      ),
+    );
+    if (!mounted || selected == null) return;
+    await ref.read(remoteUiChatProvider.notifier).selectAgent(selected);
+  }
+
+  // ===== Message list =====
+
+  Widget _buildMessageList(BuildContext context, RemoteUiChatState chat) {
+    final showStreaming = chat.isStreaming || chat.streamingText.isNotEmpty;
+    return ListView.builder(
+      key: _messageListKey,
+      controller: _scrollController,
+      padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
+      itemCount: chat.messages.length + (showStreaming ? 1 : 0),
+      itemBuilder: (context, index) {
+        if (index >= chat.messages.length) {
+          return _StreamingBubble(
+            key: _streamingBubbleKey,
+            text: chat.streamingText,
+          );
+        }
+        final message = chat.messages[index];
+        return switch (message.role) {
+          ChatRole.user => _UserMessageBubble(text: message.text),
+          ChatRole.assistant => _AssistantMessageText(text: message.text),
+        };
+      },
+    );
+  }
+
+  void _scrollToBottom() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted || !_scrollController.hasClients) return;
+      _scrollController.animateTo(
+        _scrollController.position.maxScrollExtent,
+        duration: const Duration(milliseconds: 200),
+        curve: Curves.easeOut,
+      );
+    });
+  }
+
+  // ===== Composer =====
+
+  Widget _buildComposer(
+    BuildContext context, {
+    required RemoteUiChatState chat,
+    required AgentConfig config,
+    required bool showPermissionChip,
+    required Color borderColor,
+  }) {
+    return Container(
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surface,
+        border: Border(top: BorderSide(color: borderColor)),
+      ),
+      padding: const EdgeInsets.fromLTRB(16, 12, 16, 16),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Row(
+            children: [
+              _PillChip(
+                key: _modelChipKey,
+                label: _modelChipLabel(config),
+                icon: Icons.auto_awesome_outlined,
+                onTap: _openModelAndIntelligenceSheet,
+              ),
+              if (showPermissionChip) ...[
+                const SizedBox(width: 10),
+                _PillChip(
+                  key: _permissionChipKey,
+                  label: config.permission?.label ?? 'Permissions',
+                  icon: Icons.lock_outline,
+                  onTap: _openPermissionSheet,
+                ),
+              ],
+              const Spacer(),
+            ],
+          ),
+          const SizedBox(height: 10),
+          Row(
+            children: [
+              IconButton(
+                key: _plusButtonKey,
+                onPressed: _openPlusMenu,
+                icon: const Icon(Icons.add),
+                tooltip: 'More',
+              ),
+              Expanded(
+                child: TextField(
+                  key: _composerKey,
+                  controller: _composerController,
+                  textInputAction: TextInputAction.send,
+                  minLines: 1,
+                  maxLines: 4,
+                  decoration: const InputDecoration(
+                    hintText: 'What should we code next?',
+                    isDense: true,
+                  ),
+                  onSubmitted: (_) => _send(),
+                ),
+              ),
+              const SizedBox(width: 4),
+              if (chat.isStreaming)
+                IconButton(
+                  key: _stopButtonKey,
+                  onPressed: () =>
+                      ref.read(remoteUiChatProvider.notifier).cancel(),
+                  icon: const Icon(Icons.stop_circle_outlined),
+                  tooltip: 'Stop',
+                )
+              else
+                IconButton(
+                  key: _sendButtonKey,
+                  onPressed: _send,
+                  icon: const Icon(Icons.arrow_upward),
+                  tooltip: 'Send',
+                ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// Chip label: the configured model (or `Auto` when the agent picks
+  /// the default) plus the reasoning-effort label when known.
+  String _modelChipLabel(AgentConfig config) {
+    final model = config.model ?? 'Auto';
+    final intelligence = config.intelligence;
+    return intelligence == null ? model : '$model ${intelligence.label}';
+  }
+
+  void _send() {
+    if (ref.read(remoteUiChatProvider).isStreaming) return;
+    final text = _composerController.text;
+    if (text.trim().isEmpty) return;
+    unawaited(ref.read(remoteUiChatProvider.notifier).send(text));
+    _composerController.clear();
+  }
+
+  // ===== Chip sheets (dual-mode) =====
+
+  Future<void> _openModelAndIntelligenceSheet() async {
+    final remote = ref.read(remoteUiProvider);
+    final agent = remote.agent;
+
+    if (agent != null) {
+      // Live-pane mode: show the running agent's config and apply
+      // changes to it. Unchanged values are not re-applied (applying
+      // can restart the agent, e.g. Codex).
+      final capabilities = agent.capabilities;
+      final result = await RemoteUiModelIntelligenceSheet.show(
+        context,
+        selectedModel: remote.config.model,
+        selectedIntelligence: remote.config.intelligence,
+        intelligenceLevels: capabilities.intelligenceLevels,
+        availableModels: capabilities.availableModels,
+      );
+      if (!mounted || result == null) return;
+      final notifier = ref.read(remoteUiProvider.notifier);
+      final model = result.model;
+      final intelligence = result.intelligence;
+      if (model != null && model != remote.config.model) {
+        await notifier.applyModel(model);
+      }
+      if (intelligence != null && intelligence != remote.config.intelligence) {
+        await notifier.applyIntelligence(intelligence);
+      }
+      return;
+    }
+
+    // Chat mode: edit the pending headless configuration.
+    final chatNotifier = ref.read(remoteUiChatProvider.notifier);
+    final capabilities = chatNotifier.capabilities;
+    final pending = ref.read(remoteUiChatProvider).pendingConfig;
+    final result = await RemoteUiModelIntelligenceSheet.show(
+      context,
+      selectedModel: pending.model,
+      selectedIntelligence: pending.intelligence,
+      intelligenceLevels: capabilities.intelligenceLevels,
+      availableModels: capabilities.availableModels,
+    );
+    if (!mounted || result == null) return;
+    chatNotifier.setModel(result.model);
+    final intelligence = result.intelligence;
+    if (intelligence != null) {
+      chatNotifier.setIntelligence(intelligence);
+    }
+  }
+
+  Future<void> _openPermissionSheet() async {
+    final remote = ref.read(remoteUiProvider);
+    final agent = remote.agent;
+
+    if (agent != null) {
+      final permission = await RemoteUiPermissionSheet.show(
+        context,
+        selected: remote.config.permission,
+        permissions: agent.capabilities.permissionLevels,
+      );
+      if (!mounted || permission == null) return;
+      if (permission != remote.config.permission) {
+        await ref
+            .read(remoteUiProvider.notifier)
+            .applyPermission(permission);
+      }
+      return;
+    }
+
+    final chatNotifier = ref.read(remoteUiChatProvider.notifier);
+    final permission = await RemoteUiPermissionSheet.show(
+      context,
+      selected: ref.read(remoteUiChatProvider).pendingConfig.permission,
+      permissions: chatNotifier.capabilities.permissionLevels,
+    );
+    if (!mounted || permission == null) return;
+    chatNotifier.setPermission(permission);
+  }
+
+  // ===== "+" menu =====
+
+  Future<void> _openPlusMenu() async {
+    final remote = ref.read(remoteUiProvider);
+    final agent = remote.agent;
+    final chatNotifier = ref.read(remoteUiChatProvider.notifier);
+
+    final planModeEnabled = agent != null
+        ? remote.config.planModeActive
+        : ref.read(remoteUiChatProvider).pendingConfig.planModeActive;
+    final planModeSupported = agent != null
+        ? agent.capabilities.supportsPlanMode
+        : chatNotifier.capabilities.supportsPlanMode;
+
+    await RemoteUiPlusMenuSheet.show(
+      context,
+      planModeEnabled: planModeEnabled,
+      planModeSupported: planModeSupported,
+      onPlanModeChanged: (enabled) {
+        if (agent != null) {
+          unawaited(
+            ref.read(remoteUiProvider.notifier).setPlanMode(enabled),
+          );
+        } else {
+          chatNotifier.setPlanMode(enabled);
+        }
+      },
+      onUploadPhoto: _uploadPhoto,
+    );
+  }
+
+  /// Picks a photo and uploads it to `/tmp` on the connected server via
+  /// SFTP, then inserts the remote path into the composer.
+  Future<void> _uploadPhoto() async {
+    final client = ref.read(remoteUiProvider.notifier).client;
+    if (client == null || !client.isConnected) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Connect to a server first to upload a photo.'),
+        ),
+      );
+      return;
+    }
+
+    final picked = await _imagePicker.pickImage(source: ImageSource.gallery);
+    if (picked == null || !mounted) return;
+
+    try {
+      final bytes = await picked.readAsBytes();
+      final filename = SftpService.generateFilename(
+        'img_',
+        _extensionFromPath(picked.path),
+      );
+      // The SFTP client is cached by SshClient and must not be closed
+      // by the caller.
+      final sftp = await client.openSftp();
+      final result = await _sftpService.upload(
+        sftp: sftp,
+        remoteDir: '/tmp',
+        filename: filename,
+        bytes: bytes,
+      );
+      if (!mounted) return;
+      _insertIntoComposer(result.remotePath);
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Uploaded ${result.remotePath}')),
+      );
+    } on Object catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Photo upload failed: $e')),
+      );
+    }
+  }
+
+  String _extensionFromPath(String path) {
+    final dot = path.lastIndexOf('.');
+    if (dot == -1 || dot == path.length - 1) return 'png';
+    return path.substring(dot + 1).toLowerCase();
+  }
+
+  void _insertIntoComposer(String text) {
+    final current = _composerController.text;
+    final separator =
+        current.isEmpty || current.endsWith(' ') || current.endsWith('\n')
+            ? ''
+            : ' ';
+    final updated = '$current$separator$text';
+    _composerController.value = TextEditingValue(
+      text: updated,
+      selection: TextSelection.collapsed(offset: updated.length),
+    );
+  }
+
+  // ===== Server picker =====
+
+  Future<_ServerPick?> _showServerPicker(BuildContext context) async {
+    final connections = ref.read(connectionsProvider).connections;
+    return showModalBottomSheet<_ServerPick>(
+      context: context,
+      showDragHandle: true,
+      builder: (context) => SafeArea(
+        child: ListView(
+          shrinkWrap: true,
+          children: [
+            const Padding(
+              padding: EdgeInsets.fromLTRB(16, 6, 16, 8),
+              child: Text(
+                'Servers',
+                style: TextStyle(fontSize: 16, fontWeight: FontWeight.w700),
+              ),
+            ),
+            if (connections.isEmpty)
+              const ListTile(
+                title: Text('No servers yet'),
+                subtitle: Text('Add one in the Servers tab first.'),
+              ),
+            for (final c in connections)
+              ListTile(
+                title: Text(c.name),
+                subtitle: Text('${c.username}@${c.host}:${c.port}'),
+                onTap: () =>
+                    Navigator.pop(context, _ServerPick(id: c.id, label: c.name)),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ServerPick {
+  final String id;
+  final String label;
+
+  const _ServerPick({required this.id, required this.label});
+}
+
+/// User chat bubble: right-aligned with the cyan accent color.
+class _UserMessageBubble extends StatelessWidget {
+  final String text;
+
+  const _UserMessageBubble({required this.text});
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return Align(
+      alignment: Alignment.centerRight,
+      child: Container(
+        margin: const EdgeInsets.only(left: 56, top: 4, bottom: 4),
+        padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+        decoration: BoxDecoration(
+          color: colorScheme.primary,
+          borderRadius: BorderRadius.circular(18),
+        ),
+        child: Text(
+          text,
+          style: Theme.of(context)
+              .textTheme
+              .bodyMedium
+              ?.copyWith(color: colorScheme.onPrimary),
+        ),
+      ),
+    );
+  }
+}
+
+/// Assistant reply: left-aligned plain text, no bubble.
+class _AssistantMessageText extends StatelessWidget {
+  final String text;
+
+  const _AssistantMessageText({required this.text});
+
+  @override
+  Widget build(BuildContext context) {
+    return Align(
+      alignment: Alignment.centerLeft,
+      child: Padding(
+        padding: const EdgeInsets.only(right: 56, top: 4, bottom: 4),
+        child: Text(text, style: Theme.of(context).textTheme.bodyMedium),
+      ),
+    );
+  }
+}
+
+/// The in-flight assistant reply with a blinking cursor.
+class _StreamingBubble extends StatefulWidget {
+  final String text;
+
+  const _StreamingBubble({super.key, required this.text});
+
+  @override
+  State<_StreamingBubble> createState() => _StreamingBubbleState();
+}
+
+class _StreamingBubbleState extends State<_StreamingBubble> {
+  Timer? _timer;
+  bool _cursorVisible = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _timer = Timer.periodic(const Duration(milliseconds: 500), (_) {
+      if (mounted) setState(() => _cursorVisible = !_cursorVisible);
+    });
+  }
+
+  @override
+  void dispose() {
+    _timer?.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Align(
+      alignment: Alignment.centerLeft,
+      child: Padding(
+        padding: const EdgeInsets.only(right: 56, top: 4, bottom: 4),
+        child: Text.rich(
+          TextSpan(
+            children: [
+              TextSpan(text: widget.text),
+              TextSpan(
+                text: '▍',
+                style: TextStyle(
+                  color: _cursorVisible
+                      ? DesignColors.primary
+                      : Colors.transparent,
+                ),
+              ),
+            ],
+          ),
+          style: Theme.of(context).textTheme.bodyMedium,
+        ),
+      ),
+    );
+  }
+}
+
+class _PillChip extends StatelessWidget {
+  final String label;
+  final IconData icon;
+  final VoidCallback onTap;
+
+  const _PillChip({
+    super.key,
+    required this.label,
+    required this.icon,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final bg = isDark
+        ? Colors.white.withValues(alpha: 0.08)
+        : Colors.black.withValues(alpha: 0.06);
+    final border = isDark ? DesignColors.borderDark : DesignColors.borderLight;
+    final fg = isDark ? DesignColors.textPrimary : DesignColors.textPrimaryLight;
+
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(999),
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+          decoration: BoxDecoration(
+            color: bg,
+            borderRadius: BorderRadius.circular(999),
+            border: Border.all(color: border),
+          ),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(icon, size: 16, color: fg),
+              const SizedBox(width: 8),
+              Text(
+                label,
+                style:
+                    Theme.of(context).textTheme.labelLarge?.copyWith(color: fg),
+              ),
+              const SizedBox(width: 6),
+              Icon(Icons.expand_more,
+                  size: 18, color: fg.withValues(alpha: 0.8)),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Tappable row used for the server picker and the chat-mode agent
+/// picker.
+class _TargetPickerRow extends StatelessWidget {
+  final String label;
+  final IconData? icon;
+  final VoidCallback onTap;
+
+  const _TargetPickerRow({
+    super.key,
+    required this.label,
+    required this.onTap,
+    this.icon,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final bg = isDark
+        ? Colors.white.withValues(alpha: 0.06)
+        : Colors.black.withValues(alpha: 0.04);
+    final border = isDark ? DesignColors.borderDark : DesignColors.borderLight;
+    final fg = isDark ? DesignColors.textPrimary : DesignColors.textPrimaryLight;
+
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(14),
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+          decoration: BoxDecoration(
+            color: bg,
+            borderRadius: BorderRadius.circular(14),
+            border: Border.all(color: border),
+          ),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              if (icon != null) ...[
+                Icon(icon, size: 18, color: fg.withValues(alpha: 0.85)),
+                const SizedBox(width: 8),
+              ],
+              Text(
+                label,
+                style: Theme.of(context).textTheme.titleMedium,
+              ),
+              const SizedBox(width: 8),
+              Icon(Icons.keyboard_arrow_down,
+                  color: fg.withValues(alpha: 0.85)),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/remote_ui/remote_ui_sessions_sheet.dart
+++ b/lib/screens/remote_ui/remote_ui_sessions_sheet.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+import '../../services/agent/headless/chat_session_store.dart';
+import '../../theme/design_colors.dart';
+
+/// Modal bottom sheet listing the stored chat sessions of the current
+/// (server, agent) pair.
+class RemoteUiSessionsSheet {
+  RemoteUiSessionsSheet._();
+
+  static final _dateFormat = DateFormat.yMMMd().add_Hm();
+
+  /// Shows the sheet.
+  ///
+  /// Actions are delivered through callbacks: [onOpenSession] with the
+  /// tapped session id, and [onClearHistory] when the destructive
+  /// "Clear history" entry is tapped (the caller asks for confirmation
+  /// before clearing). Both run after the sheet has closed.
+  static Future<void> show(
+    BuildContext context, {
+    required List<ChatSessionRecord> sessions,
+    required String? activeSessionId,
+    required ValueChanged<String> onOpenSession,
+    required VoidCallback onClearHistory,
+  }) {
+    return showModalBottomSheet<void>(
+      context: context,
+      showDragHandle: true,
+      isScrollControlled: true,
+      builder: (context) => SafeArea(
+        child: ListView(
+          shrinkWrap: true,
+          padding: const EdgeInsets.only(bottom: 8),
+          children: [
+            const Padding(
+              padding: EdgeInsets.fromLTRB(16, 6, 16, 8),
+              child: Text(
+                'Chats',
+                style: TextStyle(fontSize: 16, fontWeight: FontWeight.w700),
+              ),
+            ),
+            if (sessions.isEmpty)
+              const ListTile(
+                title: Text('No previous chats'),
+                subtitle: Text('Start a new chat below.'),
+              ),
+            for (final session in sessions)
+              ListTile(
+                title: Text(
+                  session.title.isEmpty ? 'New chat' : session.title,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+                subtitle: Text(_dateFormat.format(session.createdAt)),
+                trailing: session.id == activeSessionId
+                    ? const Icon(Icons.check)
+                    : null,
+                onTap: () {
+                  Navigator.pop(context);
+                  onOpenSession(session.id);
+                },
+              ),
+            if (sessions.isNotEmpty) ...[
+              const Divider(height: 1),
+              ListTile(
+                leading: const Icon(
+                  Icons.delete_outline,
+                  color: DesignColors.error,
+                ),
+                title: const Text(
+                  'Clear history',
+                  style: TextStyle(color: DesignColors.error),
+                ),
+                onTap: () {
+                  Navigator.pop(context);
+                  onClearHistory();
+                },
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/services/agent/agent_adapter.dart
+++ b/lib/services/agent/agent_adapter.dart
@@ -1,0 +1,77 @@
+import '../ssh/ssh_client.dart';
+import 'agent_types.dart';
+
+/// Everything an adapter needs to talk to a running agent: a live SSH
+/// connection plus the tmux pane the agent process runs in.
+class AgentContext {
+  /// Live SSH connection to the host running the agent.
+  final SshClient ssh;
+
+  /// tmux pane id (e.g. `%12`) where the agent process runs.
+  final String paneId;
+
+  /// Working directory of the pane, if known (`pane_current_path`).
+  /// Used when the agent must be restarted in its original directory.
+  final String? paneWorkingDirectory;
+
+  const AgentContext({
+    required this.ssh,
+    required this.paneId,
+    this.paneWorkingDirectory,
+  });
+}
+
+/// Translates the unified Remote UI controls (model, reasoning effort,
+/// autonomy) into the mechanisms of one specific AI CLI agent.
+///
+/// Implementations must be pure translators: they receive an [AgentContext]
+/// and perform remote operations through it. They never hold UI state and
+/// never create their own SSH connections.
+abstract class AgentAdapter {
+  /// Which agent this adapter controls.
+  AgentKind get kind;
+
+  /// Capabilities and selectable options for this agent.
+  AgentCapabilities get capabilities;
+
+  /// Process names matched (case-insensitively) against the tmux
+  /// `pane_current_command` format value, e.g. `claude`, `codex`, `droid`.
+  List<String> get processNames;
+
+  /// Whether [paneCurrentCommand] looks like this agent's process.
+  bool matchesCommand(String? paneCurrentCommand) {
+    if (paneCurrentCommand == null) return false;
+    final command = paneCurrentCommand.trim().toLowerCase();
+    if (command.isEmpty) return false;
+    return processNames.any(
+      (name) => command == name || command.endsWith('/$name'),
+    );
+  }
+
+  /// Reads the agent's current effective configuration.
+  ///
+  /// Implementations should prefer the agent's config files (reliable)
+  /// and only fall back to parsing pane output when necessary.
+  Future<AgentConfig> readConfig(AgentContext context);
+
+  /// Switches the active model. Returns a short human-readable
+  /// confirmation message for the UI.
+  Future<String> applyModel(AgentContext context, String model);
+
+  /// Switches the reasoning effort. Returns a confirmation message.
+  Future<String> applyIntelligence(
+    AgentContext context,
+    UnifiedIntelligence level,
+  );
+
+  /// Switches the autonomy/permission level. Returns a confirmation
+  /// message. When [AgentCapabilities.requiresRestartToApply] is true the
+  /// adapter restarts the agent process in its pane.
+  Future<String> applyPermission(
+    AgentContext context,
+    UnifiedPermission level,
+  );
+
+  /// Enables or disables plan/spec mode. Returns a confirmation message.
+  Future<String> setPlanMode(AgentContext context, bool enabled);
+}

--- a/lib/services/agent/agent_config_service.dart
+++ b/lib/services/agent/agent_config_service.dart
@@ -1,0 +1,239 @@
+import 'dart:convert';
+
+import '../ssh/ssh_client.dart';
+
+/// Safe remote editing of AI agent config files (`settings.json`,
+/// `config.toml`) over an SSH connection.
+///
+/// All parsing/serialization is pure Dart string processing (no new pub
+/// dependencies). Remote writes are atomic: the new content goes to a
+/// temporary file which is then `mv`-ed over the target, and the original
+/// file is preserved once as `<path>.muxpod-bak` before the first
+/// overwrite.
+///
+/// Shell-safety: file content travels base64-encoded (same pattern as
+/// [TmuxCommands.loadBufferAndPaste]) so no user-controlled byte is ever
+/// interpolated into a shell command. Paths passed to this service are
+/// compile-time constants defined by the adapters, never raw user input;
+/// they may contain `$HOME`, which the remote shell expands inside double
+/// quotes.
+class AgentConfigService {
+  AgentConfigService._();
+
+  /// Suffix of the one-time backup created before the first overwrite.
+  static const String backupSuffix = '.muxpod-bak';
+
+  /// Suffix of the temporary file used for atomic writes.
+  static const String tempSuffix = '.muxpod-tmp';
+
+  // ===== Remote file operations =====
+
+  /// Reads a remote text file via `cat`. Returns null when the file does
+  /// not exist or cannot be read.
+  static Future<String?> readRemoteFile(SshClient ssh, String path) async {
+    final result = await ssh.execWithExitCode('cat -- "$path"');
+    if (result.exitCode != 0) return null;
+    return result.stdout;
+  }
+
+  /// Atomically writes [content] to the remote file at [path].
+  ///
+  /// Sequence: create the parent directory, copy the current file to
+  /// `<path>.muxpod-bak` (only if no backup exists yet), write the new
+  /// content to `<path>.muxpod-tmp` via base64, then `mv` it over [path].
+  ///
+  /// Throws [StateError] when the remote command fails.
+  static Future<void> writeRemoteFileAtomic(
+    SshClient ssh,
+    String path,
+    String content,
+  ) async {
+    final dir = path.substring(0, path.lastIndexOf('/'));
+    final backupPath = '$path$backupSuffix';
+    final tempPath = '$path$tempSuffix';
+    // base64 contains only [A-Za-z0-9+/=], so single-quoting is safe.
+    final encoded = base64.encode(utf8.encode(content));
+    final command = 'mkdir -p -- "$dir" && '
+        '( [ -f "$backupPath" ] || [ ! -f "$path" ] || cp -- "$path" "$backupPath" ) && '
+        "printf '%s' '$encoded' | base64 -d > \"$tempPath\" && "
+        'mv -f -- "$tempPath" "$path"';
+    final result = await ssh.execWithExitCode(command);
+    if (result.exitCode != 0) {
+      throw StateError(
+        'Failed to write $path (exit ${result.exitCode}): ${result.stderr}',
+      );
+    }
+  }
+
+  // ===== TOML (simple top-level `key = "value"` lines) =====
+
+  /// Returns the string value of a top-level [key] in TOML [content], or
+  /// null when the key is absent.
+  ///
+  /// Only top-level keys are considered: the scan stops at the first
+  /// `[table]` header so a key inside a table is never matched. Quoted
+  /// values are unquoted; bare values are returned with trailing comments
+  /// stripped.
+  static String? tomlGetString(String content, String key) {
+    final pattern = RegExp('^\\s*${RegExp.escape(key)}\\s*=\\s*(.*)\$');
+    for (final line in content.split('\n')) {
+      final trimmed = line.trimLeft();
+      if (trimmed.startsWith('#')) continue;
+      if (trimmed.startsWith('[')) break; // top-level keys only
+      final match = pattern.firstMatch(line);
+      if (match == null) continue;
+      return _parseTomlValue(match[1]!.trim());
+    }
+    return null;
+  }
+
+  /// Sets a top-level string [key] to [value] in TOML [content].
+  ///
+  /// An existing top-level `key = ...` line is replaced in place; all
+  /// unrelated lines (comments, tables, other keys) are preserved. When
+  /// the key is missing, the line is inserted before the first `[table]`
+  /// header so it stays top-level, or appended when the file has no
+  /// tables.
+  static String tomlSetString(String content, String key, String value) {
+    // Control characters would break out of the single-line `key = "..."`
+    // form and inject extra TOML keys into the user's real config file
+    // (model entry is free text, and paste can carry newlines).
+    if (value.contains(RegExp(r'[\r\n]'))) {
+      throw ArgumentError.value(
+        value,
+        'value',
+        'TOML basic string values must not contain newlines',
+      );
+    }
+    final newLine = '$key = "${_escapeTomlBasicString(value)}"';
+    final pattern = RegExp('^\\s*${RegExp.escape(key)}\\s*=');
+    final lines = content.split('\n');
+    var firstTableIndex = -1;
+    for (var i = 0; i < lines.length; i++) {
+      final trimmed = lines[i].trimLeft();
+      if (trimmed.startsWith('[')) {
+        firstTableIndex = i;
+        break;
+      }
+      if (trimmed.startsWith('#')) continue;
+      if (pattern.hasMatch(lines[i])) {
+        lines[i] = newLine;
+        return lines.join('\n');
+      }
+    }
+    if (firstTableIndex >= 0) {
+      lines.insert(firstTableIndex, newLine);
+      return lines.join('\n');
+    }
+    // No table anywhere: append at the end, keeping exactly one trailing
+    // newline.
+    final trimmedEnd = content.trimRight();
+    if (trimmedEnd.isEmpty) return '$newLine\n';
+    return '$trimmedEnd\n$newLine\n';
+  }
+
+  /// Parses a TOML value literal into a plain string.
+  ///
+  /// Handles double-quoted basic strings (with `\"` and `\\` unescaped),
+  /// single-quoted literal strings, and bare values (numbers/booleans,
+  /// returned as their literal text).
+  static String? _parseTomlValue(String raw) {
+    if (raw.startsWith('"')) {
+      final buffer = StringBuffer();
+      var i = 1;
+      while (i < raw.length) {
+        final ch = raw[i];
+        if (ch == r'\') {
+          if (i + 1 >= raw.length) return null;
+          final escaped = raw[i + 1];
+          if (escaped != '"' && escaped != r'\') return null;
+          buffer.write(escaped);
+          i += 2;
+          continue;
+        }
+        if (ch == '"') return buffer.toString();
+        buffer.write(ch);
+        i++;
+      }
+      return null;
+    }
+    if (raw.startsWith("'")) {
+      final end = raw.indexOf("'", 1);
+      return end > 0 ? raw.substring(1, end) : null;
+    }
+    final commentIndex = raw.indexOf('#');
+    final value = (commentIndex >= 0 ? raw.substring(0, commentIndex) : raw)
+        .trim();
+    return value.isEmpty ? null : value;
+  }
+
+  /// Escapes a value for a TOML basic string (`"..."`).
+  static String _escapeTomlBasicString(String value) {
+    return value.replaceAll(r'\', r'\\').replaceAll('"', r'\"');
+  }
+
+  // ===== JSON (dotted keys) =====
+
+  /// Returns the value at [dottedKey] (e.g. `permissions.defaultMode`) in
+  /// JSON [content], or null when any segment is missing.
+  ///
+  /// Malformed JSON (hand-edited config, truncated write) degrades to
+  /// null — "value unknown" — instead of throwing, so the Remote UI keeps
+  /// working when a settings file is temporarily broken.
+  static Object? jsonGetDotted(String content, String dottedKey) {
+    if (content.trim().isEmpty) return null;
+    final Object? decoded;
+    try {
+      decoded = jsonDecode(content);
+    } on FormatException {
+      return null;
+    }
+    Object? current = decoded;
+    for (final key in dottedKey.split('.')) {
+      if (current is Map<String, Object?> && current.containsKey(key)) {
+        current = current[key];
+      } else {
+        return null;
+      }
+    }
+    return current;
+  }
+
+  /// Sets the value at [dottedKey] in JSON [content] and returns the
+  /// updated document encoded with a 2-space indent and a trailing
+  /// newline.
+  ///
+  /// Intermediate objects are created as needed. Empty [content] starts
+  /// from an empty object. Throws [FormatException] when [content] is not
+  /// a JSON object or a path segment collides with a non-object value.
+  static String jsonSetDotted(String content, String dottedKey, Object? value) {
+    final Map<String, Object?> root;
+    if (content.trim().isEmpty) {
+      root = <String, Object?>{};
+    } else {
+      final decoded = jsonDecode(content);
+      if (decoded is! Map<String, Object?>) {
+        throw const FormatException('Expected a JSON object at the top level');
+      }
+      root = decoded;
+    }
+    final keys = dottedKey.split('.');
+    var current = root;
+    for (var i = 0; i < keys.length - 1; i++) {
+      final next = current[keys[i]];
+      if (next == null) {
+        final created = <String, Object?>{};
+        current[keys[i]] = created;
+        current = created;
+      } else if (next is Map<String, Object?>) {
+        current = next;
+      } else {
+        throw FormatException(
+          'Cannot set "$dottedKey": "${keys[i]}" is not an object',
+        );
+      }
+    }
+    current[keys.last] = value;
+    return '${const JsonEncoder.withIndent('  ').convert(root)}\n';
+  }
+}

--- a/lib/services/agent/agent_registry.dart
+++ b/lib/services/agent/agent_registry.dart
@@ -1,0 +1,32 @@
+import 'agent_adapter.dart';
+import 'claude_code_adapter.dart';
+import 'codex_adapter.dart';
+import 'factory_droid_adapter.dart';
+
+/// Registry of all known agent adapters.
+///
+/// Used by the Remote UI to detect which agent (if any) runs in a tmux
+/// pane from the pane's `pane_current_command` value.
+class AgentRegistry {
+  AgentRegistry._();
+
+  /// All supported adapters, in detection priority order.
+  ///
+  /// Not const: the pinned [AgentAdapter] base class has no const
+  /// constructor, so adapter instances cannot be compile-time constants.
+  static final List<AgentAdapter> adapters = [
+    ClaudeCodeAdapter(),
+    CodexAdapter(),
+    FactoryDroidAdapter(),
+  ];
+
+  /// Returns the adapter whose [AgentAdapter.processNames] match
+  /// [paneCurrentCommand] (case-insensitive, basename-aware), or null
+  /// when the pane runs no known agent.
+  static AgentAdapter? detect(String? paneCurrentCommand) {
+    for (final adapter in adapters) {
+      if (adapter.matchesCommand(paneCurrentCommand)) return adapter;
+    }
+    return null;
+  }
+}

--- a/lib/services/agent/agent_types.dart
+++ b/lib/services/agent/agent_types.dart
@@ -1,0 +1,118 @@
+/// Unified, agent-agnostic model for AI CLI agent control.
+///
+/// These types describe the concepts shown in the Remote UI (model,
+/// reasoning effort, autonomy). Each `AgentAdapter` translates them into
+/// tool-specific mechanisms (slash commands, config files, process flags).
+library;
+
+/// Supported AI CLI agents.
+enum AgentKind {
+  claudeCode('Claude Code'),
+  codex('Codex CLI'),
+  droid('Factory Droid');
+
+  const AgentKind(this.displayName);
+
+  /// Human-readable name shown in the UI.
+  final String displayName;
+}
+
+/// Unified reasoning-effort scale shown in the Remote UI.
+///
+/// Not every agent supports every level; the levels a given agent accepts
+/// are listed in [AgentCapabilities.intelligenceLevels].
+enum UnifiedIntelligence {
+  low('Low'),
+  medium('Medium'),
+  high('High'),
+  extraHigh('Extra High'),
+  max('Max'),
+  ultra('Ultra');
+
+  const UnifiedIntelligence(this.label);
+
+  /// Label shown in the intelligence bottom sheet.
+  final String label;
+}
+
+/// Unified autonomy/permission levels shown in the Remote UI.
+enum UnifiedPermission {
+  readOnly('Read only', 'Requires approval to edit files or run commands'),
+  defaultPermissions('Default permissions', 'Runs commands in a sandbox'),
+  autoReview('Auto-review', 'Reviews elevated requests automatically'),
+  fullAccess('Full access', 'Full computer access (elevated risk)'),
+  custom('Custom', 'Uses the permissions defined in the config file');
+
+  const UnifiedPermission(this.label, this.description);
+
+  /// Label shown in the permissions bottom sheet.
+  final String label;
+
+  /// Subtitle shown under the label in the permissions bottom sheet.
+  final String description;
+}
+
+/// Which capabilities an agent supports and which concrete options the UI
+/// may offer for it.
+///
+/// Empty lists mean the feature is unsupported for that agent and the UI
+/// must hide the corresponding control.
+class AgentCapabilities {
+  /// Selectable model ids/names. Empty means free-text model entry.
+  final List<String> availableModels;
+
+  /// Supported reasoning levels. Empty means the agent has no
+  /// reasoning-effort control.
+  final List<UnifiedIntelligence> intelligenceLevels;
+
+  /// Supported permission levels. Empty means the agent has no
+  /// autonomy control.
+  final List<UnifiedPermission> permissionLevels;
+
+  /// Whether the agent has a plan/spec mode that can be toggled.
+  final bool supportsPlanMode;
+
+  /// Whether applying configuration changes requires restarting the agent
+  /// process in its pane (config-file based agents such as Codex).
+  final bool requiresRestartToApply;
+
+  const AgentCapabilities({
+    this.availableModels = const [],
+    this.intelligenceLevels = const [],
+    this.permissionLevels = const [],
+    this.supportsPlanMode = false,
+    this.requiresRestartToApply = false,
+  });
+}
+
+/// Snapshot of an agent's current effective configuration.
+///
+/// Fields are null when the value cannot be determined (e.g. the agent
+/// does not expose it and it is absent from its config file).
+class AgentConfig {
+  final String? model;
+  final UnifiedIntelligence? intelligence;
+  final UnifiedPermission? permission;
+  final bool planModeActive;
+
+  const AgentConfig({
+    this.model,
+    this.intelligence,
+    this.permission,
+    this.planModeActive = false,
+  });
+
+  AgentConfig copyWith({
+    String? model,
+    UnifiedIntelligence? intelligence,
+    UnifiedPermission? permission,
+    bool? planModeActive,
+  }) {
+    return AgentConfig(
+      model: model ?? this.model,
+      intelligence: intelligence ?? this.intelligence,
+      permission: permission ?? this.permission,
+      planModeActive: planModeActive ?? this.planModeActive,
+    );
+  }
+}

--- a/lib/services/agent/claude_code_adapter.dart
+++ b/lib/services/agent/claude_code_adapter.dart
@@ -1,0 +1,240 @@
+import '../tmux/tmux_commands.dart';
+import 'agent_adapter.dart';
+import 'agent_config_service.dart';
+import 'agent_types.dart';
+
+/// Adapter for Claude Code (`claude`).
+///
+/// Mechanisms (verified against the 2026 docs at code.claude.com/docs):
+///
+/// - Model: `/model <alias|name>` switches the running session
+///   immediately and saves it as the default for new sessions
+///   (docs/en/model-config, "Setting your model"). The persisted form is
+///   the `model` key in `~/.claude/settings.json`, which is read once at
+///   session start.
+/// - Reasoning effort: `/effort <level>` sets the level directly on the
+///   running session (docs/en/model-config, "Set the effort level").
+///   Levels are `low`, `medium`, `high`, `xhigh`, `max` (model-dependent)
+///   plus `ultracode`, a session-only Claude Code setting that pairs
+///   `xhigh` with dynamic workflow orchestration. The persisted
+///   `effortLevel` settings key accepts only `low`/`medium`/`high`/
+///   `xhigh`; `max` and `ultracode` are session-only. The older
+///   `MAX_THINKING_TOKENS` env var now applies only to fixed thinking
+///   budgets on pre-4.7 models, so `/effort` is the correct control.
+/// - Permissions: `permissions.defaultMode` in `~/.claude/settings.json`
+///   (docs/en/permission-modes). Modes: `default` (reads only without
+///   asking; prompts for edits/commands), `acceptEdits` (auto-approves
+///   file edits and common filesystem commands), `plan`, `auto` (a
+///   classifier reviews elevated requests automatically), `dontAsk`, and
+///   `bypassPermissions`. Settings files are watched and reloaded live,
+///   but `defaultMode` is the *starting* mode: the running session keeps
+///   its current mode until the user cycles it with Shift+Tab.
+/// - Plan mode: a first-class permission mode (`plan`), so it is applied
+///   through the same `permissions.defaultMode` key.
+class ClaudeCodeAdapter extends AgentAdapter {
+  // Non-const: the pinned AgentAdapter base class has no const constructor.
+  ClaudeCodeAdapter();
+
+  /// User-scope settings file (docs/en/settings).
+  static const String settingsPath = r'$HOME/.claude/settings.json';
+
+  @override
+  AgentKind get kind => AgentKind.claudeCode;
+
+  @override
+  List<String> get processNames => const ['claude'];
+
+  @override
+  AgentCapabilities get capabilities => const AgentCapabilities(
+        // Common model aliases from docs/en/model-config. The `/model`
+        // command also accepts full model IDs, so this list is a
+        // convenience, not an exhaustive allowlist.
+        availableModels: [
+          'default',
+          'sonnet',
+          'opus',
+          'haiku',
+          'fable',
+          'opusplan',
+        ],
+        // `/effort` low|medium|high|xhigh|max|ultracode.
+        intelligenceLevels: [
+          UnifiedIntelligence.low,
+          UnifiedIntelligence.medium,
+          UnifiedIntelligence.high,
+          UnifiedIntelligence.extraHigh,
+          UnifiedIntelligence.max,
+          UnifiedIntelligence.ultra,
+        ],
+        permissionLevels: [
+          UnifiedPermission.readOnly,
+          UnifiedPermission.defaultPermissions,
+          UnifiedPermission.autoReview,
+          UnifiedPermission.fullAccess,
+          UnifiedPermission.custom,
+        ],
+        supportsPlanMode: true,
+      );
+
+  // ===== Pure mappings (unit-tested directly) =====
+
+  /// Maps a unified intelligence level to a `/effort` argument.
+  static String effortForIntelligence(UnifiedIntelligence level) {
+    return switch (level) {
+      UnifiedIntelligence.low => 'low',
+      UnifiedIntelligence.medium => 'medium',
+      UnifiedIntelligence.high => 'high',
+      UnifiedIntelligence.extraHigh => 'xhigh',
+      UnifiedIntelligence.max => 'max',
+      UnifiedIntelligence.ultra => 'ultracode',
+    };
+  }
+
+  /// Maps a persisted `effortLevel` value back to a unified level.
+  ///
+  /// `max`/`ultracode` are session-only and never appear in settings, so
+  /// they (and unknown values) map to null.
+  static UnifiedIntelligence? intelligenceForEffort(String effort) {
+    return switch (effort) {
+      'low' => UnifiedIntelligence.low,
+      'medium' => UnifiedIntelligence.medium,
+      'high' => UnifiedIntelligence.high,
+      'xhigh' => UnifiedIntelligence.extraHigh,
+      _ => null,
+    };
+  }
+
+  /// Maps a unified permission level to a Claude permission mode.
+  ///
+  /// Returns null for [UnifiedPermission.custom], which means "leave the
+  /// config file untouched".
+  static String? modeForPermission(UnifiedPermission level) {
+    return switch (level) {
+      // `default` (Manual): reads run freely, edits and commands prompt.
+      UnifiedPermission.readOnly => 'default',
+      // `acceptEdits`: file edits and common filesystem commands are
+      // auto-approved inside the working directory.
+      UnifiedPermission.defaultPermissions => 'acceptEdits',
+      // `auto`: a classifier model reviews elevated requests
+      // automatically instead of prompting the user.
+      UnifiedPermission.autoReview => 'auto',
+      UnifiedPermission.fullAccess => 'bypassPermissions',
+      UnifiedPermission.custom => null,
+    };
+  }
+
+  /// Maps a persisted `permissions.defaultMode` value back to a unified
+  /// level. `plan` is reported via [AgentConfig.planModeActive] instead;
+  /// `dontAsk` and unknown values have no unified equivalent.
+  static UnifiedPermission? permissionForMode(String mode) {
+    return switch (mode) {
+      'default' || 'manual' => UnifiedPermission.readOnly,
+      'acceptEdits' => UnifiedPermission.defaultPermissions,
+      'auto' => UnifiedPermission.autoReview,
+      'bypassPermissions' => UnifiedPermission.fullAccess,
+      _ => null,
+    };
+  }
+
+  /// Builds the slash command text typed into the pane.
+  static String buildSlashCommand(String name, String argument) {
+    return '/$name $argument';
+  }
+
+  // ===== AgentAdapter implementation =====
+
+  @override
+  Future<AgentConfig> readConfig(AgentContext context) async {
+    final content = await AgentConfigService.readRemoteFile(
+      context.ssh,
+      settingsPath,
+    );
+    if (content == null) return const AgentConfig();
+    final model = AgentConfigService.jsonGetDotted(content, 'model');
+    final effort = AgentConfigService.jsonGetDotted(content, 'effortLevel');
+    final mode = AgentConfigService.jsonGetDotted(
+      content,
+      'permissions.defaultMode',
+    );
+    return AgentConfig(
+      model: model is String ? model : null,
+      intelligence:
+          effort is String ? intelligenceForEffort(effort) : null,
+      permission: mode is String ? permissionForMode(mode) : null,
+      planModeActive: mode == 'plan',
+    );
+  }
+
+  @override
+  Future<String> applyModel(AgentContext context, String model) async {
+    await _sendSlashCommand(context, buildSlashCommand('model', model));
+    return 'Sent /model $model to the pane (applies immediately and is '
+        'saved as the default for new sessions)';
+  }
+
+  @override
+  Future<String> applyIntelligence(
+    AgentContext context,
+    UnifiedIntelligence level,
+  ) async {
+    final effort = effortForIntelligence(level);
+    await _sendSlashCommand(context, buildSlashCommand('effort', effort));
+    return 'Sent /effort $effort to the pane';
+  }
+
+  @override
+  Future<String> applyPermission(
+    AgentContext context,
+    UnifiedPermission level,
+  ) async {
+    final mode = modeForPermission(level);
+    if (mode == null) {
+      return 'Custom permissions: $settingsPath left untouched';
+    }
+    await _writeSettingsKey(context, 'permissions.defaultMode', mode);
+    return 'Permission mode "$mode" saved to $settingsPath. New sessions '
+        'start in this mode; press Shift+Tab in the pane to cycle the '
+        'running session.';
+  }
+
+  @override
+  Future<String> setPlanMode(AgentContext context, bool enabled) async {
+    // Plan mode is a permission mode in Claude Code, so it is applied
+    // through the same settings key. Disabling restores `default`.
+    final mode = enabled ? 'plan' : 'default';
+    await _writeSettingsKey(context, 'permissions.defaultMode', mode);
+    return 'Plan mode ${enabled ? 'enabled' : 'disabled'} '
+        '(permissions.defaultMode="$mode" in $settingsPath). Press '
+        'Shift+Tab in the pane to toggle the running session.';
+  }
+
+  /// Types a slash command into the agent pane and submits it.
+  ///
+  /// The command text is sent with `send-keys -l` (literal) via
+  /// [TmuxCommands.sendKeys], which shell-escapes it; Enter is sent
+  /// separately so the TUI receives distinct keystrokes.
+  Future<void> _sendSlashCommand(AgentContext context, String text) async {
+    await context.ssh.sendKeysCommand(
+      TmuxCommands.sendKeys(context.paneId, text, literal: true),
+    );
+    await context.ssh.sendKeysCommand(TmuxCommands.sendEnter(context.paneId));
+  }
+
+  /// Sets a dotted key in `~/.claude/settings.json`, preserving all other
+  /// content.
+  Future<void> _writeSettingsKey(
+    AgentContext context,
+    String dottedKey,
+    Object? value,
+  ) async {
+    final current =
+        await AgentConfigService.readRemoteFile(context.ssh, settingsPath) ??
+            '';
+    final updated = AgentConfigService.jsonSetDotted(current, dottedKey, value);
+    await AgentConfigService.writeRemoteFileAtomic(
+      context.ssh,
+      settingsPath,
+      updated,
+    );
+  }
+}

--- a/lib/services/agent/codex_adapter.dart
+++ b/lib/services/agent/codex_adapter.dart
@@ -1,0 +1,305 @@
+import '../tmux/tmux_commands.dart';
+import 'agent_adapter.dart';
+import 'agent_config_service.dart';
+import 'agent_types.dart';
+
+/// Adapter for OpenAI Codex CLI (`codex`).
+///
+/// Mechanisms (verified against the 2026 config reference at
+/// developers.openai.com/codex/config-reference):
+///
+/// Codex is configured through `~/.codex/config.toml`, which is read at
+/// process start, so every change requires restarting the agent in its
+/// pane ([AgentCapabilities.requiresRestartToApply] is true):
+///
+/// - Model: top-level `model = "<id>"`.
+/// - Reasoning effort: top-level `model_reasoning_effort`, one of
+///   `minimal | low | medium | high | xhigh` (`xhigh` is model-dependent).
+///   The unified scale has no `minimal` rung and Codex has no `max`/
+///   `ultra`, so the offered levels are low/medium/high/extraHigh.
+/// - Permissions: `sandbox_mode` (`read-only | workspace-write |
+///   danger-full-access`) combined with `approval_policy` (`untrusted |
+///   on-request | never`). Note: current docs mark `on-failure` as
+///   deprecated in favor of `on-request` (plus
+///   `approvals_reviewer = "auto_review"`); it is still accepted and is
+///   kept here per the pinned mapping.
+/// - Plan mode: Codex has a TUI plan mode (`/plan` or Shift+Tab, since
+///   v0.93), but it is a session-local toggle with no config-file
+///   equivalent and no deterministic on/off command, so this adapter
+///   reports [AgentCapabilities.supportsPlanMode] as false rather than
+///   risk toggling the wrong direction.
+class CodexAdapter extends AgentAdapter {
+  // Non-const: the pinned AgentAdapter base class has no const constructor.
+  CodexAdapter();
+
+  /// User-level config file.
+  static const String configPath = r'$HOME/.codex/config.toml';
+
+  @override
+  AgentKind get kind => AgentKind.codex;
+
+  @override
+  List<String> get processNames => const ['codex'];
+
+  @override
+  AgentCapabilities get capabilities => const AgentCapabilities(
+        // Model IDs vary by provider/config; free-text entry.
+        intelligenceLevels: [
+          UnifiedIntelligence.low,
+          UnifiedIntelligence.medium,
+          UnifiedIntelligence.high,
+          UnifiedIntelligence.extraHigh,
+        ],
+        permissionLevels: [
+          UnifiedPermission.readOnly,
+          UnifiedPermission.defaultPermissions,
+          UnifiedPermission.autoReview,
+          UnifiedPermission.fullAccess,
+          UnifiedPermission.custom,
+        ],
+        requiresRestartToApply: true,
+      );
+
+  // ===== Pure mappings (unit-tested directly) =====
+
+  /// Maps a unified intelligence level to a `model_reasoning_effort`
+  /// value. Throws [ArgumentError] for levels Codex does not support
+  /// (they are excluded from [capabilities], so the UI never offers
+  /// them).
+  static String reasoningEffortForIntelligence(UnifiedIntelligence level) {
+    return switch (level) {
+      UnifiedIntelligence.low => 'low',
+      UnifiedIntelligence.medium => 'medium',
+      UnifiedIntelligence.high => 'high',
+      UnifiedIntelligence.extraHigh => 'xhigh',
+      _ => throw ArgumentError(
+          'Codex does not support reasoning effort "${level.name}"',
+        ),
+    };
+  }
+
+  /// Maps a persisted `model_reasoning_effort` value back to a unified
+  /// level. `minimal` has no unified rung and maps to null.
+  static UnifiedIntelligence? intelligenceForReasoningEffort(String effort) {
+    return switch (effort) {
+      'low' => UnifiedIntelligence.low,
+      'medium' => UnifiedIntelligence.medium,
+      'high' => UnifiedIntelligence.high,
+      'xhigh' => UnifiedIntelligence.extraHigh,
+      _ => null,
+    };
+  }
+
+  /// Maps a unified permission level to the `sandbox_mode` /
+  /// `approval_policy` pair to write. A null approval policy means the
+  /// existing `approval_policy` line is left as-is. Returns null for
+  /// [UnifiedPermission.custom] ("leave the config file untouched").
+  static ({String sandboxMode, String? approvalPolicy})? configForPermission(
+    UnifiedPermission level,
+  ) {
+    return switch (level) {
+      UnifiedPermission.readOnly => (
+          sandboxMode: 'read-only',
+          approvalPolicy: null,
+        ),
+      UnifiedPermission.defaultPermissions => (
+          sandboxMode: 'workspace-write',
+          approvalPolicy: 'on-request',
+        ),
+      UnifiedPermission.autoReview => (
+          sandboxMode: 'workspace-write',
+          approvalPolicy: 'on-failure',
+        ),
+      UnifiedPermission.fullAccess => (
+          sandboxMode: 'danger-full-access',
+          approvalPolicy: 'never',
+        ),
+      UnifiedPermission.custom => null,
+    };
+  }
+
+  /// Maps a persisted `sandbox_mode` / `approval_policy` pair back to a
+  /// unified level. Combinations this adapter would never write map to
+  /// [UnifiedPermission.custom]; a missing `sandbox_mode` maps to null
+  /// (the effective value cannot be determined from the file).
+  static UnifiedPermission? permissionForConfig(
+    String? sandboxMode,
+    String? approvalPolicy,
+  ) {
+    if (sandboxMode == null) return null;
+    return switch ((sandboxMode, approvalPolicy)) {
+      ('read-only', _) => UnifiedPermission.readOnly,
+      ('workspace-write', 'on-request') =>
+        UnifiedPermission.defaultPermissions,
+      ('workspace-write', 'on-failure') => UnifiedPermission.autoReview,
+      ('danger-full-access', 'never') => UnifiedPermission.fullAccess,
+      _ => UnifiedPermission.custom,
+    };
+  }
+
+  /// Builds the shell command typed into the pane to relaunch Codex in
+  /// its original working directory (falling back to `$HOME`).
+  static String buildRelaunchCommand(String? workingDirectory) {
+    if (workingDirectory == null || workingDirectory.trim().isEmpty) {
+      // `$HOME` must reach the pane shell unescaped so it expands there.
+      return r'cd -- "$HOME" && codex';
+    }
+    return 'cd -- "${_escapeDoubleQuoted(workingDirectory)}" && codex';
+  }
+
+  /// Escapes a string for use inside double quotes in a shell command
+  /// typed into the pane.
+  static String _escapeDoubleQuoted(String value) {
+    return value
+        .replaceAll(r'\', r'\\')
+        .replaceAll('"', r'\"')
+        .replaceAll(r'$', r'\$')
+        .replaceAll('`', r'\`');
+  }
+
+  // ===== AgentAdapter implementation =====
+
+  @override
+  Future<AgentConfig> readConfig(AgentContext context) async {
+    final content = await AgentConfigService.readRemoteFile(
+      context.ssh,
+      configPath,
+    );
+    if (content == null) return const AgentConfig();
+    final model = AgentConfigService.tomlGetString(content, 'model');
+    final effort =
+        AgentConfigService.tomlGetString(content, 'model_reasoning_effort');
+    final sandboxMode = AgentConfigService.tomlGetString(content, 'sandbox_mode');
+    final approvalPolicy =
+        AgentConfigService.tomlGetString(content, 'approval_policy');
+    return AgentConfig(
+      model: model,
+      intelligence:
+          effort == null ? null : intelligenceForReasoningEffort(effort),
+      permission: permissionForConfig(sandboxMode, approvalPolicy),
+    );
+  }
+
+  @override
+  Future<String> applyModel(AgentContext context, String model) async {
+    await _updateConfig(
+      context,
+      (content) => AgentConfigService.tomlSetString(content, 'model', model),
+    );
+    await _restartAgent(context);
+    return 'Model set to "$model" in $configPath; Codex was restarted to '
+        'apply it';
+  }
+
+  @override
+  Future<String> applyIntelligence(
+    AgentContext context,
+    UnifiedIntelligence level,
+  ) async {
+    final effort = reasoningEffortForIntelligence(level);
+    await _updateConfig(
+      context,
+      (content) => AgentConfigService.tomlSetString(
+        content,
+        'model_reasoning_effort',
+        effort,
+      ),
+    );
+    await _restartAgent(context);
+    return 'Reasoning effort set to "$effort" in $configPath; Codex was '
+        'restarted to apply it';
+  }
+
+  @override
+  Future<String> applyPermission(
+    AgentContext context,
+    UnifiedPermission level,
+  ) async {
+    final config = configForPermission(level);
+    if (config == null) {
+      return 'Custom permissions: $configPath left untouched';
+    }
+    await _updateConfig(context, (content) {
+      var updated = AgentConfigService.tomlSetString(
+        content,
+        'sandbox_mode',
+        config.sandboxMode,
+      );
+      final approvalPolicy = config.approvalPolicy;
+      if (approvalPolicy != null) {
+        updated = AgentConfigService.tomlSetString(
+          updated,
+          'approval_policy',
+          approvalPolicy,
+        );
+      }
+      return updated;
+    });
+    await _restartAgent(context);
+    return 'Permissions set to sandbox_mode="${config.sandboxMode}"'
+        '${config.approvalPolicy != null ? ', approval_policy="${config.approvalPolicy}"' : ''} '
+        'in $configPath; Codex was restarted to apply them';
+  }
+
+  @override
+  Future<String> setPlanMode(AgentContext context, bool enabled) async {
+    // Not reachable through the UI (supportsPlanMode is false). Codex
+    // plan mode is a session-local TUI toggle (/plan or Shift+Tab) with
+    // no deterministic external control.
+    return 'Codex plan mode can only be toggled in its TUI (/plan or '
+        'Shift+Tab); no change was made';
+  }
+
+  /// Reads `~/.codex/config.toml`, applies [transform], and writes it
+  /// back atomically (keeping a one-time `.muxpod-bak` backup).
+  Future<void> _updateConfig(
+    AgentContext context,
+    String Function(String content) transform,
+  ) async {
+    final current =
+        await AgentConfigService.readRemoteFile(context.ssh, configPath) ?? '';
+    await AgentConfigService.writeRemoteFileAtomic(
+      context.ssh,
+      configPath,
+      transform(current),
+    );
+  }
+
+  /// Restarts the Codex process in its pane so config changes apply.
+  ///
+  /// Codex exits its TUI on a double Ctrl+C; the relaunch command is then
+  /// typed into the pane's shell. A fixed delay here races slow TUIs (the
+  /// relaunch line would be typed into the still-running agent), so the
+  /// pane's `pane_current_command` is polled until Codex actually exits.
+  Future<void> _restartAgent(AgentContext context) async {
+    await context.ssh.sendKeysCommand(
+      TmuxCommands.sendInterrupt(context.paneId),
+    );
+    await context.ssh.sendKeysCommand(
+      TmuxCommands.sendInterrupt(context.paneId),
+    );
+
+    final deadline = DateTime.now().add(const Duration(seconds: 5));
+    while (DateTime.now().isBefore(deadline)) {
+      await Future<void>.delayed(const Duration(milliseconds: 300));
+      String? current;
+      try {
+        current = await context.ssh.execPersistent(
+          TmuxCommands.getPaneCurrentCommand(context.paneId),
+        );
+      } on Object {
+        break; // Cannot verify; proceed rather than strand the user.
+      }
+      if (!matchesCommand(current)) break;
+    }
+
+    await context.ssh.sendKeysCommand(
+      TmuxCommands.sendKeys(
+        context.paneId,
+        buildRelaunchCommand(context.paneWorkingDirectory),
+        literal: true,
+      ),
+    );
+    await context.ssh.sendKeysCommand(TmuxCommands.sendEnter(context.paneId));
+  }
+}

--- a/lib/services/agent/factory_droid_adapter.dart
+++ b/lib/services/agent/factory_droid_adapter.dart
@@ -1,0 +1,226 @@
+import '../tmux/tmux_commands.dart';
+import 'agent_adapter.dart';
+import 'agent_config_service.dart';
+import 'agent_types.dart';
+
+/// Adapter for Factory Droid (`droid`).
+///
+/// Mechanisms (verified against the 2026 docs at docs.factory.ai,
+/// droid-cli/cli-reference and droid-cli/settings):
+///
+/// - Model: `/model` switches the model mid-session (it applies between
+///   turns). The persisted form is the `model` key in
+///   `~/.factory/settings.json`.
+/// - Reasoning effort: the `reasoningEffort` settings key. Valid values
+///   are model-dependent: `none`, `dynamic`, `off`, `minimal`, `low`,
+///   `medium`, `high`, `xhigh`, `max`. The unified low/medium/high/
+///   extraHigh/max levels map onto low/medium/high/xhigh/max; `ultra`
+///   has no Droid equivalent and is not offered. Settings apply to new
+///   sessions (the running session can cycle effort with Tab, a
+///   stateful toggle this adapter deliberately does not drive).
+/// - Permissions: `sessionDefaultSettings.autonomyLevel`, one of
+///   `off | low | medium | high`. `off` keeps manual approvals
+///   (read-focused default), `low` pre-authorizes safe edits, `medium`
+///   typical development work, `high` broad operations such as
+///   deployment. Applies to new sessions (Ctrl+L cycles the running
+///   session's level, again a stateful toggle).
+/// - Plan mode: Droid's Spec Mode, controlled by
+///   `sessionDefaultSettings.interactionMode` (`auto | spec`). Applies
+///   to new sessions (Shift+Tab toggles the running session).
+class FactoryDroidAdapter extends AgentAdapter {
+  // Non-const: the pinned AgentAdapter base class has no const constructor.
+  FactoryDroidAdapter();
+
+  /// User settings file (docs.factory.ai/droid-cli/settings).
+  static const String settingsPath = r'$HOME/.factory/settings.json';
+
+  @override
+  AgentKind get kind => AgentKind.droid;
+
+  @override
+  List<String> get processNames => const ['droid'];
+
+  @override
+  AgentCapabilities get capabilities => const AgentCapabilities(
+        // Model IDs are user/org-specific (BYOK, Factory-Managed
+        // Inference); free-text entry.
+        intelligenceLevels: [
+          UnifiedIntelligence.low,
+          UnifiedIntelligence.medium,
+          UnifiedIntelligence.high,
+          UnifiedIntelligence.extraHigh,
+          UnifiedIntelligence.max,
+        ],
+        permissionLevels: [
+          UnifiedPermission.readOnly,
+          UnifiedPermission.defaultPermissions,
+          UnifiedPermission.autoReview,
+          UnifiedPermission.fullAccess,
+          UnifiedPermission.custom,
+        ],
+        supportsPlanMode: true,
+      );
+
+  // ===== Pure mappings (unit-tested directly) =====
+
+  /// Maps a unified intelligence level to a `reasoningEffort` value.
+  /// Throws [ArgumentError] for [UnifiedIntelligence.ultra], which Droid
+  /// does not support (it is excluded from [capabilities], so the UI
+  /// never offers it).
+  static String reasoningEffortForIntelligence(UnifiedIntelligence level) {
+    return switch (level) {
+      UnifiedIntelligence.low => 'low',
+      UnifiedIntelligence.medium => 'medium',
+      UnifiedIntelligence.high => 'high',
+      UnifiedIntelligence.extraHigh => 'xhigh',
+      UnifiedIntelligence.max => 'max',
+      UnifiedIntelligence.ultra => throw ArgumentError(
+          'Droid does not support reasoning effort "${level.name}"',
+        ),
+    };
+  }
+
+  /// Maps a persisted `reasoningEffort` value back to a unified level.
+  /// `off`/`none`/`minimal`/`dynamic` have no unified rung and map to
+  /// null.
+  static UnifiedIntelligence? intelligenceForReasoningEffort(String effort) {
+    return switch (effort) {
+      'low' => UnifiedIntelligence.low,
+      'medium' => UnifiedIntelligence.medium,
+      'high' => UnifiedIntelligence.high,
+      'xhigh' => UnifiedIntelligence.extraHigh,
+      'max' => UnifiedIntelligence.max,
+      _ => null,
+    };
+  }
+
+  /// Maps a unified permission level to a
+  /// `sessionDefaultSettings.autonomyLevel` value. Returns null for
+  /// [UnifiedPermission.custom] ("leave the config file untouched").
+  static String? autonomyLevelForPermission(UnifiedPermission level) {
+    return switch (level) {
+      // `off`: manual approvals; the default level is read-focused.
+      UnifiedPermission.readOnly => 'off',
+      // `low`: pre-authorizes safe edits and non-destructive commands.
+      UnifiedPermission.defaultPermissions => 'low',
+      // `medium`: pre-authorizes typical development work (install
+      // dependencies, build/test, local commits).
+      UnifiedPermission.autoReview => 'medium',
+      // `high`: pre-authorizes broad operations such as git push and
+      // deploy scripts.
+      UnifiedPermission.fullAccess => 'high',
+      UnifiedPermission.custom => null,
+    };
+  }
+
+  /// Maps a persisted `sessionDefaultSettings.autonomyLevel` value back
+  /// to a unified level. Unknown values map to null.
+  static UnifiedPermission? permissionForAutonomyLevel(String level) {
+    return switch (level) {
+      'off' => UnifiedPermission.readOnly,
+      'low' => UnifiedPermission.defaultPermissions,
+      'medium' => UnifiedPermission.autoReview,
+      'high' => UnifiedPermission.fullAccess,
+      _ => null,
+    };
+  }
+
+  // ===== AgentAdapter implementation =====
+
+  @override
+  Future<AgentConfig> readConfig(AgentContext context) async {
+    final content = await AgentConfigService.readRemoteFile(
+      context.ssh,
+      settingsPath,
+    );
+    if (content == null) return const AgentConfig();
+    final model = AgentConfigService.jsonGetDotted(content, 'model');
+    final effort = AgentConfigService.jsonGetDotted(content, 'reasoningEffort');
+    final autonomy = AgentConfigService.jsonGetDotted(
+      content,
+      'sessionDefaultSettings.autonomyLevel',
+    );
+    final interactionMode = AgentConfigService.jsonGetDotted(
+      content,
+      'sessionDefaultSettings.interactionMode',
+    );
+    return AgentConfig(
+      model: model is String ? model : null,
+      intelligence:
+          effort is String ? intelligenceForReasoningEffort(effort) : null,
+      permission:
+          autonomy is String ? permissionForAutonomyLevel(autonomy) : null,
+      planModeActive: interactionMode == 'spec',
+    );
+  }
+
+  @override
+  Future<String> applyModel(AgentContext context, String model) async {
+    await context.ssh.sendKeysCommand(
+      TmuxCommands.sendKeys(context.paneId, '/model $model', literal: true),
+    );
+    await context.ssh.sendKeysCommand(TmuxCommands.sendEnter(context.paneId));
+    return 'Sent /model $model to the pane (applies between turns)';
+  }
+
+  @override
+  Future<String> applyIntelligence(
+    AgentContext context,
+    UnifiedIntelligence level,
+  ) async {
+    final effort = reasoningEffortForIntelligence(level);
+    await _writeSettingsKey(context, 'reasoningEffort', effort);
+    return 'Reasoning effort "$effort" saved to $settingsPath (applies '
+        'to new sessions)';
+  }
+
+  @override
+  Future<String> applyPermission(
+    AgentContext context,
+    UnifiedPermission level,
+  ) async {
+    final autonomy = autonomyLevelForPermission(level);
+    if (autonomy == null) {
+      return 'Custom permissions: $settingsPath left untouched';
+    }
+    await _writeSettingsKey(
+      context,
+      'sessionDefaultSettings.autonomyLevel',
+      autonomy,
+    );
+    return 'Autonomy level "$autonomy" saved to $settingsPath (applies '
+        'to new sessions)';
+  }
+
+  @override
+  Future<String> setPlanMode(AgentContext context, bool enabled) async {
+    // Droid's Spec Mode is the plan-first interaction mode.
+    final mode = enabled ? 'spec' : 'auto';
+    await _writeSettingsKey(
+      context,
+      'sessionDefaultSettings.interactionMode',
+      mode,
+    );
+    return 'Spec mode ${enabled ? 'enabled' : 'disabled'} '
+        '(sessionDefaultSettings.interactionMode="$mode" in '
+        '$settingsPath; applies to new sessions)';
+  }
+
+  /// Sets a dotted key in `~/.factory/settings.json`, preserving all
+  /// other content.
+  Future<void> _writeSettingsKey(
+    AgentContext context,
+    String dottedKey,
+    Object? value,
+  ) async {
+    final current =
+        await AgentConfigService.readRemoteFile(context.ssh, settingsPath) ??
+            '';
+    final updated = AgentConfigService.jsonSetDotted(current, dottedKey, value);
+    await AgentConfigService.writeRemoteFileAtomic(
+      context.ssh,
+      settingsPath,
+      updated,
+    );
+  }
+}

--- a/lib/services/agent/headless/chat_event.dart
+++ b/lib/services/agent/headless/chat_event.dart
@@ -1,0 +1,108 @@
+/// Structured chat events parsed from the streaming output of headless
+/// AI CLI agents (Claude Code, Codex CLI, Factory Droid).
+///
+/// The headless runners emit newline-delimited JSON (NDJSON) on stdout.
+/// Each agent's dialect is translated into this unified, sealed hierarchy
+/// by `chat_event_parser.dart`, so the UI layer never touches raw JSON.
+library;
+
+/// Base type for all parsed chat events.
+sealed class ChatEvent {
+  const ChatEvent();
+}
+
+/// A chunk of assistant reply text.
+///
+/// Emitted by all three agents. Without partial-message streaming this is
+/// one event per completed assistant message rather than per token.
+final class TextDelta extends ChatEvent {
+  /// The text fragment.
+  final String text;
+
+  const TextDelta(this.text);
+}
+
+/// A chunk of agent reasoning ("thinking") text.
+///
+/// Emitted by Claude Code (`thinking` content blocks) and Codex CLI
+/// (`reasoning` items). Factory Droid's stream-json reasoning shape is not
+/// publicly documented; it is mapped best-effort when recognized.
+final class ThinkingDelta extends ChatEvent {
+  /// The reasoning text fragment.
+  final String text;
+
+  const ThinkingDelta(this.text);
+}
+
+/// The agent started invoking a tool.
+///
+/// For Claude Code this carries the tool name (e.g. `Bash`, `Edit`).
+/// For Codex CLI it carries the item type (e.g. `command_execution`,
+/// `file_change`, `mcp_tool_call`, `web_search`).
+final class ToolCallStarted extends ChatEvent {
+  /// Tool name (Claude) or item type (Codex).
+  final String name;
+
+  const ToolCallStarted(this.name);
+}
+
+/// The agent asks the user to approve a privileged action.
+///
+/// Reserved for future use: none of the three headless modes currently
+/// emits interactive approval requests. Claude Code headless auto-denies
+/// tools that need approval unless `--permission-prompt-tool` is set,
+/// Codex `exec` runs with pre-set sandbox/approval flags, and `droid exec`
+/// fails fast on permission violations instead of asking.
+final class ApprovalRequested extends ChatEvent {
+  /// Identifier used to correlate the approval response.
+  final String id;
+
+  /// Human-readable description of the action awaiting approval.
+  final String description;
+
+  const ApprovalRequested({required this.id, required this.description});
+}
+
+/// The agent reported its session id.
+///
+/// Emitted once per run when the agent announces the session (Claude
+/// `system/init`, Codex `thread.started`, Droid `result.session_id`).
+/// The id is required to resume the conversation with a follow-up prompt.
+final class SessionStarted extends ChatEvent {
+  /// Agent-specific session/thread id.
+  final String sessionId;
+
+  const SessionStarted(this.sessionId);
+}
+
+/// Token usage and/or cost update for the run.
+///
+/// Fields are null when the agent does not report them. Claude Code
+/// reports all three on its `result` event; Codex reports token counts on
+/// `turn.completed`; Factory Droid does not report usage in its documented
+/// output.
+final class UsageUpdated extends ChatEvent {
+  /// Input (prompt) tokens consumed.
+  final int? inputTokens;
+
+  /// Output (completion) tokens produced.
+  final int? outputTokens;
+
+  /// Total run cost in USD, when reported.
+  final double? costUsd;
+
+  const UsageUpdated({this.inputTokens, this.outputTokens, this.costUsd});
+}
+
+/// The run finished successfully.
+final class RunCompleted extends ChatEvent {
+  const RunCompleted();
+}
+
+/// The run failed (agent error, non-zero exit, or SSH disconnect).
+final class RunFailed extends ChatEvent {
+  /// Human-readable failure description.
+  final String message;
+
+  const RunFailed(this.message);
+}

--- a/lib/services/agent/headless/chat_event_parser.dart
+++ b/lib/services/agent/headless/chat_event_parser.dart
@@ -1,0 +1,349 @@
+/// Parses the newline-delimited JSON (NDJSON) output of headless AI CLI
+/// agents into the unified [ChatEvent] hierarchy.
+///
+/// Output dialects (verified 2026-08):
+///
+/// * Claude Code (`claude -p --output-format stream-json --verbose`):
+///   `system/init` (session_id), `assistant` (message.content blocks of
+///   type `text` / `thinking` / `tool_use`), `result` (subtype, is_error,
+///   usage, total_cost_usd, session_id).
+///   https://code.claude.com/docs/en/cli-reference
+///
+/// * Codex CLI (`codex exec --json`): `thread.started` (thread_id),
+///   `item.started` / `item.completed` (items of type `agent_message`,
+///   `reasoning`, `command_execution`, `file_change`, `mcp_tool_call`,
+///   `web_search`), `turn.completed` (usage), `turn.failed`, `error`.
+///   https://developers.openai.com/codex/noninteractive
+///
+/// * Factory Droid (`droid exec -o stream-json`): the stream-json event
+///   schema is not publicly documented; only the `result` object shape is
+///   documented (`{"type":"result","subtype":"success","is_error":false,
+///   "result":"...","session_id":"..."}`). The Droid parser therefore
+///   handles the documented `result` shape strictly and interprets
+///   Claude-like shapes (`system/init`, `assistant`, text/tool events)
+///   best-effort. https://docs.factory.ai/droid-exec/overview
+library;
+
+import 'dart:async';
+import 'dart:convert';
+
+import '../agent_types.dart';
+import 'chat_event.dart';
+
+/// Transforms a stream of raw stdout chunks from a headless agent into
+/// parsed [ChatEvent]s.
+///
+/// Chunks are arbitrary byte boundaries: lines may be split across chunks
+/// or multiple lines may arrive in one chunk. A line buffer reassembles
+/// them; a trailing unterminated line is flushed when the source closes.
+/// Source stream errors propagate to the returned stream.
+///
+/// Implemented with a plain [StreamController] (not `async*`) so that
+/// cancelling a subscription immediately cancels the source subscription —
+/// an `async*` generator suspended in `await for` on a silent source does
+/// not process cancellation until the source emits, which would hang
+/// [HeadlessAgentSession.cancel].
+Stream<ChatEvent> parseAgentEventStream(
+  AgentKind kind,
+  Stream<String> chunks,
+) {
+  late StreamController<ChatEvent> controller;
+  StreamSubscription<String>? sourceSubscription;
+  final pending = StringBuffer();
+
+  void emitLines({required bool includeRemainder}) {
+    final text = pending.toString();
+    var start = 0;
+    while (true) {
+      final newline = text.indexOf('\n', start);
+      if (newline == -1) break;
+      for (final event
+          in parseAgentOutputLine(kind, text.substring(start, newline))) {
+        controller.add(event);
+      }
+      start = newline + 1;
+    }
+    pending
+      ..clear()
+      ..write(text.substring(start));
+    if (includeRemainder) {
+      final rest = pending.toString().trim();
+      pending.clear();
+      if (rest.isNotEmpty) {
+        for (final event in parseAgentOutputLine(kind, rest)) {
+          controller.add(event);
+        }
+      }
+    }
+  }
+
+  controller = StreamController<ChatEvent>(
+    onListen: () {
+      sourceSubscription = chunks.listen(
+        (chunk) {
+          pending.write(chunk);
+          emitLines(includeRemainder: false);
+        },
+        onError: (Object error, StackTrace stackTrace) =>
+            controller.addError(error, stackTrace),
+        onDone: () {
+          emitLines(includeRemainder: true);
+          controller.close();
+        },
+      );
+    },
+    onCancel: () => sourceSubscription?.cancel(),
+  );
+  return controller.stream;
+}
+
+/// Parses a single NDJSON line into zero or more [ChatEvent]s.
+///
+/// Returns an empty list for blank lines, non-JSON noise (progress
+/// banners, warnings) and JSON values that are not objects — headless
+/// tools occasionally print non-JSON lines to stdout.
+List<ChatEvent> parseAgentOutputLine(AgentKind kind, String line) {
+  final trimmed = line.trim();
+  if (trimmed.isEmpty) return const [];
+
+  final Object? decoded;
+  try {
+    decoded = jsonDecode(trimmed);
+  } on FormatException {
+    return const [];
+  }
+  if (decoded is! Map<String, dynamic>) return const [];
+
+  return switch (kind) {
+    AgentKind.claudeCode => _parseClaudeEvent(decoded),
+    AgentKind.codex => _parseCodexEvent(decoded),
+    AgentKind.droid => _parseDroidEvent(decoded),
+  };
+}
+
+/// Safe dynamic → int conversion (no casts on untrusted JSON).
+int? _asInt(Object? value) => value is num ? value.toInt() : null;
+
+/// Safe dynamic → double conversion.
+double? _asDouble(Object? value) => value is num ? value.toDouble() : null;
+
+List<ChatEvent> _parseClaudeEvent(Map<String, dynamic> json) {
+  final type = json['type'];
+
+  if (type == 'system') {
+    if (json['subtype'] == 'init') {
+      final sessionId = json['session_id'];
+      if (sessionId is String && sessionId.isNotEmpty) {
+        return [SessionStarted(sessionId)];
+      }
+    }
+    return const [];
+  }
+
+  if (type == 'assistant') {
+    return _parseClaudeAssistantContent(json['message']);
+  }
+
+  if (type == 'result') {
+    final events = <ChatEvent>[];
+    final usage = json['usage'];
+    int? inputTokens;
+    int? outputTokens;
+    if (usage is Map<String, dynamic>) {
+      inputTokens = _asInt(usage['input_tokens']);
+      outputTokens = _asInt(usage['output_tokens']);
+    }
+    final costUsd = _asDouble(json['total_cost_usd']);
+    if (inputTokens != null || outputTokens != null || costUsd != null) {
+      events.add(UsageUpdated(
+        inputTokens: inputTokens,
+        outputTokens: outputTokens,
+        costUsd: costUsd,
+      ));
+    }
+    final subtype = json['subtype'];
+    final failed =
+        json['is_error'] == true || (subtype is String && subtype != 'success');
+    if (failed) {
+      final result = json['result'];
+      events.add(RunFailed(
+        result is String && result.isNotEmpty
+            ? result
+            : 'Claude run failed${subtype is String ? ' ($subtype)' : ''}',
+      ));
+    } else {
+      events.add(const RunCompleted());
+    }
+    return events;
+  }
+
+  // user (tool_result), rate_limit_event, etc. carry no chat content.
+  return const [];
+}
+
+/// Parses the content blocks of a Claude `assistant` message.
+///
+/// Shared with the Droid parser, whose stream-json assistant events are
+/// expected to be Claude-compatible (best-effort, see library doc).
+List<ChatEvent> _parseClaudeAssistantContent(Object? message) {
+  if (message is! Map<String, dynamic>) return const [];
+  final content = message['content'];
+  if (content is! List) return const [];
+
+  final events = <ChatEvent>[];
+  for (final block in content) {
+    if (block is! Map<String, dynamic>) continue;
+    final blockType = block['type'];
+    if (blockType == 'text') {
+      final text = block['text'];
+      if (text is String && text.isNotEmpty) events.add(TextDelta(text));
+    } else if (blockType == 'thinking') {
+      final thinking = block['thinking'];
+      if (thinking is String && thinking.isNotEmpty) {
+        events.add(ThinkingDelta(thinking));
+      }
+    } else if (blockType == 'tool_use') {
+      final name = block['name'];
+      if (name is String && name.isNotEmpty) events.add(ToolCallStarted(name));
+    }
+  }
+  return events;
+}
+
+/// Codex item types that represent tool invocations.
+/// https://developers.openai.com/codex/noninteractive
+const _codexToolItemTypes = {
+  'command_execution',
+  'file_change',
+  'mcp_tool_call',
+  'web_search',
+};
+
+List<ChatEvent> _parseCodexEvent(Map<String, dynamic> json) {
+  final type = json['type'];
+
+  if (type == 'thread.started') {
+    final threadId = json['thread_id'];
+    if (threadId is String && threadId.isNotEmpty) {
+      return [SessionStarted(threadId)];
+    }
+    return const [];
+  }
+
+  if (type == 'item.started') {
+    final item = json['item'];
+    if (item is! Map<String, dynamic>) return const [];
+    final itemType = item['type'];
+    if (itemType is String && _codexToolItemTypes.contains(itemType)) {
+      return [ToolCallStarted(itemType)];
+    }
+    return const [];
+  }
+
+  if (type == 'item.completed') {
+    final item = json['item'];
+    if (item is! Map<String, dynamic>) return const [];
+    final itemType = item['type'];
+    if (itemType == 'agent_message') {
+      final text = item['text'];
+      if (text is String && text.isNotEmpty) return [TextDelta(text)];
+    } else if (itemType == 'reasoning') {
+      // `text` is a plain string in current releases; older builds emitted
+      // a list of strings. Accept both.
+      final raw = item['text'];
+      final text = switch (raw) {
+        String s => s,
+        List l => l.whereType<String>().join('\n'),
+        _ => '',
+      };
+      if (text.isNotEmpty) return [ThinkingDelta(text)];
+    }
+    return const [];
+  }
+
+  if (type == 'turn.completed') {
+    final events = <ChatEvent>[];
+    final usage = json['usage'];
+    if (usage is Map<String, dynamic>) {
+      events.add(UsageUpdated(
+        inputTokens: _asInt(usage['input_tokens']),
+        outputTokens: _asInt(usage['output_tokens']),
+      ));
+    }
+    events.add(const RunCompleted());
+    return events;
+  }
+
+  if (type == 'turn.failed') {
+    final error = json['error'];
+    String? message;
+    if (error is Map<String, dynamic>) {
+      final m = error['message'];
+      if (m is String && m.isNotEmpty) message = m;
+    } else if (error is String && error.isNotEmpty) {
+      message = error;
+    }
+    return [RunFailed(message ?? 'Codex turn failed')];
+  }
+
+  if (type == 'error') {
+    final message = json['message'];
+    return [
+      RunFailed(message is String && message.isNotEmpty ? message : 'Codex error'),
+    ];
+  }
+
+  // turn.started and friends carry no chat content.
+  return const [];
+}
+
+List<ChatEvent> _parseDroidEvent(Map<String, dynamic> json) {
+  final type = json['type'];
+
+  // Documented shape (also the whole payload of `-o json`):
+  // {"type":"result","subtype":"success","is_error":false,"duration_ms":N,
+  //  "num_turns":N,"result":"...","session_id":"..."}
+  if (type == 'result') {
+    final events = <ChatEvent>[];
+    final sessionId = json['session_id'];
+    if (sessionId is String && sessionId.isNotEmpty) {
+      events.add(SessionStarted(sessionId));
+    }
+    final subtype = json['subtype'];
+    final failed =
+        json['is_error'] == true || (subtype is String && subtype != 'success');
+    final result = json['result'];
+    if (failed) {
+      events.add(RunFailed(
+        result is String && result.isNotEmpty ? result : 'Droid run failed',
+      ));
+    } else {
+      events.add(const RunCompleted());
+    }
+    return events;
+  }
+
+  // Best-effort Claude-compatible shapes (stream-json schema undocumented).
+  if (type == 'system' && json['subtype'] == 'init') {
+    final sessionId = json['session_id'];
+    if (sessionId is String && sessionId.isNotEmpty) {
+      return [SessionStarted(sessionId)];
+    }
+    return const [];
+  }
+  if (type == 'assistant') {
+    return _parseClaudeAssistantContent(json['message']);
+  }
+  if (type == 'text' || type == 'text_delta' || type == 'message') {
+    final text = json['text'] ?? json['delta'];
+    if (text is String && text.isNotEmpty) return [TextDelta(text)];
+    return const [];
+  }
+  if (type == 'tool_call' || type == 'tool_use' || type == 'tool.started') {
+    final name = json['name'] ?? json['tool'];
+    if (name is String && name.isNotEmpty) return [ToolCallStarted(name)];
+    return const [];
+  }
+
+  return const [];
+}

--- a/lib/services/agent/headless/chat_session_store.dart
+++ b/lib/services/agent/headless/chat_session_store.dart
@@ -1,0 +1,299 @@
+/// Persists Remote UI chat history per (SSH connection, agent kind) in
+/// SharedPreferences as JSON.
+///
+/// Layout: one SharedPreferences string key per pair,
+/// `remote_ui_chat_sessions_<connectionId>_<agentKind>`, holding a JSON
+/// list of session objects:
+/// ```json
+/// [{
+///   "id": "…",
+///   "agentKind": "claudeCode",
+///   "title": "…",
+///   "createdAt": "2026-08-08T01:23:45.000",
+///   "messages": [{"role": "user", "text": "…", "timestamp": "…"}]
+/// }]
+/// ```
+/// At most [ChatSessionStore.maxSessions] sessions are kept per key; the
+/// oldest are dropped first. Sessions are stored newest-first.
+library;
+
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:uuid/uuid.dart';
+
+import '../agent_types.dart';
+
+/// Who authored a stored chat message.
+enum ChatRole {
+  user('user'),
+  assistant('assistant');
+
+  const ChatRole(this.wireName);
+
+  /// Serialized form used in the JSON payload.
+  final String wireName;
+
+  /// Parses [wireName]; unknown values default to [ChatRole.assistant]
+  /// so old payloads never crash the load path.
+  static ChatRole parse(String? wireName) => switch (wireName) {
+        'user' => ChatRole.user,
+        _ => ChatRole.assistant,
+      };
+}
+
+/// One stored chat message.
+class ChatMessageRecord {
+  /// Author of the message.
+  final ChatRole role;
+
+  /// Message text.
+  final String text;
+
+  /// When the message was recorded.
+  final DateTime timestamp;
+
+  const ChatMessageRecord({
+    required this.role,
+    required this.text,
+    required this.timestamp,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'role': role.wireName,
+        'text': text,
+        'timestamp': timestamp.toIso8601String(),
+      };
+
+  /// Strictly parses one message entry; returns null on malformed input.
+  static ChatMessageRecord? fromJson(Object? json) {
+    if (json is! Map<String, dynamic>) return null;
+    final text = json['text'];
+    final timestampRaw = json['timestamp'];
+    if (text is! String || timestampRaw is! String) return null;
+    final timestamp = DateTime.tryParse(timestampRaw);
+    if (timestamp == null) return null;
+    final roleRaw = json['role'];
+    return ChatMessageRecord(
+      role: ChatRole.parse(roleRaw is String ? roleRaw : null),
+      text: text,
+      timestamp: timestamp,
+    );
+  }
+}
+
+/// One stored chat session with its message history.
+class ChatSessionRecord {
+  /// Unique session id (UUID v4).
+  final String id;
+
+  /// Which agent this conversation ran on.
+  final AgentKind agentKind;
+
+  /// Title shown in the session list. Empty until the first user message,
+  /// from which [ChatSessionStore.addMessage] derives it.
+  final String title;
+
+  /// When the session was created.
+  final DateTime createdAt;
+
+  /// Messages in chronological order.
+  final List<ChatMessageRecord> messages;
+
+  /// The agent-side session id captured from its output, used to resume
+  /// the conversation after an app restart. Null until the agent
+  /// announces it (or forever, when the agent reports none).
+  final String? remoteSessionId;
+
+  const ChatSessionRecord({
+    required this.id,
+    required this.agentKind,
+    required this.title,
+    required this.createdAt,
+    required this.messages,
+    this.remoteSessionId,
+  });
+
+  ChatSessionRecord copyWith({
+    String? title,
+    List<ChatMessageRecord>? messages,
+    String? remoteSessionId,
+  }) {
+    return ChatSessionRecord(
+      id: id,
+      agentKind: agentKind,
+      title: title ?? this.title,
+      createdAt: createdAt,
+      messages: messages ?? this.messages,
+      remoteSessionId: remoteSessionId ?? this.remoteSessionId,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'agentKind': agentKind.name,
+        'title': title,
+        'createdAt': createdAt.toIso8601String(),
+        'messages': messages.map((m) => m.toJson()).toList(),
+        if (remoteSessionId != null) 'remoteSessionId': remoteSessionId,
+      };
+
+  /// Strictly parses one session entry; returns null on malformed input.
+  static ChatSessionRecord? fromJson(Object? json) {
+    if (json is! Map<String, dynamic>) return null;
+    final id = json['id'];
+    final agentKindRaw = json['agentKind'];
+    final createdAtRaw = json['createdAt'];
+    if (id is! String || agentKindRaw is! String || createdAtRaw is! String) {
+      return null;
+    }
+    final agentKind = AgentKind.values.asNameMap()[agentKindRaw];
+    final createdAt = DateTime.tryParse(createdAtRaw);
+    if (agentKind == null || createdAt == null) return null;
+    final title = json['title'];
+    final messagesRaw = json['messages'];
+    final messages = <ChatMessageRecord>[
+      if (messagesRaw is List)
+        for (final m in messagesRaw)
+          if (ChatMessageRecord.fromJson(m) case final message?) message,
+    ];
+    final remoteSessionId = json['remoteSessionId'];
+    return ChatSessionRecord(
+      id: id,
+      agentKind: agentKind,
+      title: title is String ? title : '',
+      createdAt: createdAt,
+      messages: messages,
+      remoteSessionId:
+          remoteSessionId is String ? remoteSessionId : null,
+    );
+  }
+}
+
+/// SharedPreferences-backed store for Remote UI chat histories.
+class ChatSessionStore {
+  /// Maximum sessions kept per (connection, agent) pair.
+  static const int maxSessions = 50;
+
+  /// SharedPreferences key prefix, per the repo's `remote_ui_` convention.
+  static const String _keyPrefix = 'remote_ui_chat_sessions_';
+
+  /// Length of a derived session title.
+  static const int _titleMaxLength = 40;
+
+  static const _uuid = Uuid();
+
+  String _key(String connectionId, AgentKind kind) =>
+      '$_keyPrefix${connectionId}_${kind.name}';
+
+  /// Loads all sessions for the pair, newest first. Returns an empty list
+  /// when nothing is stored or the payload is corrupted.
+  Future<List<ChatSessionRecord>> load(
+    String connectionId,
+    AgentKind kind,
+  ) async {
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString(_key(connectionId, kind));
+    if (raw == null || raw.isEmpty) return const [];
+    final Object? decoded;
+    try {
+      decoded = jsonDecode(raw);
+    } on FormatException {
+      return const [];
+    }
+    if (decoded is! List) return const [];
+    return [
+      for (final entry in decoded)
+        if (ChatSessionRecord.fromJson(entry) case final session?) session,
+    ];
+  }
+
+  /// Overwrites the stored session list for the pair, keeping at most
+  /// [maxSessions] entries (oldest dropped).
+  Future<void> save(
+    String connectionId,
+    AgentKind kind,
+    List<ChatSessionRecord> sessions,
+  ) async {
+    final prefs = await SharedPreferences.getInstance();
+    final trimmed = sessions.length > maxSessions
+        ? sessions.sublist(0, maxSessions)
+        : sessions;
+    await prefs.setString(
+      _key(connectionId, kind),
+      jsonEncode(trimmed.map((s) => s.toJson()).toList()),
+    );
+  }
+
+  /// Creates an empty session, prepends it (trimming to [maxSessions]) and
+  /// returns it. [title] may be empty; it is then derived from the first
+  /// user message by [addMessage].
+  Future<ChatSessionRecord> createSession(
+    String connectionId,
+    AgentKind kind, {
+    String title = '',
+  }) async {
+    final session = ChatSessionRecord(
+      id: _uuid.v4(),
+      agentKind: kind,
+      title: title,
+      createdAt: DateTime.now(),
+      messages: const [],
+    );
+    final sessions = await load(connectionId, kind);
+    await save(connectionId, kind, [session, ...sessions]);
+    return session;
+  }
+
+  /// Appends [message] to the session [sessionId]. Unknown session ids are
+  /// ignored. Derives the session title from the first user message when
+  /// no title is set yet.
+  Future<void> addMessage(
+    String connectionId,
+    AgentKind kind,
+    String sessionId,
+    ChatMessageRecord message,
+  ) async {
+    final sessions = await load(connectionId, kind);
+    final index = sessions.indexWhere((s) => s.id == sessionId);
+    if (index == -1) return;
+
+    final session = sessions[index];
+    var title = session.title;
+    if (title.isEmpty && message.role == ChatRole.user) {
+      final firstLine = message.text.trim().split('\n').first;
+      title = firstLine.length <= _titleMaxLength
+          ? firstLine
+          : '${firstLine.substring(0, _titleMaxLength)}…';
+    }
+    sessions[index] = session.copyWith(
+      title: title,
+      messages: [...session.messages, message],
+    );
+    await save(connectionId, kind, sessions);
+  }
+
+  /// Records the agent-side session id for [sessionId] so the
+  /// conversation can be resumed in a later app session. Unknown session
+  /// ids are ignored.
+  Future<void> setRemoteSessionId(
+    String connectionId,
+    AgentKind kind,
+    String sessionId,
+    String remoteSessionId,
+  ) async {
+    final sessions = await load(connectionId, kind);
+    final index = sessions.indexWhere((s) => s.id == sessionId);
+    if (index == -1) return;
+    sessions[index] = sessions[index].copyWith(
+      remoteSessionId: remoteSessionId,
+    );
+    await save(connectionId, kind, sessions);
+  }
+
+  /// Deletes all sessions for the pair.
+  Future<void> clear(String connectionId, AgentKind kind) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_key(connectionId, kind));
+  }
+}

--- a/lib/services/agent/headless/headless_agent_session.dart
+++ b/lib/services/agent/headless/headless_agent_session.dart
@@ -1,0 +1,180 @@
+import 'dart:async';
+
+import '../../ssh/ssh_client.dart';
+import '../agent_types.dart';
+import 'chat_event.dart';
+import 'chat_event_parser.dart';
+import 'headless_command_builder.dart';
+
+/// A chat conversation with one AI CLI agent running headlessly over SSH.
+///
+/// Each user prompt spawns a new remote process via [SshClient.execStream]
+/// (agents have no persistent headless stdin protocol in the modes used
+/// here); follow-up prompts pass the captured [sessionId] through the
+/// agent's resume flag (`--resume` for Claude, `exec resume` for Codex,
+/// `--session-id` for Droid) so conversation context is preserved.
+///
+/// Usage:
+/// ```dart
+/// final session = HeadlessAgentSession(ssh: ssh, kind: AgentKind.claudeCode);
+/// final sub = session.events.listen((event) { ... });
+/// await session.start('Summarize this repo');
+/// // ... after RunCompleted:
+/// await session.send('Now list the risky parts');
+/// ```
+///
+/// Listen to [events] before calling [start]: the stream is broadcast and
+/// events emitted without a listener are lost. Runs are serialized —
+/// calling [start]/[send] while a run is active throws a [StateError].
+class HeadlessAgentSession {
+  HeadlessAgentSession({
+    required SshClient ssh,
+    required AgentKind kind,
+    String? model,
+    UnifiedIntelligence? intelligence,
+    UnifiedPermission? permission,
+    bool planMode = false,
+    String? workingDirectory,
+    String? resumeSessionId,
+  })  : _ssh = ssh,
+        _kind = kind,
+        _model = model,
+        _intelligence = intelligence,
+        _permission = permission,
+        _planMode = planMode,
+        _workingDirectory = workingDirectory,
+        _sessionId = resumeSessionId;
+
+  final SshClient _ssh;
+  final AgentKind _kind;
+  final String? _model;
+  final UnifiedIntelligence? _intelligence;
+  final UnifiedPermission? _permission;
+  final bool _planMode;
+  final String? _workingDirectory;
+
+  final _eventsController = StreamController<ChatEvent>.broadcast();
+
+  StreamSubscription<ChatEvent>? _activeRun;
+  Completer<void>? _activeDone;
+  String? _sessionId;
+  bool _disposed = false;
+
+  /// Parsed chat events from the current and past runs.
+  Stream<ChatEvent> get events => _eventsController.stream;
+
+  /// The agent's session id, captured from its output. Null until the
+  /// agent announces it (or never, if the agent does not report one).
+  String? get sessionId => _sessionId;
+
+  /// Whether a run is currently streaming.
+  bool get isRunning => _activeRun != null;
+
+  /// Starts a fresh conversation with [prompt].
+  ///
+  /// The returned future completes when the run ends: a terminal event
+  /// ([RunCompleted]/[RunFailed]), the output stream closing, or
+  /// [cancel]. Progress events are delivered through [events], which
+  /// should be listened to before calling this method. Throws
+  /// [StateError] if a run is already active.
+  Future<void> start(String prompt) => _run(prompt, resume: false);
+
+  /// Sends a follow-up [prompt], resuming the stored [sessionId].
+  ///
+  /// Throws [StateError] if a run is active or no session id has been
+  /// captured yet (without one, context cannot be resumed).
+  Future<void> send(String prompt) {
+    final id = _sessionId;
+    if (id == null) {
+      throw StateError(
+        'Cannot send a follow-up: no session id captured yet. '
+        'Use start() to begin a new conversation.',
+      );
+    }
+    return _run(prompt, resume: true);
+  }
+
+  Future<void> _run(String prompt, {required bool resume}) {
+    if (_disposed) {
+      throw StateError('HeadlessAgentSession is disposed');
+    }
+    if (_activeRun != null) {
+      throw StateError('A run is already in progress');
+    }
+
+    final command = buildHeadlessCommand(
+      kind: _kind,
+      prompt: prompt,
+      model: _model,
+      intelligence: _intelligence,
+      permission: _permission,
+      planMode: _planMode,
+      resumeSessionId: resume ? _sessionId : null,
+      workingDirectory: _workingDirectory,
+    );
+
+    // execStream throws synchronously when the SSH connection is down;
+    // let that propagate to the caller of start()/send().
+    final output = _ssh.execStream(command);
+
+    var terminalEmitted = false;
+    final done = Completer<void>();
+    _activeDone = done;
+    _activeRun = parseAgentEventStream(_kind, output).listen(
+      (event) {
+        if (event is SessionStarted) {
+          _sessionId = event.sessionId;
+        }
+        if (event is RunCompleted || event is RunFailed) {
+          terminalEmitted = true;
+        }
+        _eventsController.add(event);
+      },
+      onError: (Object error) {
+        // Non-zero exit or SSH disconnect mid-run. When the parser
+        // already emitted a terminal event (agents print an error result
+        // line and then exit non-zero), do not emit a duplicate.
+        if (!terminalEmitted) {
+          _eventsController.add(RunFailed(error.toString()));
+        }
+        if (!done.isCompleted) done.complete();
+      },
+      onDone: () {
+        // The process exited cleanly without a parseable terminal event;
+        // synthesize completion so listeners never wait forever.
+        if (!terminalEmitted) {
+          _eventsController.add(const RunCompleted());
+        }
+        if (!done.isCompleted) done.complete();
+      },
+      cancelOnError: true,
+    );
+
+    return done.future.whenComplete(() {
+      _activeRun = null;
+      _activeDone = null;
+    });
+  }
+
+  /// Cancels the active run, killing the remote process by closing its
+  /// SSH exec channel. Does nothing when no run is active.
+  Future<void> cancel() async {
+    final run = _activeRun;
+    final done = _activeDone;
+    _activeRun = null;
+    _activeDone = null;
+    // Cancelling the subscription closes the exec channel (see
+    // SshClient.execStream onCancel), which kills the remote process.
+    await run?.cancel();
+    // Unblock callers awaiting start()/send(); the subscription is already
+    // cancelled so done would never complete otherwise.
+    if (done != null && !done.isCompleted) done.complete();
+  }
+
+  /// Cancels any active run and closes the event stream.
+  Future<void> dispose() async {
+    _disposed = true;
+    await cancel();
+    await _eventsController.close();
+  }
+}

--- a/lib/services/agent/headless/headless_command_builder.dart
+++ b/lib/services/agent/headless/headless_command_builder.dart
@@ -1,0 +1,300 @@
+/// Builds the remote shell command that runs an AI CLI agent in headless
+/// (non-interactive, machine-readable) mode.
+///
+/// Flag references (verified 2026-08):
+///
+/// * Claude Code — https://code.claude.com/docs/en/cli-reference
+///   `claude -p "<prompt>" --output-format stream-json --verbose`
+///   (`--verbose` is required for `-p` + `stream-json`), `--model`,
+///   `--effort low|medium|high|xhigh|max|ultracode`,
+///   `--permission-mode default|acceptEdits|plan|auto|dontAsk|bypassPermissions`,
+///   `--resume <session-id>`.
+///
+/// * Codex CLI — https://developers.openai.com/codex/noninteractive and
+///   https://learn.chatgpt.com/docs/developer-commands?surface=cli
+///   `codex exec --json "<prompt>"` (JSONL events on stdout),
+///   `-m/--model`, `-s/--sandbox read-only|workspace-write|danger-full-access`,
+///   `-c key=value` config overrides, `codex exec resume` with a session id
+///   and follow-up prompt. Note: the `resume` subcommand rejects `-m`, `-s` and `-C`
+///   (codex-cli 0.125, https://github.com/garrytan/gstack/issues/1258), so
+///   resumed runs pass model/sandbox/effort via `-c` overrides instead.
+///
+/// * Factory Droid — https://docs.factory.ai/droid-exec/overview and
+///   https://docs.factory.ai/docs/droid-cli/cli-reference
+///   `droid exec -o stream-json "<prompt>"` (NDJSON event stream),
+///   `-m/--model`, `-r/--reasoning-effort` (in `droid exec`, `-r` means
+///   reasoning-effort, NOT resume), `--auto low|medium|high`,
+///   `--use-spec`, `--session-id <id>` to continue a session.
+library;
+
+import '../agent_types.dart';
+
+/// Builds the full shell command for [kind], running [prompt] headlessly.
+///
+/// The prompt is single-quote shell-escaped. When [workingDirectory] is
+/// provided the command is prefixed with `cd <dir> &&` so the agent starts
+/// in the pane's directory (uniform across agents; Codex `exec resume` has
+/// no working-directory flag, so a shell `cd` is the only portable option).
+///
+/// [resumeSessionId] continues a previous agent session; pass null for a
+/// fresh conversation. [permission] == [UnifiedPermission.custom] (or null)
+/// omits all permission flags so the agent's own config file applies.
+String buildHeadlessCommand({
+  required AgentKind kind,
+  required String prompt,
+  String? model,
+  UnifiedIntelligence? intelligence,
+  UnifiedPermission? permission,
+  bool planMode = false,
+  String? resumeSessionId,
+  String? workingDirectory,
+}) {
+  final command = switch (kind) {
+    AgentKind.claudeCode => _buildClaudeCommand(
+        prompt,
+        model: model,
+        intelligence: intelligence,
+        permission: permission,
+        planMode: planMode,
+        resumeSessionId: resumeSessionId,
+      ),
+    AgentKind.codex => _buildCodexCommand(
+        prompt,
+        model: model,
+        intelligence: intelligence,
+        permission: permission,
+        resumeSessionId: resumeSessionId,
+      ),
+    AgentKind.droid => _buildDroidCommand(
+        prompt,
+        model: model,
+        intelligence: intelligence,
+        permission: permission,
+        planMode: planMode,
+        resumeSessionId: resumeSessionId,
+      ),
+  };
+
+  final dir = workingDirectory;
+  if (dir != null && dir.isNotEmpty) {
+    return 'cd ${_shSingleQuote(dir)} && $command';
+  }
+  return command;
+}
+
+/// Shell-escapes [value] by wrapping it in single quotes.
+///
+/// Mirrors `SshClient._shSingleQuote`; duplicated here (2nd occurrence, per
+/// the DRY rule of three) so this builder stays a pure string function with
+/// no dependency on the SSH layer.
+String _shSingleQuote(String value) => "'${value.replaceAll("'", r"'\''")}'";
+
+String _buildClaudeCommand(
+  String prompt, {
+  String? model,
+  UnifiedIntelligence? intelligence,
+  UnifiedPermission? permission,
+  required bool planMode,
+  String? resumeSessionId,
+}) {
+  final args = <String>[
+    'claude',
+    '-p',
+    _shSingleQuote(prompt),
+    '--output-format',
+    'stream-json',
+    // stream-json with -p requires --verbose (CLI reference, see above).
+    '--verbose',
+  ];
+  if (model != null && model.isNotEmpty) {
+    args.addAll(['--model', _shSingleQuote(model)]);
+  }
+  final effort = _claudeEffort(intelligence);
+  if (effort != null) {
+    args.addAll(['--effort', effort]);
+  }
+  // Plan mode is expressed through the permission mode and wins over the
+  // autonomy mapping when both are set.
+  final mode = planMode ? 'plan' : _claudePermissionMode(permission);
+  if (mode != null) {
+    args.addAll(['--permission-mode', mode]);
+  }
+  if (resumeSessionId != null && resumeSessionId.isNotEmpty) {
+    args.addAll(['--resume', _shSingleQuote(resumeSessionId)]);
+  }
+  return args.join(' ');
+}
+
+/// Maps unified reasoning levels to Claude `--effort` values.
+/// https://code.claude.com/docs/en/cli-reference (`--effort`).
+String? _claudeEffort(UnifiedIntelligence? level) => switch (level) {
+      UnifiedIntelligence.low => 'low',
+      UnifiedIntelligence.medium => 'medium',
+      UnifiedIntelligence.high => 'high',
+      UnifiedIntelligence.extraHigh => 'xhigh',
+      UnifiedIntelligence.max => 'max',
+      UnifiedIntelligence.ultra => 'ultracode',
+      null => null,
+    };
+
+/// Maps unified autonomy to Claude `--permission-mode` values.
+/// https://code.claude.com/docs/en/permission-modes
+///
+/// [UnifiedPermission.readOnly] maps to `default`: edits/commands require
+/// approval, which headless runs cannot grant, so the run stays read-only
+/// in practice. [UnifiedPermission.custom] (and null) defers to the user's
+/// settings files.
+String? _claudePermissionMode(UnifiedPermission? permission) =>
+    switch (permission) {
+      UnifiedPermission.readOnly => 'default',
+      UnifiedPermission.defaultPermissions => 'acceptEdits',
+      UnifiedPermission.autoReview => 'auto',
+      UnifiedPermission.fullAccess => 'bypassPermissions',
+      UnifiedPermission.custom => null,
+      null => null,
+    };
+
+String _buildCodexCommand(
+  String prompt, {
+  String? model,
+  UnifiedIntelligence? intelligence,
+  UnifiedPermission? permission,
+  String? resumeSessionId,
+}) {
+  // Codex has no headless plan-mode flag (`/plan` is TUI-only); planMode is
+  // silently unsupported for codex exec.
+  if (resumeSessionId != null && resumeSessionId.isNotEmpty) {
+    // `codex exec resume` accepts only -c/--config, --enable/--disable,
+    // --last, --all and the inherited --json (codex-cli 0.125). Model,
+    // sandbox and effort therefore go through -c config overrides.
+    final args = <String>[
+      'codex',
+      'exec',
+      'resume',
+      _shSingleQuote(resumeSessionId),
+      '--json',
+    ];
+    if (model != null && model.isNotEmpty) {
+      args.addAll(['-c', _shSingleQuote('model="$model"')]);
+    }
+    final sandbox = _codexSandbox(permission);
+    if (sandbox != null) {
+      args.addAll(['-c', _shSingleQuote('sandbox_mode="$sandbox"')]);
+    }
+    final effort = _codexEffort(intelligence);
+    if (effort != null) {
+      args.addAll(['-c', _shSingleQuote('model_reasoning_effort="$effort"')]);
+    }
+    args.add(_shSingleQuote(prompt));
+    return args.join(' ');
+  }
+
+  final args = <String>['codex', 'exec', '--json'];
+  if (model != null && model.isNotEmpty) {
+    args.addAll(['-m', _shSingleQuote(model)]);
+  }
+  final sandbox = _codexSandbox(permission);
+  if (sandbox != null) {
+    args.addAll(['-s', sandbox]);
+  }
+  final effort = _codexEffort(intelligence);
+  if (effort != null) {
+    // No dedicated CLI flag; config key override is the documented path.
+    args.addAll(['-c', _shSingleQuote('model_reasoning_effort="$effort"')]);
+  }
+  args.add(_shSingleQuote(prompt));
+  return args.join(' ');
+}
+
+/// Maps unified autonomy to Codex `--sandbox` values.
+/// https://developers.openai.com/codex/noninteractive
+///
+/// [UnifiedPermission.autoReview] degrades to `workspace-write`: codex exec
+/// is non-interactive and has no auto-review classifier, so approval
+/// prompts can never be answered. [UnifiedPermission.custom] (and null)
+/// defers to `config.toml`.
+String? _codexSandbox(UnifiedPermission? permission) => switch (permission) {
+      UnifiedPermission.readOnly => 'read-only',
+      UnifiedPermission.defaultPermissions => 'workspace-write',
+      UnifiedPermission.autoReview => 'workspace-write',
+      UnifiedPermission.fullAccess => 'danger-full-access',
+      UnifiedPermission.custom => null,
+      null => null,
+    };
+
+/// Maps unified reasoning levels to Codex `model_reasoning_effort` values.
+///
+/// Codex supports at most `xhigh`; [UnifiedIntelligence.max] and
+/// [UnifiedIntelligence.ultra] clamp to it.
+String? _codexEffort(UnifiedIntelligence? level) => switch (level) {
+      UnifiedIntelligence.low => 'low',
+      UnifiedIntelligence.medium => 'medium',
+      UnifiedIntelligence.high => 'high',
+      UnifiedIntelligence.extraHigh => 'xhigh',
+      UnifiedIntelligence.max => 'xhigh',
+      UnifiedIntelligence.ultra => 'xhigh',
+      null => null,
+    };
+
+String _buildDroidCommand(
+  String prompt, {
+  String? model,
+  UnifiedIntelligence? intelligence,
+  UnifiedPermission? permission,
+  required bool planMode,
+  String? resumeSessionId,
+}) {
+  final args = <String>['droid', 'exec', '-o', 'stream-json'];
+  if (model != null && model.isNotEmpty) {
+    args.addAll(['-m', _shSingleQuote(model)]);
+  }
+  final effort = _droidEffort(intelligence);
+  if (effort != null) {
+    // In `droid exec`, `-r` is --reasoning-effort (NOT --resume).
+    args.addAll(['-r', effort]);
+  }
+  final auto = _droidAutoLevel(permission);
+  if (auto != null) {
+    args.addAll(['--auto', auto]);
+  }
+  if (planMode) {
+    // Droid's plan-before-execute mode.
+    args.add('--use-spec');
+  }
+  if (resumeSessionId != null && resumeSessionId.isNotEmpty) {
+    args.addAll(['--session-id', _shSingleQuote(resumeSessionId)]);
+  }
+  args.add(_shSingleQuote(prompt));
+  return args.join(' ');
+}
+
+/// Maps unified autonomy to Droid `--auto` levels.
+/// https://docs.factory.ai/droid-exec/overview#autonomy-levels
+///
+/// [UnifiedPermission.readOnly] needs no flag: droid exec is read-only
+/// (spec-mode) by default. [UnifiedPermission.fullAccess] deliberately maps
+/// to `--auto high` rather than `--skip-permissions-unsafe`, which Factory
+/// reserves for disposable containers.
+String? _droidAutoLevel(UnifiedPermission? permission) => switch (permission) {
+      UnifiedPermission.readOnly => null,
+      UnifiedPermission.defaultPermissions => 'low',
+      UnifiedPermission.autoReview => 'medium',
+      UnifiedPermission.fullAccess => 'high',
+      UnifiedPermission.custom => null,
+      null => null,
+    };
+
+/// Maps unified reasoning levels to Droid `-r/--reasoning-effort` values.
+///
+/// Valid levels are model-dependent (https://docs.factory.ai/docs/models);
+/// `low|medium|high` pass through and anything higher clamps to `high`,
+/// the documented safe ceiling.
+String? _droidEffort(UnifiedIntelligence? level) => switch (level) {
+      UnifiedIntelligence.low => 'low',
+      UnifiedIntelligence.medium => 'medium',
+      UnifiedIntelligence.high => 'high',
+      UnifiedIntelligence.extraHigh => 'high',
+      UnifiedIntelligence.max => 'high',
+      UnifiedIntelligence.ultra => 'high',
+      null => null,
+    };

--- a/lib/services/ssh/connection_credentials.dart
+++ b/lib/services/ssh/connection_credentials.dart
@@ -1,0 +1,34 @@
+import '../keychain/secure_storage.dart';
+import 'ssh_client.dart';
+
+/// Builds [SshConnectOptions] from a stored connection's credentials.
+///
+/// Centralizes the key-vs-password credential resolution shared by
+/// providers that open ad-hoc SSH connections (Remote UI, alert panes).
+class ConnectionCredentials {
+  ConnectionCredentials._();
+
+  /// Resolves the credentials for a connection described by [authMethod]
+  /// (`'key'` or `'password'`), [keyId] and [connectionId] into
+  /// [SshConnectOptions].
+  static Future<SshConnectOptions> resolve({
+    required String connectionId,
+    required String authMethod,
+    String? keyId,
+    String? tmuxPath,
+    SecureStorageService? storage,
+  }) async {
+    final store = storage ?? SecureStorageService();
+    if (authMethod == 'key' && keyId != null) {
+      return SshConnectOptions(
+        privateKey: await store.getPrivateKey(keyId),
+        passphrase: await store.getPassphrase(keyId),
+        tmuxPath: tmuxPath,
+      );
+    }
+    return SshConnectOptions(
+      password: await store.getPassword(connectionId),
+      tmuxPath: tmuxPath,
+    );
+  }
+}

--- a/lib/services/ssh/ssh_client.dart
+++ b/lib/services/ssh/ssh_client.dart
@@ -938,6 +938,119 @@ class SshClient {
     }
   }
 
+  /// コマンドを実行し、stdoutを増分ストリーミングする
+  ///
+  /// [exec] と異なり、長時間実行されるコマンド（ヘッドレスAIエージェント等）の
+  /// 出力をリアルタイムに購読できる。バイト列は `utf8.decoder` でストリーム
+  /// デコードするため、チャンク境界でマルチバイト文字が分割されても壊れない
+  /// （[exec] のバイト蓄積→一括デコードと同等のUTF-8安全性）。
+  ///
+  /// execロックはストリームの生存期間中保持される（[exec] と同じ排他規律）。
+  /// そのためストリームが開いている間、他の [exec]/[execWithExitCode] 呼び出しは
+  /// ブロックされる。長時間のストリーミングには専用のSSH接続を使うこと。
+  ///
+  /// stderrはNDJSONストリームの行汚染を防ぐためストリームには混ぜずバッファし、
+  /// プロセスが非ゼロ終了した場合に限り [SshConnectionError] として通知する。
+  /// リスナーがキャンセルするとチャネルを閉じ、リモートプロセスを終了させる。
+  ///
+  /// [command] 実行コマンド
+  /// 戻り値: デコード済みstdoutチャンクのストリーム
+  Stream<String> execStream(String command) {
+    if (!isConnected || _client == null) {
+      throw SshConnectionError('Not connected');
+    }
+
+    final resolvedCommand = _resolveTmuxCommand(command);
+    SSHSession? session;
+    var cancelled = false;
+    final cancelCompleter = Completer<void>();
+
+    final controller = StreamController<String>();
+    controller.onCancel = () {
+      cancelled = true;
+      // チャネルを閉じてリモートプロセスを終了させる
+      session?.close();
+      // 待機中の stdout/stderr 完了待ちを解除し、execロックを解放させる。
+      // リモートがCLOSEを返さない（半開き/切断）場合にロックが永久に
+      // 保持されるのを防ぐ。
+      if (!cancelCompleter.isCompleted) cancelCompleter.complete();
+    };
+
+    // ロック取得を含めて非同期で開始し、ストリームは即座に返す。
+    unawaited(_withExecLock(() async {
+      if (cancelled) return;
+      try {
+        session = await _client!.execute(resolvedCommand);
+        // execute() 完了までにキャンセルされた場合は、起動したばかりの
+        // リモートプロセスを放置せずチャネルを閉じて終了させる。
+        if (cancelled) {
+          session?.close();
+          return;
+        }
+        final activeSession = session!;
+
+        // stdoutは増分デコードしてそのまま流す
+        // （cast: utf8.decoder は StreamTransformer<List<int>, String> なので
+        //   Stream<Uint8List> を List<int> として扱えるようキャストする）
+        final stdoutDone = Completer<void>();
+        final stdoutSubscription =
+            activeSession.stdout.cast<List<int>>().transform(utf8.decoder).listen(
+          (text) {
+            if (!controller.isClosed) controller.add(text);
+          },
+          onDone: () => stdoutDone.complete(),
+          onError: (Object e) => stdoutDone.completeError(e),
+        );
+
+        // stderrはエラー報告用にバッファするだけ（ストリームには流さない）
+        final stderrBytes = <int>[];
+        final stderrDone = Completer<void>();
+        final stderrSubscription = activeSession.stderr.listen(
+          (data) => stderrBytes.addAll(data),
+          onDone: () => stderrDone.complete(),
+          onError: (Object e) => stderrDone.completeError(e),
+        );
+
+        try {
+          // キャンセルとのレース: キャンセル時はリモートのCLOSE待ちで
+          // 永久にブロックせず、ロック解放を優先する。
+          await Future.any([
+            Future.wait([stdoutDone.future, stderrDone.future]),
+            cancelCompleter.future,
+          ]);
+        } finally {
+          await stdoutSubscription.cancel();
+          await stderrSubscription.cancel();
+        }
+
+        final exitCode = activeSession.exitCode;
+        activeSession.close();
+
+        if (controller.isClosed) return;
+        if (exitCode != null && exitCode != 0) {
+          final stderrText =
+              utf8.decode(stderrBytes, allowMalformed: true).trim();
+          controller.addError(SshConnectionError(
+            'Command exited with code $exitCode'
+            '${stderrText.isEmpty ? '' : ': $stderrText'}',
+          ));
+        }
+        await controller.close();
+      } catch (e) {
+        session?.close();
+        if (controller.isClosed) return;
+        controller.addError(
+          e is SshConnectionError
+              ? e
+              : SshConnectionError('Failed to execute command: $e', e),
+        );
+        await controller.close();
+      }
+    }));
+
+    return controller.stream;
+  }
+
   /// イベントハンドラを設定する
   void setEventHandlers(SshEvents events) {
     _events = events;

--- a/lib/services/tmux/tmux_commands.dart
+++ b/lib/services/tmux/tmux_commands.dart
@@ -341,6 +341,12 @@ class TmuxCommands {
     return 'tmux display-message -p -t ${_escapeArg(target)} "#{pane_mode}"';
   }
 
+  /// ペインで実行中のコマンド名を取得（エージェント終了検出用）
+  static String getPaneCurrentCommand(String target) {
+    return 'tmux display-message -p -t ${_escapeArg(target)} '
+        '"#{pane_current_command}"';
+  }
+
   /// copy-modeに入る
   static String enterCopyMode(String target) {
     return 'tmux copy-mode -t ${_escapeArg(target)}';

--- a/test/providers/remote_ui_chat_provider_test.dart
+++ b/test/providers/remote_ui_chat_provider_test.dart
@@ -1,0 +1,147 @@
+import 'dart:convert';
+
+import 'package:flutter_muxpod/providers/remote_ui_chat_provider.dart';
+import 'package:flutter_muxpod/providers/remote_ui_provider.dart';
+import 'package:flutter_muxpod/services/agent/agent_types.dart';
+import 'package:flutter_muxpod/services/agent/headless/chat_session_store.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// RemoteUiNotifier with a fixed connected state (no real SSH).
+class _FixedRemoteUiNotifier extends RemoteUiNotifier {
+  _FixedRemoteUiNotifier(this._state);
+
+  final RemoteUiState _state;
+
+  @override
+  RemoteUiState build() => _state;
+}
+
+/// Chat notifier seeded into a mid-streaming state, as if a headless run
+/// were in flight (the run itself is not reproducible without SSH; the
+/// streaming state is what cancel()/openSession() must handle).
+class _StreamingChatNotifier extends RemoteUiChatNotifier {
+  @override
+  RemoteUiChatState build() {
+    super.build();
+    return const RemoteUiChatState(
+      activeSessionId: 's1',
+      isStreaming: true,
+      streamingText: 'partial answer',
+      messages: [],
+    );
+  }
+}
+
+String _sessionsPayload() {
+  return jsonEncode([
+    {
+      'id': 's1',
+      'agentKind': 'claudeCode',
+      'title': 'first',
+      'createdAt': '2026-08-08T12:00:00.000',
+      'messages': [
+        {'role': 'user', 'text': 'hi', 'timestamp': '2026-08-08T12:00:01.000'},
+      ],
+    },
+    {
+      'id': 's2',
+      'agentKind': 'claudeCode',
+      'title': 'second',
+      'createdAt': '2026-08-08T12:10:00.000',
+      'messages': [
+        {
+          'role': 'user',
+          'text': 'other',
+          'timestamp': '2026-08-08T12:10:01.000',
+        },
+      ],
+    },
+  ]);
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({
+      'remote_ui_chat_sessions_c1_claudeCode': _sessionsPayload(),
+    });
+  });
+
+  ProviderContainer makeContainer() {
+    return ProviderContainer(
+      overrides: [
+        remoteUiProvider.overrideWith(
+          () => _FixedRemoteUiNotifier(
+            const RemoteUiState(connectionId: 'c1', isConnected: true),
+          ),
+        ),
+        remoteUiChatProvider.overrideWith(_StreamingChatNotifier.new),
+      ],
+    );
+  }
+
+  group('RemoteUiChatNotifier streaming lifecycle', () {
+    test('cancel resets isStreaming and persists the partial response',
+        () async {
+      final container = makeContainer();
+      addTearDown(container.dispose);
+      final notifier = container.read(remoteUiChatProvider.notifier);
+      await notifier.loadSessions();
+
+      await notifier.cancel();
+
+      final state = container.read(remoteUiChatProvider);
+      expect(state.isStreaming, isFalse);
+      expect(state.streamingText, isEmpty);
+      // The partial response lands in the visible (still active) session.
+      expect(state.messages.last.text, 'partial answer');
+      expect(state.messages.last.role, ChatRole.assistant);
+
+      // And it is persisted under the correct session id.
+      final stored = await ChatSessionStore().load('c1', AgentKind.claudeCode);
+      final s1 = stored.firstWhere((s) => s.id == 's1');
+      expect(s1.messages.last.text, 'partial answer');
+      expect(s1.messages.last.role, ChatRole.assistant);
+    });
+
+    test('openSession mid-stream finalizes the old run without corrupting '
+        'the newly opened session', () async {
+      final container = makeContainer();
+      addTearDown(container.dispose);
+      final notifier = container.read(remoteUiChatProvider.notifier);
+      await notifier.loadSessions();
+
+      await notifier.openSession('s2');
+
+      final state = container.read(remoteUiChatProvider);
+      expect(state.activeSessionId, 's2');
+      expect(state.isStreaming, isFalse);
+      // The opened session shows only its own messages.
+      expect(state.messages.map((m) => m.text), ['other']);
+
+      // The old session kept the partial response; the new one did not.
+      final stored = await ChatSessionStore().load('c1', AgentKind.claudeCode);
+      final s1 = stored.firstWhere((s) => s.id == 's1');
+      final s2 = stored.firstWhere((s) => s.id == 's2');
+      expect(s1.messages.last.text, 'partial answer');
+      expect(s2.messages.length, 1);
+    });
+
+    test('newSession mid-stream clears streaming state', () async {
+      final container = makeContainer();
+      addTearDown(container.dispose);
+      final notifier = container.read(remoteUiChatProvider.notifier);
+      await notifier.loadSessions();
+
+      await notifier.newSession();
+
+      final state = container.read(remoteUiChatProvider);
+      expect(state.activeSessionId, isNull);
+      expect(state.isStreaming, isFalse);
+      expect(state.messages, isEmpty);
+    });
+  });
+}

--- a/test/screens/remote_ui/remote_ui_screen_test.dart
+++ b/test/screens/remote_ui/remote_ui_screen_test.dart
@@ -1,0 +1,453 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_muxpod/providers/remote_ui_chat_provider.dart';
+import 'package:flutter_muxpod/providers/remote_ui_provider.dart';
+import 'package:flutter_muxpod/screens/remote_ui/remote_ui_screen.dart';
+import 'package:flutter_muxpod/services/agent/agent_types.dart';
+import 'package:flutter_muxpod/services/agent/claude_code_adapter.dart';
+import 'package:flutter_muxpod/services/agent/headless/chat_session_store.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Remote UI provider with a fixed state; apply calls are recorded
+/// instead of touching SSH/tmux.
+class _FixedRemoteUiNotifier extends RemoteUiNotifier {
+  _FixedRemoteUiNotifier(this._initialState);
+
+  final RemoteUiState _initialState;
+
+  final List<String> appliedModels = [];
+  final List<UnifiedIntelligence> appliedIntelligence = [];
+  final List<UnifiedPermission> appliedPermissions = [];
+  final List<bool> planModeCalls = [];
+
+  @override
+  RemoteUiState build() => _initialState;
+
+  @override
+  Future<void> applyModel(String model) async {
+    appliedModels.add(model);
+  }
+
+  @override
+  Future<void> applyIntelligence(UnifiedIntelligence level) async {
+    appliedIntelligence.add(level);
+  }
+
+  @override
+  Future<void> applyPermission(UnifiedPermission level) async {
+    appliedPermissions.add(level);
+  }
+
+  @override
+  Future<void> setPlanMode(bool enabled) async {
+    planModeCalls.add(enabled);
+  }
+}
+
+/// Chat provider with a fixed initial state. Network/store operations
+/// are recorded; the pure state setters are inherited from the base
+/// notifier.
+class _FakeRemoteUiChatNotifier extends RemoteUiChatNotifier {
+  _FakeRemoteUiChatNotifier(this._initialState);
+
+  final RemoteUiChatState _initialState;
+
+  final List<String> sentTexts = [];
+  int cancelCalls = 0;
+  int newSessionCalls = 0;
+  int clearHistoryCalls = 0;
+  AgentKind? selectedAgent;
+  String? openedSessionId;
+
+  @override
+  RemoteUiChatState build() => _initialState;
+
+  @override
+  Future<void> selectAgent(AgentKind kind) async {
+    selectedAgent = kind;
+    state = state.copyWith(
+      agentKind: kind,
+      pendingConfig: const AgentConfig(),
+    );
+  }
+
+  @override
+  Future<void> loadSessions() async {}
+
+  @override
+  Future<void> newSession() async {
+    newSessionCalls++;
+    state = state.copyWith(
+      activeSessionId: null,
+      messages: const [],
+      streamingText: '',
+      isStreaming: false,
+    );
+  }
+
+  @override
+  Future<void> openSession(String sessionId) async {
+    openedSessionId = sessionId;
+    final session =
+        state.sessions.where((s) => s.id == sessionId).firstOrNull;
+    if (session == null) return;
+    state = state.copyWith(
+      activeSessionId: sessionId,
+      messages: session.messages,
+      streamingText: '',
+      isStreaming: false,
+    );
+  }
+
+  @override
+  Future<void> send(String text) async {
+    sentTexts.add(text);
+  }
+
+  @override
+  Future<void> cancel() async {
+    cancelCalls++;
+    state = state.copyWith(isStreaming: false, streamingText: '');
+  }
+
+  @override
+  Future<void> clearHistory() async {
+    clearHistoryCalls++;
+    state = state.copyWith(
+      sessions: const [],
+      activeSessionId: null,
+      messages: const [],
+    );
+  }
+}
+
+Widget _buildApp(
+  _FakeRemoteUiChatNotifier chat, {
+  _FixedRemoteUiNotifier? remote,
+}) {
+  return ProviderScope(
+    overrides: [
+      remoteUiProvider.overrideWith(
+        () => remote ?? _FixedRemoteUiNotifier(const RemoteUiState()),
+      ),
+      remoteUiChatProvider.overrideWith(() => chat),
+    ],
+    child: const MaterialApp(home: RemoteUiScreen()),
+  );
+}
+
+ChatMessageRecord _userMessage(String text) => ChatMessageRecord(
+      role: ChatRole.user,
+      text: text,
+      timestamp: DateTime(2026, 8, 8, 12),
+    );
+
+void main() {
+  setUp(() {
+    // ConnectionsNotifier loads from SharedPreferences at build time.
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  group('RemoteUiScreen', () {
+    testWidgets('empty state renders server picker, toggle and agent picker',
+        (tester) async {
+      final chat = _FakeRemoteUiChatNotifier(const RemoteUiChatState());
+      await tester.pumpWidget(_buildApp(chat));
+      await tester.pumpAndSettle();
+
+      expect(find.text("Let's work on"), findsOneWidget);
+      expect(find.text('Select a server'), findsOneWidget);
+      expect(find.text('Workspace'), findsOneWidget);
+      expect(find.text('Worktree'), findsOneWidget);
+      expect(find.byKey(const Key('remote_ui.agent_picker')), findsOneWidget);
+      expect(find.text('New chat'), findsOneWidget);
+
+      // No mockup placeholder model names; the default label is "Auto".
+      expect(find.text('Auto'), findsOneWidget);
+      expect(find.text('GPT-5.6-Sol'), findsNothing);
+
+      // The mic button was removed (no backend exists).
+      expect(find.byIcon(Icons.mic_none_outlined), findsNothing);
+      expect(find.byKey(const Key('remote_ui.send_button')), findsOneWidget);
+    });
+
+    testWidgets('chips open sheets and reflect the pending config selection',
+        (tester) async {
+      final chat = _FakeRemoteUiChatNotifier(const RemoteUiChatState());
+      await tester.pumpWidget(_buildApp(chat));
+      await tester.pumpAndSettle();
+
+      // Model + intelligence chip.
+      await tester.tap(find.byKey(const Key('remote_ui.model_chip')));
+      await tester.pumpAndSettle();
+      expect(find.text('Intelligence'), findsOneWidget);
+      await tester.tap(find.text('High'));
+      await tester.pumpAndSettle();
+      expect(find.text('Auto High'), findsOneWidget);
+      expect(chat.state.pendingConfig.intelligence, UnifiedIntelligence.high);
+
+      // Permission chip.
+      await tester.tap(find.byKey(const Key('remote_ui.permission_chip')));
+      await tester.pumpAndSettle();
+      expect(find.text('Permissions'), findsWidgets); // chip + sheet header
+      await tester.tap(find.text('Read only'));
+      await tester.pumpAndSettle();
+      expect(find.text('Read only'), findsOneWidget);
+      expect(chat.state.pendingConfig.permission, UnifiedPermission.readOnly);
+    });
+
+    testWidgets('agent picker appears in chat mode and switches the agent',
+        (tester) async {
+      final chat = _FakeRemoteUiChatNotifier(const RemoteUiChatState());
+      await tester.pumpWidget(_buildApp(chat));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const Key('remote_ui.agent_picker')));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Claude Code'), findsWidgets); // picker row + sheet
+      expect(find.text('Codex CLI'), findsOneWidget);
+      expect(find.text('Factory Droid'), findsOneWidget);
+
+      await tester.tap(find.text('Codex CLI'));
+      await tester.pumpAndSettle();
+
+      expect(chat.selectedAgent, AgentKind.codex);
+      expect(find.text('Codex CLI'), findsOneWidget); // picker row label
+    });
+
+    testWidgets('live mode hides the agent picker and shows the live config',
+        (tester) async {
+      final remote = _FixedRemoteUiNotifier(
+        RemoteUiState(
+          connectionId: 'c1',
+          isConnected: true,
+          agent: ClaudeCodeAdapter(),
+          agentPaneId: '%3',
+          config: const AgentConfig(
+            model: 'sonnet',
+            intelligence: UnifiedIntelligence.medium,
+            permission: UnifiedPermission.defaultPermissions,
+          ),
+        ),
+      );
+      final chat = _FakeRemoteUiChatNotifier(const RemoteUiChatState());
+      await tester.pumpWidget(_buildApp(chat, remote: remote));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('remote_ui.agent_picker')), findsNothing);
+      expect(find.text('sonnet Medium'), findsOneWidget);
+      expect(find.text('Default permissions'), findsOneWidget);
+      expect(find.text('Detected: Claude Code (pane %3)'), findsOneWidget);
+      expect(remote.appliedModels, isEmpty);
+    });
+
+    testWidgets('live mode applies sheet changes through remoteUiProvider',
+        (tester) async {
+      final remote = _FixedRemoteUiNotifier(
+        RemoteUiState(
+          connectionId: 'c1',
+          isConnected: true,
+          agent: ClaudeCodeAdapter(),
+          agentPaneId: '%3',
+          config: const AgentConfig(
+            model: 'sonnet',
+            intelligence: UnifiedIntelligence.medium,
+          ),
+        ),
+      );
+      final chat = _FakeRemoteUiChatNotifier(const RemoteUiChatState());
+      await tester.pumpWidget(_buildApp(chat, remote: remote));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const Key('remote_ui.model_chip')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('High'));
+      await tester.pumpAndSettle();
+
+      // Only the changed value is applied; the unchanged model is not
+      // re-applied.
+      expect(remote.appliedIntelligence, [UnifiedIntelligence.high]);
+      expect(remote.appliedModels, isEmpty);
+      // Chat pending config stays untouched in live mode.
+      expect(chat.state.pendingConfig.intelligence, isNull);
+    });
+
+    testWidgets('sending a message calls the chat provider and clears field',
+        (tester) async {
+      final chat = _FakeRemoteUiChatNotifier(const RemoteUiChatState());
+      await tester.pumpWidget(_buildApp(chat));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(
+        find.byKey(const Key('remote_ui.composer')),
+        'fix the flaky test',
+      );
+      await tester.tap(find.byKey(const Key('remote_ui.send_button')));
+      await tester.pumpAndSettle();
+
+      expect(chat.sentTexts, ['fix the flaky test']);
+      expect(
+        tester
+            .widget<TextField>(find.byKey(const Key('remote_ui.composer')))
+            .controller!
+            .text,
+        isEmpty,
+      );
+    });
+
+    testWidgets('shows a stop button while streaming; stop cancels the run',
+        (tester) async {
+      final chat = _FakeRemoteUiChatNotifier(
+        RemoteUiChatState(
+          activeSessionId: 's1',
+          messages: [_userMessage('hello')],
+          streamingText: 'Working on it',
+          isStreaming: true,
+        ),
+      );
+      await tester.pumpWidget(_buildApp(chat));
+      // No pumpAndSettle here: the streaming cursor blinks on a timer.
+      await tester.pump();
+
+      expect(find.byKey(const Key('remote_ui.message_list')), findsOneWidget);
+      // The user bubble inside the message list (the app-bar title is
+      // derived from the first user message and also shows "hello").
+      expect(
+        find.descendant(
+          of: find.byKey(const Key('remote_ui.message_list')),
+          matching: find.text('hello'),
+        ),
+        findsOneWidget,
+      );
+      expect(find.textContaining('Working on it'), findsOneWidget);
+      expect(find.byKey(const Key('remote_ui.stop_button')), findsOneWidget);
+      expect(find.byKey(const Key('remote_ui.send_button')), findsNothing);
+
+      await tester.tap(find.byKey(const Key('remote_ui.stop_button')));
+      await tester.pump();
+
+      expect(chat.cancelCalls, 1);
+      expect(find.byKey(const Key('remote_ui.send_button')), findsOneWidget);
+      // The streaming bubble is gone, so no timers remain pending.
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets('history sheet lists sessions and opens one', (tester) async {
+      final session = ChatSessionRecord(
+        id: 's1',
+        agentKind: AgentKind.claudeCode,
+        title: 'Fix bug',
+        createdAt: DateTime(2026, 8, 8, 12, 30),
+        messages: [_userMessage('hi')],
+      );
+      final chat = _FakeRemoteUiChatNotifier(
+        RemoteUiChatState(sessions: [session]),
+      );
+      await tester.pumpWidget(_buildApp(chat));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const Key('remote_ui.history_button')));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Chats'), findsOneWidget);
+      expect(find.text('Fix bug'), findsOneWidget);
+
+      await tester.tap(find.text('Fix bug'));
+      await tester.pumpAndSettle();
+
+      expect(chat.openedSessionId, 's1');
+      expect(find.text('hi'), findsOneWidget); // message list shown
+    });
+
+    testWidgets('clear history asks for confirmation', (tester) async {
+      final session = ChatSessionRecord(
+        id: 's1',
+        agentKind: AgentKind.claudeCode,
+        title: 'Fix bug',
+        createdAt: DateTime(2026, 8, 8, 12, 30),
+        messages: const [],
+      );
+      final chat = _FakeRemoteUiChatNotifier(
+        RemoteUiChatState(sessions: [session]),
+      );
+      await tester.pumpWidget(_buildApp(chat));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const Key('remote_ui.history_button')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Clear history'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Clear history?'), findsOneWidget);
+      await tester.tap(find.text('Clear'));
+      await tester.pumpAndSettle();
+
+      expect(chat.clearHistoryCalls, 1);
+    });
+
+    testWidgets('new chat button resets the conversation', (tester) async {
+      final chat = _FakeRemoteUiChatNotifier(
+        RemoteUiChatState(
+          activeSessionId: 's1',
+          messages: [_userMessage('hello')],
+        ),
+      );
+      await tester.pumpWidget(_buildApp(chat));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.descendant(
+          of: find.byKey(const Key('remote_ui.message_list')),
+          matching: find.text('hello'),
+        ),
+        findsOneWidget,
+      );
+      await tester.tap(find.byKey(const Key('remote_ui.new_chat_button')));
+      await tester.pumpAndSettle();
+
+      expect(chat.newSessionCalls, 1);
+      expect(find.text("Let's work on"), findsOneWidget);
+    });
+
+    testWidgets('workspace/worktree toggle updates the chat provider',
+        (tester) async {
+      final chat = _FakeRemoteUiChatNotifier(const RemoteUiChatState());
+      await tester.pumpWidget(_buildApp(chat));
+      await tester.pumpAndSettle();
+
+      expect(chat.state.worktreeMode, isFalse);
+      await tester.tap(find.text('Worktree'));
+      await tester.pumpAndSettle();
+      expect(chat.state.worktreeMode, isTrue);
+    });
+
+    testWidgets('plus menu toggles plan mode; upload without server hints',
+        (tester) async {
+      final chat = _FakeRemoteUiChatNotifier(const RemoteUiChatState());
+      await tester.pumpWidget(_buildApp(chat));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const Key('remote_ui.plus_button')));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Upload photo'), findsOneWidget);
+      expect(find.text('Plan mode'), findsOneWidget);
+
+      await tester.tap(find.text('Plan mode'));
+      await tester.pumpAndSettle();
+      expect(chat.state.pendingConfig.planModeActive, isTrue);
+
+      // Upload photo without a connected server shows an explanation.
+      await tester.tap(find.text('Upload photo'));
+      await tester.pumpAndSettle();
+      expect(
+        find.text('Connect to a server first to upload a photo.'),
+        findsOneWidget,
+      );
+      // Flush the snackbar's auto-dismiss timer.
+      await tester.pumpAndSettle(const Duration(seconds: 5));
+    });
+  });
+}

--- a/test/services/agent/agent_config_service_test.dart
+++ b/test/services/agent/agent_config_service_test.dart
@@ -1,0 +1,288 @@
+import 'package:flutter_muxpod/services/agent/agent_config_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'fake_ssh_client.dart';
+
+void main() {
+  group('AgentConfigService.tomlGetString', () {
+    test('returns the unquoted value of a top-level key', () {
+      const content = 'model = "gpt-5.5"\nmodel_reasoning_effort = "high"\n';
+      expect(AgentConfigService.tomlGetString(content, 'model'), 'gpt-5.5');
+      expect(
+        AgentConfigService.tomlGetString(content, 'model_reasoning_effort'),
+        'high',
+      );
+    });
+
+    test('returns null when the key is absent', () {
+      const content = 'model = "gpt-5.5"\n';
+      expect(AgentConfigService.tomlGetString(content, 'sandbox_mode'), isNull);
+    });
+
+    test('ignores keys inside tables (top-level only)', () {
+      const content = '[profiles.work]\nmodel = "gpt-5.5"\n';
+      expect(AgentConfigService.tomlGetString(content, 'model'), isNull);
+    });
+
+    test('ignores commented-out keys', () {
+      const content = '# model = "gpt-5.5"\n';
+      expect(AgentConfigService.tomlGetString(content, 'model'), isNull);
+    });
+
+    test('strips trailing comments on bare values', () {
+      const content = 'approval_policy = on-request # ask each time\n';
+      expect(
+        AgentConfigService.tomlGetString(content, 'approval_policy'),
+        'on-request',
+      );
+    });
+
+    test('handles single-quoted literal strings', () {
+      const content = "model = 'gpt-5.5'\n";
+      expect(AgentConfigService.tomlGetString(content, 'model'), 'gpt-5.5');
+    });
+  });
+
+  group('AgentConfigService.tomlSetString', () {
+    test('replaces an existing key and preserves unrelated lines', () {
+      const content = '# Codex config\n'
+          'model = "gpt-5"\n'
+          'approval_policy = "on-request"\n'
+          '\n'
+          '[mcp_servers.fs]\n'
+          'command = "npx"\n';
+      final updated = AgentConfigService.tomlSetString(
+        content,
+        'model',
+        'gpt-5.5',
+      );
+      expect(
+        updated,
+        '# Codex config\n'
+        'model = "gpt-5.5"\n'
+        'approval_policy = "on-request"\n'
+        '\n'
+        '[mcp_servers.fs]\n'
+        'command = "npx"\n',
+      );
+    });
+
+    test('appends the key when missing and no table exists', () {
+      const content = 'model = "gpt-5"\n';
+      final updated = AgentConfigService.tomlSetString(
+        content,
+        'sandbox_mode',
+        'read-only',
+      );
+      expect(updated, 'model = "gpt-5"\nsandbox_mode = "read-only"\n');
+    });
+
+    test('inserts before the first table so the key stays top-level', () {
+      const content = 'model = "gpt-5"\n'
+          '\n'
+          '[mcp_servers.fs]\n'
+          'command = "npx"\n';
+      final updated = AgentConfigService.tomlSetString(
+        content,
+        'sandbox_mode',
+        'read-only',
+      );
+      expect(
+        updated,
+        'model = "gpt-5"\n'
+        '\n'
+        'sandbox_mode = "read-only"\n'
+        '[mcp_servers.fs]\n'
+        'command = "npx"\n',
+      );
+    });
+
+    test('does not replace a key that only exists inside a table', () {
+      const content = '[profiles.work]\nmodel = "gpt-5"\n';
+      final updated = AgentConfigService.tomlSetString(
+        content,
+        'model',
+        'gpt-5.5',
+      );
+      expect(
+        updated,
+        'model = "gpt-5.5"\n[profiles.work]\nmodel = "gpt-5"\n',
+      );
+    });
+
+    test('creates content from an empty file', () {
+      expect(
+        AgentConfigService.tomlSetString('', 'model', 'gpt-5.5'),
+        'model = "gpt-5.5"\n',
+      );
+    });
+
+    test('escapes double quotes and backslashes in values', () {
+      final updated = AgentConfigService.tomlSetString(
+        '',
+        'model',
+        'a"b\\c',
+      );
+      expect(updated, 'model = "a\\"b\\\\c"\n');
+      // Round-trip: escaped quotes and backslashes parse back.
+      expect(AgentConfigService.tomlGetString(updated, 'model'), 'a"b\\c');
+    });
+  });
+
+  group('AgentConfigService.jsonSetDotted', () {
+    test('sets a top-level key in an empty document', () {
+      expect(
+        AgentConfigService.jsonSetDotted('', 'model', 'opus'),
+        '{\n  "model": "opus"\n}\n',
+      );
+    });
+
+    test('creates intermediate objects for dotted keys', () {
+      final updated = AgentConfigService.jsonSetDotted(
+        '{}',
+        'permissions.defaultMode',
+        'plan',
+      );
+      expect(
+        updated,
+        '{\n  "permissions": {\n    "defaultMode": "plan"\n  }\n}\n',
+      );
+    });
+
+    test('preserves existing keys and uses 2-space indent', () {
+      const content = '{\n'
+          '  "model": "sonnet",\n'
+          '  "permissions": {\n'
+          '    "allow": [\n'
+          '      "Bash(npm run test *)"\n'
+          '    ]\n'
+          '  }\n'
+          '}\n';
+      final updated = AgentConfigService.jsonSetDotted(
+        content,
+        'permissions.defaultMode',
+        'acceptEdits',
+      );
+      expect(
+        updated,
+        '{\n'
+        '  "model": "sonnet",\n'
+        '  "permissions": {\n'
+        '    "allow": [\n'
+        '      "Bash(npm run test *)"\n'
+        '    ],\n'
+        '    "defaultMode": "acceptEdits"\n'
+        '  }\n'
+        '}\n',
+      );
+    });
+
+    test('throws when the top level is not an object', () {
+      expect(
+        () => AgentConfigService.jsonSetDotted('[1, 2]', 'model', 'opus'),
+        throwsFormatException,
+      );
+    });
+
+    test('throws when a path segment collides with a scalar', () {
+      expect(
+        () => AgentConfigService.jsonSetDotted(
+          '{"permissions": true}',
+          'permissions.defaultMode',
+          'plan',
+        ),
+        throwsFormatException,
+      );
+    });
+  });
+
+  group('AgentConfigService.jsonGetDotted', () {
+    test('reads a nested value', () {
+      const content = '{"permissions": {"defaultMode": "plan"}}';
+      expect(
+        AgentConfigService.jsonGetDotted(content, 'permissions.defaultMode'),
+        'plan',
+      );
+    });
+
+    test('returns null for missing segments', () {
+      const content = '{"permissions": {}}';
+      expect(
+        AgentConfigService.jsonGetDotted(content, 'permissions.defaultMode'),
+        isNull,
+      );
+      expect(
+        AgentConfigService.jsonGetDotted(content, 'other.key'),
+        isNull,
+      );
+    });
+
+    test('returns null for empty content', () {
+      expect(AgentConfigService.jsonGetDotted('', 'model'), isNull);
+    });
+  });
+
+  group('AgentConfigService remote file operations', () {
+    test('readRemoteFile returns null for a missing file', () async {
+      final ssh = FakeSshClient();
+      expect(
+        await AgentConfigService.readRemoteFile(ssh, r'$HOME/x.json'),
+        isNull,
+      );
+    });
+
+    test('readRemoteFile returns file content', () async {
+      final ssh = FakeSshClient(files: {r'$HOME/x.json': '{"a": 1}'});
+      expect(
+        await AgentConfigService.readRemoteFile(ssh, r'$HOME/x.json'),
+        '{"a": 1}',
+      );
+    });
+
+    test('writeRemoteFileAtomic writes content and keeps a one-time backup',
+        () async {
+      const path = r'$HOME/.codex/config.toml';
+      final ssh = FakeSshClient(files: {path: 'model = "gpt-5"\n'});
+
+      await AgentConfigService.writeRemoteFileAtomic(
+        ssh,
+        path,
+        'model = "gpt-5.5"\n',
+      );
+      expect(ssh.files[path], 'model = "gpt-5.5"\n');
+      expect(
+        ssh.files['$path${AgentConfigService.backupSuffix}'],
+        'model = "gpt-5"\n',
+      );
+      // The write went through a temp file + mv (atomic rename).
+      expect(
+        ssh.execCommands.last,
+        allOf(contains('base64 -d'), contains('mv -f --')),
+      );
+
+      // A second write must not overwrite the original backup.
+      await AgentConfigService.writeRemoteFileAtomic(
+        ssh,
+        path,
+        'model = "gpt-6"\n',
+      );
+      expect(ssh.files[path], 'model = "gpt-6"\n');
+      expect(
+        ssh.files['$path${AgentConfigService.backupSuffix}'],
+        'model = "gpt-5"\n',
+      );
+    });
+
+    test('writeRemoteFileAtomic creates the file when it does not exist',
+        () async {
+      const path = r'$HOME/.claude/settings.json';
+      final ssh = FakeSshClient();
+      await AgentConfigService.writeRemoteFileAtomic(ssh, path, '{}\n');
+      expect(ssh.files[path], '{}\n');
+      expect(
+        ssh.files.containsKey('$path${AgentConfigService.backupSuffix}'),
+        isFalse,
+      );
+    });
+  });
+}

--- a/test/services/agent/agent_registry_test.dart
+++ b/test/services/agent/agent_registry_test.dart
@@ -1,0 +1,52 @@
+import 'package:flutter_muxpod/services/agent/agent_registry.dart';
+import 'package:flutter_muxpod/services/agent/agent_types.dart';
+import 'package:flutter_muxpod/services/agent/claude_code_adapter.dart';
+import 'package:flutter_muxpod/services/agent/codex_adapter.dart';
+import 'package:flutter_muxpod/services/agent/factory_droid_adapter.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('AgentRegistry.adapters', () {
+    test('contains all three adapters', () {
+      expect(AgentRegistry.adapters, hasLength(3));
+      expect(
+        AgentRegistry.adapters.map((a) => a.kind),
+        containsAll(AgentKind.values),
+      );
+    });
+  });
+
+  group('AgentRegistry.detect', () {
+    test('detects each agent by bare process name', () {
+      expect(AgentRegistry.detect('claude'), isA<ClaudeCodeAdapter>());
+      expect(AgentRegistry.detect('codex'), isA<CodexAdapter>());
+      expect(AgentRegistry.detect('droid'), isA<FactoryDroidAdapter>());
+    });
+
+    test('matches absolute paths by basename', () {
+      expect(AgentRegistry.detect('/usr/bin/codex'), isA<CodexAdapter>());
+      expect(
+        AgentRegistry.detect('/usr/local/bin/claude'),
+        isA<ClaudeCodeAdapter>(),
+      );
+    });
+
+    test('is case-insensitive and trims whitespace', () {
+      expect(AgentRegistry.detect('Claude'), isA<ClaudeCodeAdapter>());
+      expect(AgentRegistry.detect('  droid  '), isA<FactoryDroidAdapter>());
+    });
+
+    test('returns null for non-agent commands', () {
+      expect(AgentRegistry.detect('bash'), isNull);
+      expect(AgentRegistry.detect('vim'), isNull);
+      // Substring matches must not count.
+      expect(AgentRegistry.detect('claude-helper'), isNull);
+    });
+
+    test('returns null for null or empty input', () {
+      expect(AgentRegistry.detect(null), isNull);
+      expect(AgentRegistry.detect(''), isNull);
+      expect(AgentRegistry.detect('   '), isNull);
+    });
+  });
+}

--- a/test/services/agent/claude_code_adapter_test.dart
+++ b/test/services/agent/claude_code_adapter_test.dart
@@ -1,0 +1,241 @@
+import 'package:flutter_muxpod/services/agent/agent_adapter.dart';
+import 'package:flutter_muxpod/services/agent/agent_types.dart';
+import 'package:flutter_muxpod/services/agent/claude_code_adapter.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'fake_ssh_client.dart';
+
+void main() {
+  final adapter = ClaudeCodeAdapter();
+
+  AgentContext contextFor(FakeSshClient ssh) {
+    return AgentContext(ssh: ssh, paneId: '%7');
+  }
+
+  group('capabilities', () {
+    test('offers model aliases, all effort levels, and plan mode', () {
+      expect(adapter.kind, AgentKind.claudeCode);
+      expect(adapter.processNames, ['claude']);
+      expect(adapter.capabilities.availableModels, contains('opus'));
+      expect(
+        adapter.capabilities.intelligenceLevels,
+        containsAll(UnifiedIntelligence.values),
+      );
+      expect(
+        adapter.capabilities.permissionLevels,
+        containsAll(UnifiedPermission.values),
+      );
+      expect(adapter.capabilities.supportsPlanMode, isTrue);
+      expect(adapter.capabilities.requiresRestartToApply, isFalse);
+    });
+  });
+
+  group('pure mappings', () {
+    test('effortForIntelligence maps every unified level', () {
+      expect(
+        ClaudeCodeAdapter.effortForIntelligence(UnifiedIntelligence.low),
+        'low',
+      );
+      expect(
+        ClaudeCodeAdapter.effortForIntelligence(UnifiedIntelligence.medium),
+        'medium',
+      );
+      expect(
+        ClaudeCodeAdapter.effortForIntelligence(UnifiedIntelligence.high),
+        'high',
+      );
+      expect(
+        ClaudeCodeAdapter.effortForIntelligence(UnifiedIntelligence.extraHigh),
+        'xhigh',
+      );
+      expect(
+        ClaudeCodeAdapter.effortForIntelligence(UnifiedIntelligence.max),
+        'max',
+      );
+      expect(
+        ClaudeCodeAdapter.effortForIntelligence(UnifiedIntelligence.ultra),
+        'ultracode',
+      );
+    });
+
+    test('intelligenceForEffort maps persisted levels only', () {
+      expect(
+        ClaudeCodeAdapter.intelligenceForEffort('xhigh'),
+        UnifiedIntelligence.extraHigh,
+      );
+      // Session-only levels are never persisted.
+      expect(ClaudeCodeAdapter.intelligenceForEffort('max'), isNull);
+      expect(ClaudeCodeAdapter.intelligenceForEffort('ultracode'), isNull);
+    });
+
+    test('modeForPermission maps to Claude permission modes', () {
+      expect(
+        ClaudeCodeAdapter.modeForPermission(UnifiedPermission.readOnly),
+        'default',
+      );
+      expect(
+        ClaudeCodeAdapter.modeForPermission(
+          UnifiedPermission.defaultPermissions,
+        ),
+        'acceptEdits',
+      );
+      expect(
+        ClaudeCodeAdapter.modeForPermission(UnifiedPermission.autoReview),
+        'auto',
+      );
+      expect(
+        ClaudeCodeAdapter.modeForPermission(UnifiedPermission.fullAccess),
+        'bypassPermissions',
+      );
+      expect(
+        ClaudeCodeAdapter.modeForPermission(UnifiedPermission.custom),
+        isNull,
+      );
+    });
+
+    test('permissionForMode maps modes back, plan/dontAsk excluded', () {
+      expect(
+        ClaudeCodeAdapter.permissionForMode('default'),
+        UnifiedPermission.readOnly,
+      );
+      expect(
+        ClaudeCodeAdapter.permissionForMode('manual'),
+        UnifiedPermission.readOnly,
+      );
+      expect(
+        ClaudeCodeAdapter.permissionForMode('acceptEdits'),
+        UnifiedPermission.defaultPermissions,
+      );
+      expect(
+        ClaudeCodeAdapter.permissionForMode('auto'),
+        UnifiedPermission.autoReview,
+      );
+      expect(
+        ClaudeCodeAdapter.permissionForMode('bypassPermissions'),
+        UnifiedPermission.fullAccess,
+      );
+      // Reported via AgentConfig.planModeActive instead.
+      expect(ClaudeCodeAdapter.permissionForMode('plan'), isNull);
+      // No unified equivalent.
+      expect(ClaudeCodeAdapter.permissionForMode('dontAsk'), isNull);
+    });
+  });
+
+  group('applyModel', () {
+    test('types /model into the pane and submits it', () async {
+      final ssh = FakeSshClient();
+      final message = await adapter.applyModel(contextFor(ssh), 'opus');
+      expect(ssh.sentKeyCommands, [
+        'tmux send-keys -t %7 -l -- "/model opus"',
+        'tmux send-keys -t %7 Enter',
+      ]);
+      expect(message, contains('/model opus'));
+    });
+  });
+
+  group('applyIntelligence', () {
+    test('types /effort into the pane and submits it', () async {
+      final ssh = FakeSshClient();
+      final message = await adapter.applyIntelligence(
+        contextFor(ssh),
+        UnifiedIntelligence.extraHigh,
+      );
+      expect(ssh.sentKeyCommands, [
+        'tmux send-keys -t %7 -l -- "/effort xhigh"',
+        'tmux send-keys -t %7 Enter',
+      ]);
+      expect(message, contains('xhigh'));
+    });
+  });
+
+  group('applyPermission', () {
+    test('writes permissions.defaultMode to settings.json', () async {
+      final ssh = FakeSshClient(files: {
+        ClaudeCodeAdapter.settingsPath: '{\n  "model": "sonnet"\n}\n',
+      });
+      final message = await adapter.applyPermission(
+        contextFor(ssh),
+        UnifiedPermission.autoReview,
+      );
+      expect(
+        ssh.files[ClaudeCodeAdapter.settingsPath],
+        '{\n'
+        '  "model": "sonnet",\n'
+        '  "permissions": {\n'
+        '    "defaultMode": "auto"\n'
+        '  }\n'
+        '}\n',
+      );
+      expect(message, contains('"auto"'));
+    });
+
+    test('custom leaves the config file untouched', () async {
+      final ssh = FakeSshClient(files: {
+        ClaudeCodeAdapter.settingsPath: '{}\n',
+      });
+      final message = await adapter.applyPermission(
+        contextFor(ssh),
+        UnifiedPermission.custom,
+      );
+      expect(ssh.files[ClaudeCodeAdapter.settingsPath], '{}\n');
+      // No read and no write command was issued.
+      expect(ssh.execCommands, isEmpty);
+      expect(message, contains('untouched'));
+    });
+  });
+
+  group('setPlanMode', () {
+    test('enable writes defaultMode "plan", disable restores "default"',
+        () async {
+      final ssh = FakeSshClient();
+      await adapter.setPlanMode(contextFor(ssh), true);
+      expect(
+        ssh.files[ClaudeCodeAdapter.settingsPath],
+        '{\n  "permissions": {\n    "defaultMode": "plan"\n  }\n}\n',
+      );
+      await adapter.setPlanMode(contextFor(ssh), false);
+      expect(
+        ssh.files[ClaudeCodeAdapter.settingsPath],
+        '{\n  "permissions": {\n    "defaultMode": "default"\n  }\n}\n',
+      );
+    });
+  });
+
+  group('readConfig', () {
+    test('parses model, effortLevel, and defaultMode', () async {
+      final ssh = FakeSshClient(files: {
+        ClaudeCodeAdapter.settingsPath: '{\n'
+            '  "model": "opus",\n'
+            '  "effortLevel": "xhigh",\n'
+            '  "permissions": {\n'
+            '    "defaultMode": "acceptEdits"\n'
+            '  }\n'
+            '}\n',
+      });
+      final config = await adapter.readConfig(contextFor(ssh));
+      expect(config.model, 'opus');
+      expect(config.intelligence, UnifiedIntelligence.extraHigh);
+      expect(config.permission, UnifiedPermission.defaultPermissions);
+      expect(config.planModeActive, isFalse);
+    });
+
+    test('reports plan mode via planModeActive', () async {
+      final ssh = FakeSshClient(files: {
+        ClaudeCodeAdapter.settingsPath:
+            '{"permissions": {"defaultMode": "plan"}}',
+      });
+      final config = await adapter.readConfig(contextFor(ssh));
+      expect(config.planModeActive, isTrue);
+      expect(config.permission, isNull);
+    });
+
+    test('returns an empty config when the file is missing', () async {
+      final ssh = FakeSshClient();
+      final config = await adapter.readConfig(contextFor(ssh));
+      expect(config.model, isNull);
+      expect(config.intelligence, isNull);
+      expect(config.permission, isNull);
+      expect(config.planModeActive, isFalse);
+    });
+  });
+}

--- a/test/services/agent/codex_adapter_test.dart
+++ b/test/services/agent/codex_adapter_test.dart
@@ -1,0 +1,301 @@
+import 'package:flutter_muxpod/services/agent/agent_adapter.dart';
+import 'package:flutter_muxpod/services/agent/agent_types.dart';
+import 'package:flutter_muxpod/services/agent/codex_adapter.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'fake_ssh_client.dart';
+
+void main() {
+  final adapter = CodexAdapter();
+
+  AgentContext contextFor(FakeSshClient ssh, {String? workingDirectory}) {
+    return AgentContext(
+      ssh: ssh,
+      paneId: '%3',
+      paneWorkingDirectory: workingDirectory,
+    );
+  }
+
+  group('capabilities', () {
+    test('is config-file based and requires a restart to apply', () {
+      expect(adapter.kind, AgentKind.codex);
+      expect(adapter.processNames, ['codex']);
+      expect(adapter.capabilities.requiresRestartToApply, isTrue);
+      // Codex has no max/ultra reasoning rungs.
+      expect(
+        adapter.capabilities.intelligenceLevels,
+        [
+          UnifiedIntelligence.low,
+          UnifiedIntelligence.medium,
+          UnifiedIntelligence.high,
+          UnifiedIntelligence.extraHigh,
+        ],
+      );
+      // TUI plan mode has no deterministic external control.
+      expect(adapter.capabilities.supportsPlanMode, isFalse);
+      // Model IDs vary by provider: free-text entry.
+      expect(adapter.capabilities.availableModels, isEmpty);
+    });
+  });
+
+  group('pure mappings', () {
+    test('reasoningEffortForIntelligence maps supported levels', () {
+      expect(
+        CodexAdapter.reasoningEffortForIntelligence(UnifiedIntelligence.low),
+        'low',
+      );
+      expect(
+        CodexAdapter.reasoningEffortForIntelligence(
+          UnifiedIntelligence.medium,
+        ),
+        'medium',
+      );
+      expect(
+        CodexAdapter.reasoningEffortForIntelligence(UnifiedIntelligence.high),
+        'high',
+      );
+      expect(
+        CodexAdapter.reasoningEffortForIntelligence(
+          UnifiedIntelligence.extraHigh,
+        ),
+        'xhigh',
+      );
+    });
+
+    test('reasoningEffortForIntelligence rejects unsupported levels', () {
+      expect(
+        () => CodexAdapter.reasoningEffortForIntelligence(
+          UnifiedIntelligence.max,
+        ),
+        throwsArgumentError,
+      );
+      expect(
+        () => CodexAdapter.reasoningEffortForIntelligence(
+          UnifiedIntelligence.ultra,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('intelligenceForReasoningEffort maps back, minimal excluded', () {
+      expect(
+        CodexAdapter.intelligenceForReasoningEffort('xhigh'),
+        UnifiedIntelligence.extraHigh,
+      );
+      expect(CodexAdapter.intelligenceForReasoningEffort('minimal'), isNull);
+    });
+
+    test('configForPermission maps to sandbox_mode/approval_policy pairs',
+        () {
+      expect(
+        CodexAdapter.configForPermission(UnifiedPermission.readOnly),
+        (sandboxMode: 'read-only', approvalPolicy: null),
+      );
+      expect(
+        CodexAdapter.configForPermission(UnifiedPermission.defaultPermissions),
+        (sandboxMode: 'workspace-write', approvalPolicy: 'on-request'),
+      );
+      expect(
+        CodexAdapter.configForPermission(UnifiedPermission.autoReview),
+        (sandboxMode: 'workspace-write', approvalPolicy: 'on-failure'),
+      );
+      expect(
+        CodexAdapter.configForPermission(UnifiedPermission.fullAccess),
+        (sandboxMode: 'danger-full-access', approvalPolicy: 'never'),
+      );
+      expect(
+        CodexAdapter.configForPermission(UnifiedPermission.custom),
+        isNull,
+      );
+    });
+
+    test('permissionForConfig maps written combos back', () {
+      expect(
+        CodexAdapter.permissionForConfig('read-only', null),
+        UnifiedPermission.readOnly,
+      );
+      expect(
+        CodexAdapter.permissionForConfig('workspace-write', 'on-request'),
+        UnifiedPermission.defaultPermissions,
+      );
+      expect(
+        CodexAdapter.permissionForConfig('workspace-write', 'on-failure'),
+        UnifiedPermission.autoReview,
+      );
+      expect(
+        CodexAdapter.permissionForConfig('danger-full-access', 'never'),
+        UnifiedPermission.fullAccess,
+      );
+      // Combinations this adapter never writes are custom.
+      expect(
+        CodexAdapter.permissionForConfig('workspace-write', 'never'),
+        UnifiedPermission.custom,
+      );
+      // Not determinable from the file.
+      expect(CodexAdapter.permissionForConfig(null, null), isNull);
+    });
+
+    test('buildRelaunchCommand uses the pane working directory', () {
+      expect(
+        CodexAdapter.buildRelaunchCommand('/home/user/proj'),
+        'cd -- "/home/user/proj" && codex',
+      );
+    });
+
+    test('buildRelaunchCommand falls back to \$HOME', () {
+      expect(
+        CodexAdapter.buildRelaunchCommand(null),
+        r'cd -- "$HOME" && codex',
+      );
+      expect(
+        CodexAdapter.buildRelaunchCommand('  '),
+        r'cd -- "$HOME" && codex',
+      );
+    });
+
+    test('buildRelaunchCommand escapes shell-special characters', () {
+      expect(
+        CodexAdapter.buildRelaunchCommand('/home/a"b\$`x`/c'),
+        r'cd -- "/home/a\"b\$\`x\`/c" && codex',
+      );
+    });
+  });
+
+  group('applyModel', () {
+    test('writes the model key, preserves other lines, and restarts',
+        () async {
+      final ssh = FakeSshClient(files: {
+        CodexAdapter.configPath: '# my config\n'
+            'model = "gpt-5"\n'
+            'approval_policy = "on-request"\n',
+      });
+      final message = await adapter.applyModel(
+        contextFor(ssh, workingDirectory: '/home/user/proj'),
+        'gpt-5.5',
+      );
+      expect(ssh.files[CodexAdapter.configPath], '# my config\n'
+          'model = "gpt-5.5"\n'
+          'approval_policy = "on-request"\n');
+      // Restart: double Ctrl+C, then relaunch in the pane's directory.
+      expect(ssh.sentKeyCommands, [
+        'tmux send-keys -t %3 C-c',
+        'tmux send-keys -t %3 C-c',
+        'tmux send-keys -t %3 -l -- "cd -- \\"/home/user/proj\\" && codex"',
+        'tmux send-keys -t %3 Enter',
+      ]);
+      expect(message, contains('gpt-5.5'));
+      expect(message, contains('restarted'));
+    });
+  });
+
+  group('applyIntelligence', () {
+    test('writes model_reasoning_effort and restarts with \$HOME fallback',
+        () async {
+      final ssh = FakeSshClient();
+      await adapter.applyIntelligence(
+        contextFor(ssh),
+        UnifiedIntelligence.high,
+      );
+      expect(
+        ssh.files[CodexAdapter.configPath],
+        'model_reasoning_effort = "high"\n',
+      );
+      expect(ssh.sentKeyCommands.last, 'tmux send-keys -t %3 Enter');
+      expect(
+        ssh.sentKeyCommands[ssh.sentKeyCommands.length - 2],
+        r'tmux send-keys -t %3 -l -- "cd -- \"\$HOME\" && codex"',
+      );
+    });
+
+    test('rejects unsupported levels without touching the file', () async {
+      final ssh = FakeSshClient();
+      await expectLater(
+        adapter.applyIntelligence(contextFor(ssh), UnifiedIntelligence.max),
+        throwsArgumentError,
+      );
+      expect(ssh.files, isEmpty);
+      expect(ssh.sentKeyCommands, isEmpty);
+    });
+  });
+
+  group('applyPermission', () {
+    test('readOnly writes only sandbox_mode', () async {
+      final ssh = FakeSshClient();
+      await adapter.applyPermission(contextFor(ssh), UnifiedPermission.readOnly);
+      expect(
+        ssh.files[CodexAdapter.configPath],
+        'sandbox_mode = "read-only"\n',
+      );
+    });
+
+    test('defaultPermissions writes sandbox_mode and approval_policy',
+        () async {
+      final ssh = FakeSshClient();
+      await adapter.applyPermission(
+        contextFor(ssh),
+        UnifiedPermission.defaultPermissions,
+      );
+      expect(
+        ssh.files[CodexAdapter.configPath],
+        'sandbox_mode = "workspace-write"\napproval_policy = "on-request"\n',
+      );
+    });
+
+    test('fullAccess writes danger-full-access and never', () async {
+      final ssh = FakeSshClient();
+      await adapter.applyPermission(
+        contextFor(ssh),
+        UnifiedPermission.fullAccess,
+      );
+      expect(
+        ssh.files[CodexAdapter.configPath],
+        'sandbox_mode = "danger-full-access"\napproval_policy = "never"\n',
+      );
+    });
+
+    test('custom leaves the file untouched and does not restart', () async {
+      final ssh = FakeSshClient(files: {CodexAdapter.configPath: ''});
+      final message = await adapter.applyPermission(
+        contextFor(ssh),
+        UnifiedPermission.custom,
+      );
+      expect(ssh.files[CodexAdapter.configPath], '');
+      expect(ssh.sentKeyCommands, isEmpty);
+      expect(message, contains('untouched'));
+    });
+  });
+
+  group('setPlanMode', () {
+    test('explains that plan mode is a TUI-only toggle', () async {
+      final ssh = FakeSshClient();
+      final message = await adapter.setPlanMode(contextFor(ssh), true);
+      expect(message, contains('/plan'));
+      expect(ssh.files, isEmpty);
+      expect(ssh.sentKeyCommands, isEmpty);
+    });
+  });
+
+  group('readConfig', () {
+    test('parses model, effort, and permission from config.toml', () async {
+      final ssh = FakeSshClient(files: {
+        CodexAdapter.configPath: 'model = "gpt-5.5"\n'
+            'model_reasoning_effort = "xhigh"\n'
+            'sandbox_mode = "workspace-write"\n'
+            'approval_policy = "on-failure"\n',
+      });
+      final config = await adapter.readConfig(contextFor(ssh));
+      expect(config.model, 'gpt-5.5');
+      expect(config.intelligence, UnifiedIntelligence.extraHigh);
+      expect(config.permission, UnifiedPermission.autoReview);
+      expect(config.planModeActive, isFalse);
+    });
+
+    test('returns an empty config when the file is missing', () async {
+      final ssh = FakeSshClient();
+      final config = await adapter.readConfig(contextFor(ssh));
+      expect(config.model, isNull);
+      expect(config.intelligence, isNull);
+      expect(config.permission, isNull);
+    });
+  });
+}

--- a/test/services/agent/factory_droid_adapter_test.dart
+++ b/test/services/agent/factory_droid_adapter_test.dart
@@ -1,0 +1,274 @@
+import 'package:flutter_muxpod/services/agent/agent_adapter.dart';
+import 'package:flutter_muxpod/services/agent/agent_types.dart';
+import 'package:flutter_muxpod/services/agent/factory_droid_adapter.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'fake_ssh_client.dart';
+
+void main() {
+  final adapter = FactoryDroidAdapter();
+
+  AgentContext contextFor(FakeSshClient ssh) {
+    return AgentContext(ssh: ssh, paneId: '%9');
+  }
+
+  group('capabilities', () {
+    test('offers reasoning, autonomy, and spec mode', () {
+      expect(adapter.kind, AgentKind.droid);
+      expect(adapter.processNames, ['droid']);
+      // Droid reasoningEffort has no "ultra" rung.
+      expect(
+        adapter.capabilities.intelligenceLevels,
+        [
+          UnifiedIntelligence.low,
+          UnifiedIntelligence.medium,
+          UnifiedIntelligence.high,
+          UnifiedIntelligence.extraHigh,
+          UnifiedIntelligence.max,
+        ],
+      );
+      expect(
+        adapter.capabilities.permissionLevels,
+        containsAll(UnifiedPermission.values),
+      );
+      expect(adapter.capabilities.supportsPlanMode, isTrue);
+      expect(adapter.capabilities.requiresRestartToApply, isFalse);
+      // Model IDs are user/org-specific: free-text entry.
+      expect(adapter.capabilities.availableModels, isEmpty);
+    });
+  });
+
+  group('pure mappings', () {
+    test('reasoningEffortForIntelligence maps supported levels', () {
+      expect(
+        FactoryDroidAdapter.reasoningEffortForIntelligence(
+          UnifiedIntelligence.low,
+        ),
+        'low',
+      );
+      expect(
+        FactoryDroidAdapter.reasoningEffortForIntelligence(
+          UnifiedIntelligence.medium,
+        ),
+        'medium',
+      );
+      expect(
+        FactoryDroidAdapter.reasoningEffortForIntelligence(
+          UnifiedIntelligence.high,
+        ),
+        'high',
+      );
+      expect(
+        FactoryDroidAdapter.reasoningEffortForIntelligence(
+          UnifiedIntelligence.extraHigh,
+        ),
+        'xhigh',
+      );
+      expect(
+        FactoryDroidAdapter.reasoningEffortForIntelligence(
+          UnifiedIntelligence.max,
+        ),
+        'max',
+      );
+    });
+
+    test('reasoningEffortForIntelligence rejects ultra', () {
+      expect(
+        () => FactoryDroidAdapter.reasoningEffortForIntelligence(
+          UnifiedIntelligence.ultra,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('intelligenceForReasoningEffort maps back, off/none excluded', () {
+      expect(
+        FactoryDroidAdapter.intelligenceForReasoningEffort('max'),
+        UnifiedIntelligence.max,
+      );
+      expect(
+        FactoryDroidAdapter.intelligenceForReasoningEffort('xhigh'),
+        UnifiedIntelligence.extraHigh,
+      );
+      expect(
+        FactoryDroidAdapter.intelligenceForReasoningEffort('off'),
+        isNull,
+      );
+      expect(
+        FactoryDroidAdapter.intelligenceForReasoningEffort('dynamic'),
+        isNull,
+      );
+    });
+
+    test('autonomyLevelForPermission maps to Droid autonomy levels', () {
+      expect(
+        FactoryDroidAdapter.autonomyLevelForPermission(
+          UnifiedPermission.readOnly,
+        ),
+        'off',
+      );
+      expect(
+        FactoryDroidAdapter.autonomyLevelForPermission(
+          UnifiedPermission.defaultPermissions,
+        ),
+        'low',
+      );
+      expect(
+        FactoryDroidAdapter.autonomyLevelForPermission(
+          UnifiedPermission.autoReview,
+        ),
+        'medium',
+      );
+      expect(
+        FactoryDroidAdapter.autonomyLevelForPermission(
+          UnifiedPermission.fullAccess,
+        ),
+        'high',
+      );
+      expect(
+        FactoryDroidAdapter.autonomyLevelForPermission(
+          UnifiedPermission.custom,
+        ),
+        isNull,
+      );
+    });
+
+    test('permissionForAutonomyLevel maps back', () {
+      expect(
+        FactoryDroidAdapter.permissionForAutonomyLevel('off'),
+        UnifiedPermission.readOnly,
+      );
+      expect(
+        FactoryDroidAdapter.permissionForAutonomyLevel('low'),
+        UnifiedPermission.defaultPermissions,
+      );
+      expect(
+        FactoryDroidAdapter.permissionForAutonomyLevel('medium'),
+        UnifiedPermission.autoReview,
+      );
+      expect(
+        FactoryDroidAdapter.permissionForAutonomyLevel('high'),
+        UnifiedPermission.fullAccess,
+      );
+      expect(FactoryDroidAdapter.permissionForAutonomyLevel('inherit'), isNull);
+    });
+  });
+
+  group('applyModel', () {
+    test('types /model into the pane and submits it', () async {
+      final ssh = FakeSshClient();
+      final message = await adapter.applyModel(
+        contextFor(ssh),
+        'claude-opus-4-7',
+      );
+      expect(ssh.sentKeyCommands, [
+        'tmux send-keys -t %9 -l -- "/model claude-opus-4-7"',
+        'tmux send-keys -t %9 Enter',
+      ]);
+      expect(message, contains('/model claude-opus-4-7'));
+    });
+  });
+
+  group('applyIntelligence', () {
+    test('writes reasoningEffort to settings.json', () async {
+      final ssh = FakeSshClient(files: {
+        FactoryDroidAdapter.settingsPath: '{\n  "theme": "dark"\n}\n',
+      });
+      final message = await adapter.applyIntelligence(
+        contextFor(ssh),
+        UnifiedIntelligence.high,
+      );
+      expect(
+        ssh.files[FactoryDroidAdapter.settingsPath],
+        '{\n  "theme": "dark",\n  "reasoningEffort": "high"\n}\n',
+      );
+      expect(message, contains('"high"'));
+    });
+  });
+
+  group('applyPermission', () {
+    test('writes sessionDefaultSettings.autonomyLevel', () async {
+      final ssh = FakeSshClient();
+      final message = await adapter.applyPermission(
+        contextFor(ssh),
+        UnifiedPermission.defaultPermissions,
+      );
+      expect(
+        ssh.files[FactoryDroidAdapter.settingsPath],
+        '{\n'
+        '  "sessionDefaultSettings": {\n'
+        '    "autonomyLevel": "low"\n'
+        '  }\n'
+        '}\n',
+      );
+      expect(message, contains('"low"'));
+    });
+
+    test('custom leaves the config file untouched', () async {
+      final ssh = FakeSshClient(files: {
+        FactoryDroidAdapter.settingsPath: '{}\n',
+      });
+      final message = await adapter.applyPermission(
+        contextFor(ssh),
+        UnifiedPermission.custom,
+      );
+      expect(ssh.files[FactoryDroidAdapter.settingsPath], '{}\n');
+      // No read and no write command was issued.
+      expect(ssh.execCommands, isEmpty);
+      expect(message, contains('untouched'));
+    });
+  });
+
+  group('setPlanMode', () {
+    test('toggles sessionDefaultSettings.interactionMode', () async {
+      final ssh = FakeSshClient();
+      await adapter.setPlanMode(contextFor(ssh), true);
+      expect(
+        ssh.files[FactoryDroidAdapter.settingsPath],
+        '{\n'
+        '  "sessionDefaultSettings": {\n'
+        '    "interactionMode": "spec"\n'
+        '  }\n'
+        '}\n',
+      );
+      await adapter.setPlanMode(contextFor(ssh), false);
+      expect(
+        ssh.files[FactoryDroidAdapter.settingsPath],
+        '{\n'
+        '  "sessionDefaultSettings": {\n'
+        '    "interactionMode": "auto"\n'
+        '  }\n'
+        '}\n',
+      );
+    });
+  });
+
+  group('readConfig', () {
+    test('parses model, effort, autonomy, and interaction mode', () async {
+      final ssh = FakeSshClient(files: {
+        FactoryDroidAdapter.settingsPath: '{\n'
+            '  "model": "claude-opus-4-7",\n'
+            '  "reasoningEffort": "xhigh",\n'
+            '  "sessionDefaultSettings": {\n'
+            '    "autonomyLevel": "medium",\n'
+            '    "interactionMode": "spec"\n'
+            '  }\n'
+            '}\n',
+      });
+      final config = await adapter.readConfig(contextFor(ssh));
+      expect(config.model, 'claude-opus-4-7');
+      expect(config.intelligence, UnifiedIntelligence.extraHigh);
+      expect(config.permission, UnifiedPermission.autoReview);
+      expect(config.planModeActive, isTrue);
+    });
+
+    test('returns an empty config when the file is missing', () async {
+      final ssh = FakeSshClient();
+      final config = await adapter.readConfig(contextFor(ssh));
+      expect(config.model, isNull);
+      expect(config.intelligence, isNull);
+      expect(config.permission, isNull);
+      expect(config.planModeActive, isFalse);
+    });
+  });
+}

--- a/test/services/agent/fake_ssh_client.dart
+++ b/test/services/agent/fake_ssh_client.dart
@@ -1,0 +1,75 @@
+import 'dart:convert';
+
+import 'package:flutter_muxpod/services/agent/agent_config_service.dart';
+import 'package:flutter_muxpod/services/ssh/ssh_client.dart';
+
+/// Hand-written fake of [SshClient] for agent adapter tests.
+///
+/// Records every command sent through [sendKeysCommand] and emulates a
+/// tiny remote filesystem for the two command shapes
+/// [AgentConfigService] issues through [execWithExitCode]:
+///
+/// - `cat -- "<path>"` reads a file (exit code 1 when missing).
+/// - The atomic-write pipeline (`printf ... | base64 -d > tmp && mv -f`)
+///   writes a file and keeps a one-time `.muxpod-bak` backup.
+class FakeSshClient extends SshClient {
+  /// Emulated remote filesystem: absolute path -> file content.
+  final Map<String, String> files;
+
+  /// Every command passed to [execWithExitCode], in order.
+  final List<String> execCommands = [];
+
+  /// Every command passed to [sendKeysCommand], in order.
+  final List<String> sentKeyCommands = [];
+
+  FakeSshClient({Map<String, String>? files}) : files = files ?? {};
+
+  @override
+  Future<({String stdout, String stderr, int? exitCode})> execWithExitCode(
+    String command, {
+    Duration? timeout,
+  }) async {
+    execCommands.add(command);
+    final catMatch = RegExp(r'^cat -- "([^"]+)"$').firstMatch(command);
+    if (catMatch != null) {
+      final path = catMatch.group(1)!;
+      final content = files[path];
+      if (content == null) {
+        return (
+          stdout: '',
+          stderr: 'cat: $path: No such file or directory',
+          exitCode: 1,
+        );
+      }
+      return (stdout: content, stderr: '', exitCode: 0);
+    }
+    if (command.contains('base64 -d') && command.contains('mv -f --')) {
+      _emulateAtomicWrite(command);
+      return (stdout: '', stderr: '', exitCode: 0);
+    }
+    return (stdout: '', stderr: '', exitCode: 0);
+  }
+
+  /// Applies the shell semantics of
+  /// [AgentConfigService.writeRemoteFileAtomic] to [files].
+  void _emulateAtomicWrite(String command) {
+    final encoded = RegExp(r"printf '%s' '([A-Za-z0-9+/=]*)'")
+        .firstMatch(command)!
+        .group(1)!;
+    final content = utf8.decode(base64.decode(encoded));
+    final mvMatch =
+        RegExp(r'mv -f -- "([^"]+)" "([^"]+)"').firstMatch(command)!;
+    final target = mvMatch.group(2)!;
+    final backup = '$target${AgentConfigService.backupSuffix}';
+    final existing = files[target];
+    if (existing != null && !files.containsKey(backup)) {
+      files[backup] = existing;
+    }
+    files[target] = content;
+  }
+
+  @override
+  Future<void> sendKeysCommand(String command) async {
+    sentKeyCommands.add(command);
+  }
+}

--- a/test/services/agent/headless/chat_event_parser_test.dart
+++ b/test/services/agent/headless/chat_event_parser_test.dart
@@ -1,0 +1,312 @@
+import 'package:flutter_muxpod/services/agent/agent_types.dart';
+import 'package:flutter_muxpod/services/agent/headless/chat_event.dart';
+import 'package:flutter_muxpod/services/agent/headless/chat_event_parser.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('parseAgentOutputLine', () {
+    group('noise tolerance', () {
+      test('ignores blank lines', () {
+        expect(parseAgentOutputLine(AgentKind.claudeCode, '   '), isEmpty);
+      });
+
+      test('ignores non-JSON lines', () {
+        expect(
+          parseAgentOutputLine(AgentKind.claudeCode, 'Loading plugins...'),
+          isEmpty,
+        );
+      });
+
+      test('ignores JSON values that are not objects', () {
+        expect(parseAgentOutputLine(AgentKind.codex, '[1, 2, 3]'), isEmpty);
+        expect(parseAgentOutputLine(AgentKind.codex, '"text"'), isEmpty);
+        expect(parseAgentOutputLine(AgentKind.codex, '42'), isEmpty);
+      });
+    });
+
+    group('claudeCode', () {
+      test('parses system/init into SessionStarted', () {
+        final events = parseAgentOutputLine(
+          AgentKind.claudeCode,
+          '{"type":"system","subtype":"init","session_id":"sess-1","model":"claude-sonnet-5"}',
+        );
+        expect(events, hasLength(1));
+        expect(events[0], isA<SessionStarted>());
+        expect((events[0] as SessionStarted).sessionId, 'sess-1');
+      });
+
+      test('parses assistant text block into TextDelta', () {
+        final events = parseAgentOutputLine(
+          AgentKind.claudeCode,
+          '{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Hello world"}]}}',
+        );
+        expect(events, hasLength(1));
+        expect(events[0], isA<TextDelta>());
+        expect((events[0] as TextDelta).text, 'Hello world');
+      });
+
+      test('parses thinking, text and tool_use blocks from one message', () {
+        final events = parseAgentOutputLine(
+          AgentKind.claudeCode,
+          '{"type":"assistant","message":{"content":['
+          '{"type":"thinking","thinking":"let me think"},'
+          '{"type":"text","text":"answer"},'
+          '{"type":"tool_use","name":"Bash","input":{"command":"ls"}}'
+          ']}}',
+        );
+        expect(events, hasLength(3));
+        expect(events[0], isA<ThinkingDelta>());
+        expect((events[0] as ThinkingDelta).text, 'let me think');
+        expect(events[1], isA<TextDelta>());
+        expect(events[2], isA<ToolCallStarted>());
+        expect((events[2] as ToolCallStarted).name, 'Bash');
+      });
+
+      test('parses successful result into UsageUpdated + RunCompleted', () {
+        final events = parseAgentOutputLine(
+          AgentKind.claudeCode,
+          '{"type":"result","subtype":"success","is_error":false,'
+          '"session_id":"sess-1","total_cost_usd":0.0123,'
+          '"usage":{"input_tokens":100,"output_tokens":50}}',
+        );
+        expect(events, hasLength(2));
+        final usage = events[0] as UsageUpdated;
+        expect(usage.inputTokens, 100);
+        expect(usage.outputTokens, 50);
+        expect(usage.costUsd, closeTo(0.0123, 1e-9));
+        expect(events[1], isA<RunCompleted>());
+      });
+
+      test('parses error result into RunFailed with result text', () {
+        final events = parseAgentOutputLine(
+          AgentKind.claudeCode,
+          '{"type":"result","subtype":"error_max_turns","is_error":true,"result":"too many turns"}',
+        );
+        expect(events, hasLength(1));
+        expect(events[0], isA<RunFailed>());
+        expect((events[0] as RunFailed).message, 'too many turns');
+      });
+
+      test('ignores user tool_result messages', () {
+        final events = parseAgentOutputLine(
+          AgentKind.claudeCode,
+          '{"type":"user","message":{"content":[{"type":"tool_result","content":"ok"}]}}',
+        );
+        expect(events, isEmpty);
+      });
+    });
+
+    group('codex', () {
+      test('parses thread.started into SessionStarted', () {
+        final events = parseAgentOutputLine(
+          AgentKind.codex,
+          '{"type":"thread.started","thread_id":"0199a213-81c0-7800-8aa1-bbab2a035a53"}',
+        );
+        expect(events, hasLength(1));
+        expect(
+          (events[0] as SessionStarted).sessionId,
+          '0199a213-81c0-7800-8aa1-bbab2a035a53',
+        );
+      });
+
+      test('parses item.started tool item into ToolCallStarted', () {
+        final events = parseAgentOutputLine(
+          AgentKind.codex,
+          '{"type":"item.started","item":{"id":"item_1","type":"command_execution","command":"bash -lc ls","status":"in_progress"}}',
+        );
+        expect(events, hasLength(1));
+        expect((events[0] as ToolCallStarted).name, 'command_execution');
+      });
+
+      test('ignores item.started for non-tool items', () {
+        final events = parseAgentOutputLine(
+          AgentKind.codex,
+          '{"type":"item.started","item":{"id":"item_1","type":"agent_message"}}',
+        );
+        expect(events, isEmpty);
+      });
+
+      test('parses item.completed agent_message into TextDelta', () {
+        final events = parseAgentOutputLine(
+          AgentKind.codex,
+          '{"type":"item.completed","item":{"id":"item_3","type":"agent_message","text":"Repo contains docs."}}',
+        );
+        expect(events, hasLength(1));
+        expect((events[0] as TextDelta).text, 'Repo contains docs.');
+      });
+
+      test('parses item.completed reasoning into ThinkingDelta', () {
+        final events = parseAgentOutputLine(
+          AgentKind.codex,
+          '{"type":"item.completed","item":{"id":"item_0","type":"reasoning","text":"thinking hard"}}',
+        );
+        expect(events, hasLength(1));
+        expect((events[0] as ThinkingDelta).text, 'thinking hard');
+      });
+
+      test('accepts reasoning text as a list of strings', () {
+        final events = parseAgentOutputLine(
+          AgentKind.codex,
+          '{"type":"item.completed","item":{"id":"item_0","type":"reasoning","text":["part a","part b"]}}',
+        );
+        expect(events, hasLength(1));
+        expect((events[0] as ThinkingDelta).text, 'part a\npart b');
+      });
+
+      test('parses turn.completed into UsageUpdated + RunCompleted', () {
+        final events = parseAgentOutputLine(
+          AgentKind.codex,
+          '{"type":"turn.completed","usage":{"input_tokens":24763,"cached_input_tokens":24448,"output_tokens":122}}',
+        );
+        expect(events, hasLength(2));
+        final usage = events[0] as UsageUpdated;
+        expect(usage.inputTokens, 24763);
+        expect(usage.outputTokens, 122);
+        expect(events[1], isA<RunCompleted>());
+      });
+
+      test('parses turn.failed into RunFailed', () {
+        final events = parseAgentOutputLine(
+          AgentKind.codex,
+          '{"type":"turn.failed","error":{"message":"model overloaded"}}',
+        );
+        expect(events, hasLength(1));
+        expect((events[0] as RunFailed).message, 'model overloaded');
+      });
+
+      test('parses error event into RunFailed', () {
+        final events = parseAgentOutputLine(
+          AgentKind.codex,
+          '{"type":"error","message":"stream disconnected"}',
+        );
+        expect(events, hasLength(1));
+        expect((events[0] as RunFailed).message, 'stream disconnected');
+      });
+
+      test('ignores turn.started', () {
+        expect(
+          parseAgentOutputLine(AgentKind.codex, '{"type":"turn.started"}'),
+          isEmpty,
+        );
+      });
+    });
+
+    group('droid', () {
+      test('parses documented result shape into SessionStarted + RunCompleted',
+          () {
+        final events = parseAgentOutputLine(
+          AgentKind.droid,
+          '{"type":"result","subtype":"success","is_error":false,'
+          '"duration_ms":5657,"num_turns":1,"result":"summary text",'
+          '"session_id":"8af22e0a-d222-42c6-8c7e-7a059e391b0b"}',
+        );
+        expect(events, hasLength(2));
+        expect(
+          (events[0] as SessionStarted).sessionId,
+          '8af22e0a-d222-42c6-8c7e-7a059e391b0b',
+        );
+        expect(events[1], isA<RunCompleted>());
+      });
+
+      test('parses error result into RunFailed', () {
+        final events = parseAgentOutputLine(
+          AgentKind.droid,
+          '{"type":"result","subtype":"error","is_error":true,"result":"permission denied","session_id":"s-1"}',
+        );
+        expect(events, hasLength(2));
+        expect(events[0], isA<SessionStarted>());
+        expect((events[1] as RunFailed).message, 'permission denied');
+      });
+
+      test('parses Claude-compatible assistant message best-effort', () {
+        final events = parseAgentOutputLine(
+          AgentKind.droid,
+          '{"type":"assistant","message":{"content":[{"type":"text","text":"hi"}]}}',
+        );
+        expect(events, hasLength(1));
+        expect((events[0] as TextDelta).text, 'hi');
+      });
+
+      test('parses generic text event best-effort', () {
+        final events = parseAgentOutputLine(
+          AgentKind.droid,
+          '{"type":"text","text":"streaming"}',
+        );
+        expect(events, hasLength(1));
+        expect((events[0] as TextDelta).text, 'streaming');
+      });
+
+      test('parses generic tool event best-effort', () {
+        final events = parseAgentOutputLine(
+          AgentKind.droid,
+          '{"type":"tool_call","name":"ApplyPatch"}',
+        );
+        expect(events, hasLength(1));
+        expect((events[0] as ToolCallStarted).name, 'ApplyPatch');
+      });
+    });
+  });
+
+  group('parseAgentEventStream', () {
+    test('reassembles a JSON line split across chunks', () async {
+      const line =
+          '{"type":"assistant","message":{"content":[{"type":"text","text":"split me"}]}}';
+      final chunks = [
+        line.substring(0, 10),
+        line.substring(10, 40),
+        '${line.substring(40)}\n',
+      ];
+      final events = await parseAgentEventStream(
+        AgentKind.claudeCode,
+        Stream.fromIterable(chunks),
+      ).toList();
+      expect(events, hasLength(1));
+      expect((events[0] as TextDelta).text, 'split me');
+    });
+
+    test('parses multiple lines arriving in one chunk', () async {
+      const chunk =
+          '{"type":"system","subtype":"init","session_id":"s-1"}\n'
+          '{"type":"assistant","message":{"content":[{"type":"text","text":"a"}]}}\n'
+          '{"type":"assistant","message":{"content":[{"type":"text","text":"b"}]}}\n';
+      final events = await parseAgentEventStream(
+        AgentKind.claudeCode,
+        Stream.value(chunk),
+      ).toList();
+      expect(events, hasLength(3));
+      expect(events[0], isA<SessionStarted>());
+      expect((events[1] as TextDelta).text, 'a');
+      expect((events[2] as TextDelta).text, 'b');
+    });
+
+    test('flushes a trailing unterminated line when the stream closes',
+        () async {
+      final events = await parseAgentEventStream(
+        AgentKind.codex,
+        Stream.value('{"type":"turn.started"}\n{"type":"error","message":"x"}'),
+      ).toList();
+      expect(events, hasLength(1));
+      expect(events[0], isA<RunFailed>());
+    });
+
+    test('skips noise lines interleaved with JSON', () async {
+      const chunk = 'Compiling...\n'
+          '{"type":"thread.started","thread_id":"t-1"}\n'
+          'some warning\n';
+      final events = await parseAgentEventStream(
+        AgentKind.codex,
+        Stream.value(chunk),
+      ).toList();
+      expect(events, hasLength(1));
+      expect(events[0], isA<SessionStarted>());
+    });
+
+    test('propagates source stream errors', () async {
+      final stream = parseAgentEventStream(
+        AgentKind.claudeCode,
+        Stream.error(StateError('ssh gone')),
+      );
+      await expectLater(stream.toList(), throwsA(isA<StateError>()));
+    });
+  });
+}

--- a/test/services/agent/headless/chat_session_store_test.dart
+++ b/test/services/agent/headless/chat_session_store_test.dart
@@ -1,0 +1,162 @@
+import 'package:flutter_muxpod/services/agent/agent_types.dart';
+import 'package:flutter_muxpod/services/agent/headless/chat_session_store.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late ChatSessionStore store;
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    store = ChatSessionStore();
+  });
+
+  ChatMessageRecord userMessage(String text) => ChatMessageRecord(
+        role: ChatRole.user,
+        text: text,
+        timestamp: DateTime.utc(2026, 8, 8, 12),
+      );
+
+  ChatMessageRecord assistantMessage(String text) => ChatMessageRecord(
+        role: ChatRole.assistant,
+        text: text,
+        timestamp: DateTime.utc(2026, 8, 8, 12, 1),
+      );
+
+  group('ChatSessionStore', () {
+    test('returns an empty list when nothing is stored', () async {
+      expect(await store.load('conn-1', AgentKind.claudeCode), isEmpty);
+    });
+
+    test('createSession + load round-trips', () async {
+      final created = await store.createSession(
+        'conn-1',
+        AgentKind.claudeCode,
+        title: 'My chat',
+      );
+
+      final sessions = await store.load('conn-1', AgentKind.claudeCode);
+      expect(sessions, hasLength(1));
+      final loaded = sessions[0];
+      expect(loaded.id, created.id);
+      expect(loaded.agentKind, AgentKind.claudeCode);
+      expect(loaded.title, 'My chat');
+      expect(loaded.createdAt, created.createdAt);
+      expect(loaded.messages, isEmpty);
+    });
+
+    test('addMessage appends and derives the title from the first user '
+        'message', () async {
+      final session = await store.createSession('conn-1', AgentKind.codex);
+      await store.addMessage(
+        'conn-1',
+        AgentKind.codex,
+        session.id,
+        userMessage('summarize the repo'),
+      );
+      await store.addMessage(
+        'conn-1',
+        AgentKind.codex,
+        session.id,
+        assistantMessage('It contains docs and src.'),
+      );
+
+      final sessions = await store.load('conn-1', AgentKind.codex);
+      expect(sessions, hasLength(1));
+      expect(sessions[0].title, 'summarize the repo');
+      expect(sessions[0].messages, hasLength(2));
+      expect(sessions[0].messages[0].role, ChatRole.user);
+      expect(sessions[0].messages[0].text, 'summarize the repo');
+      expect(sessions[0].messages[1].role, ChatRole.assistant);
+      expect(
+        sessions[0].messages[0].timestamp,
+        DateTime.utc(2026, 8, 8, 12),
+      );
+    });
+
+    test('truncates long derived titles', () async {
+      final session = await store.createSession('conn-1', AgentKind.droid);
+      await store.addMessage(
+        'conn-1',
+        AgentKind.droid,
+        session.id,
+        userMessage('x' * 100),
+      );
+      final sessions = await store.load('conn-1', AgentKind.droid);
+      expect(sessions[0].title.length, 41); // 40 chars + ellipsis
+    });
+
+    test('addMessage ignores unknown session ids', () async {
+      await store.createSession('conn-1', AgentKind.codex);
+      await store.addMessage(
+        'conn-1',
+        AgentKind.codex,
+        'no-such-session',
+        userMessage('hi'),
+      );
+      final sessions = await store.load('conn-1', AgentKind.codex);
+      expect(sessions[0].messages, isEmpty);
+    });
+
+    test('keeps at most 50 sessions, dropping the oldest', () async {
+      for (var i = 0; i < 55; i++) {
+        await store.createSession('conn-1', AgentKind.claudeCode,
+            title: 'chat $i');
+      }
+      final sessions = await store.load('conn-1', AgentKind.claudeCode);
+      expect(sessions, hasLength(50));
+      // Newest-first: the latest session is at the front, the five oldest
+      // (chat 0..4) were dropped.
+      expect(sessions.first.title, 'chat 54');
+      expect(sessions.last.title, 'chat 5');
+    });
+
+    test('save overwrites the list', () async {
+      final a = await store.createSession('conn-1', AgentKind.codex);
+      await store.createSession('conn-1', AgentKind.codex);
+      await store.save('conn-1', AgentKind.codex, [a]);
+      final sessions = await store.load('conn-1', AgentKind.codex);
+      expect(sessions, hasLength(1));
+      expect(sessions[0].id, a.id);
+    });
+
+    test('clear removes all sessions for the pair', () async {
+      await store.createSession('conn-1', AgentKind.claudeCode);
+      await store.clear('conn-1', AgentKind.claudeCode);
+      expect(await store.load('conn-1', AgentKind.claudeCode), isEmpty);
+    });
+
+    test('histories are isolated per connection and agent kind', () async {
+      await store.createSession('conn-1', AgentKind.claudeCode);
+      await store.createSession('conn-2', AgentKind.claudeCode);
+      await store.createSession('conn-1', AgentKind.droid);
+
+      expect(await store.load('conn-1', AgentKind.claudeCode), hasLength(1));
+      expect(await store.load('conn-2', AgentKind.claudeCode), hasLength(1));
+      expect(await store.load('conn-1', AgentKind.droid), hasLength(1));
+      expect(await store.load('conn-2', AgentKind.droid), isEmpty);
+      expect(await store.load('conn-1', AgentKind.codex), isEmpty);
+    });
+
+    test('returns an empty list for corrupted JSON', () async {
+      SharedPreferences.setMockInitialValues({
+        'remote_ui_chat_sessions_conn-1_claudeCode': 'not json {{{',
+      });
+      expect(await store.load('conn-1', AgentKind.claudeCode), isEmpty);
+    });
+
+    test('skips malformed entries inside a valid list', () async {
+      SharedPreferences.setMockInitialValues({
+        'remote_ui_chat_sessions_conn-1_codex':
+            '[{"broken": true}, {"id": "s-1", "agentKind": "codex", '
+                '"title": "ok", "createdAt": "2026-08-08T12:00:00.000Z", '
+                '"messages": []}]',
+      });
+      final sessions = await store.load('conn-1', AgentKind.codex);
+      expect(sessions, hasLength(1));
+      expect(sessions[0].id, 's-1');
+    });
+  });
+}

--- a/test/services/agent/headless/headless_agent_session_test.dart
+++ b/test/services/agent/headless/headless_agent_session_test.dart
@@ -1,0 +1,157 @@
+import 'dart:async';
+
+import 'package:flutter_muxpod/services/agent/agent_types.dart';
+import 'package:flutter_muxpod/services/agent/headless/chat_event.dart';
+import 'package:flutter_muxpod/services/agent/headless/headless_agent_session.dart';
+import 'package:flutter_muxpod/services/ssh/ssh_client.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Hand-written fake that serves canned exec output and records commands.
+class _FakeSshClient extends SshClient {
+  final List<String> commands = [];
+  Stream<String> Function(String command)? onExecStream;
+
+  @override
+  Stream<String> execStream(String command) {
+    commands.add(command);
+    final factory = onExecStream;
+    if (factory == null) {
+      throw StateError('onExecStream not set');
+    }
+    return factory(command);
+  }
+}
+
+void main() {
+  group('HeadlessAgentSession', () {
+    late _FakeSshClient ssh;
+    late HeadlessAgentSession session;
+
+    setUp(() {
+      ssh = _FakeSshClient();
+      session = HeadlessAgentSession(
+        ssh: ssh,
+        kind: AgentKind.claudeCode,
+        workingDirectory: '/repo',
+      );
+    });
+
+    tearDown(() async {
+      await session.dispose();
+    });
+
+    test('streams parsed events and captures the session id', () async {
+      ssh.onExecStream = (_) => Stream.fromIterable([
+            '{"type":"system","subtype":"init","session_id":"sess-1"}\n',
+            '{"type":"assistant","message":{"content":[{"type":"text","text":"Hi"}]}}\n',
+            '{"type":"result","subtype":"success","is_error":false,'
+                '"usage":{"input_tokens":10,"output_tokens":5}}\n',
+          ]);
+
+      final events = <ChatEvent>[];
+      final sub = session.events.listen(events.add);
+
+      await session.start('hello');
+      await sub.cancel();
+
+      expect(events[0], isA<SessionStarted>());
+      expect(events[1], isA<TextDelta>());
+      expect(events[2], isA<UsageUpdated>());
+      expect(events[3], isA<RunCompleted>());
+      expect(session.sessionId, 'sess-1');
+      expect(session.isRunning, isFalse);
+
+      expect(ssh.commands, hasLength(1));
+      expect(ssh.commands[0], startsWith("cd '/repo' && claude -p 'hello'"));
+      expect(ssh.commands[0], isNot(contains('--resume')));
+    });
+
+    test('synthesizes RunCompleted when the stream ends silently', () async {
+      ssh.onExecStream = (_) => Stream.value('noise line\n');
+
+      final events = <ChatEvent>[];
+      final sub = session.events.listen(events.add);
+
+      await session.start('hello');
+      await sub.cancel();
+
+      expect(events, hasLength(1));
+      expect(events[0], isA<RunCompleted>());
+    });
+
+    test('emits RunFailed when the stream errors (SSH disconnect)', () async {
+      ssh.onExecStream =
+          (_) => Stream.error(SshConnectionError('Connection lost'));
+
+      final events = <ChatEvent>[];
+      final sub = session.events.listen(events.add);
+
+      await session.start('hello');
+      await sub.cancel();
+
+      expect(events, hasLength(1));
+      expect(events[0], isA<RunFailed>());
+      expect((events[0] as RunFailed).message, contains('Connection lost'));
+      expect(session.isRunning, isFalse);
+    });
+
+    test('send() resumes with the stored session id', () async {
+      ssh.onExecStream = (_) => Stream.fromIterable([
+            '{"type":"system","subtype":"init","session_id":"sess-1"}\n',
+            '{"type":"result","subtype":"success","is_error":false}\n',
+          ]);
+
+      final sub = session.events.listen((_) {});
+      await session.start('first');
+      await session.send('second');
+      await sub.cancel();
+
+      expect(ssh.commands, hasLength(2));
+      expect(ssh.commands[1], contains("--resume 'sess-1'"));
+      expect(ssh.commands[1], contains("-p 'second'"));
+    });
+
+    test('send() throws when no session id was captured', () {
+      expect(
+        () => session.send('follow-up'),
+        throwsA(isA<StateError>()),
+      );
+    });
+
+    test('start() throws while a run is active', () async {
+      final controller = StreamController<String>();
+      ssh.onExecStream = (_) => controller.stream;
+
+      final sub = session.events.listen((_) {});
+      final runFuture = session.start('hello');
+      expect(session.isRunning, isTrue);
+      expect(() => session.start('again'), throwsA(isA<StateError>()));
+
+      await session.cancel();
+      await runFuture;
+      await sub.cancel();
+      await controller.close();
+    });
+
+    test('cancel() kills the run and unblocks start()', () async {
+      final controller = StreamController<String>();
+      var sourceCancelled = false;
+      controller.onCancel = () {
+        sourceCancelled = true;
+      };
+      ssh.onExecStream = (_) => controller.stream;
+
+      final sub = session.events.listen((_) {});
+      final runFuture = session.start('hello');
+
+      await session.cancel();
+      // start()'s future must complete even though the stream never did.
+      await runFuture;
+
+      expect(sourceCancelled, isTrue);
+      expect(session.isRunning, isFalse);
+      await sub.cancel();
+      await controller.close();
+    });
+  });
+}

--- a/test/services/agent/headless/headless_command_builder_test.dart
+++ b/test/services/agent/headless/headless_command_builder_test.dart
@@ -1,0 +1,332 @@
+import 'package:flutter_muxpod/services/agent/agent_types.dart';
+import 'package:flutter_muxpod/services/agent/headless/headless_command_builder.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('buildHeadlessCommand', () {
+    group('shell escaping', () {
+      test('wraps the prompt in single quotes', () {
+        final command = buildHeadlessCommand(
+          kind: AgentKind.claudeCode,
+          prompt: 'hello world',
+        );
+        expect(command, contains("-p 'hello world'"));
+      });
+
+      test('escapes single quotes in the prompt', () {
+        final command = buildHeadlessCommand(
+          kind: AgentKind.claudeCode,
+          prompt: "it's a test",
+        );
+        expect(command, contains(r"-p 'it'\''s a test'"));
+      });
+
+      test('neutralizes dollar signs, backticks and double quotes', () {
+        const prompt = 'run `rm -rf \$HOME` and say "hi"';
+        final command = buildHeadlessCommand(
+          kind: AgentKind.codex,
+          prompt: prompt,
+        );
+        // Inside single quotes the shell performs no expansion.
+        expect(command, contains("'run `rm -rf \$HOME` and say \"hi\"'"));
+      });
+
+      test('escapes the working directory and prefixes with cd', () {
+        final command = buildHeadlessCommand(
+          kind: AgentKind.droid,
+          prompt: 'x',
+          workingDirectory: "/home/user's dir",
+        );
+        expect(
+          command,
+          startsWith(r"cd '/home/user'\''s dir' && droid exec"),
+        );
+      });
+
+      test('omits cd when no working directory is given', () {
+        final command = buildHeadlessCommand(
+          kind: AgentKind.claudeCode,
+          prompt: 'x',
+        );
+        expect(command, startsWith('claude '));
+      });
+    });
+
+    group('claudeCode', () {
+      test('builds the documented stream-json invocation', () {
+        final command = buildHeadlessCommand(
+          kind: AgentKind.claudeCode,
+          prompt: 'summarize',
+        );
+        expect(
+          command,
+          "claude -p 'summarize' --output-format stream-json --verbose",
+        );
+      });
+
+      test('passes model and effort', () {
+        final command = buildHeadlessCommand(
+          kind: AgentKind.claudeCode,
+          prompt: 'x',
+          model: 'claude-sonnet-5',
+          intelligence: UnifiedIntelligence.ultra,
+        );
+        expect(command, contains("--model 'claude-sonnet-5'"));
+        expect(command, contains('--effort ultracode'));
+      });
+
+      test('maps extraHigh to xhigh', () {
+        final command = buildHeadlessCommand(
+          kind: AgentKind.claudeCode,
+          prompt: 'x',
+          intelligence: UnifiedIntelligence.extraHigh,
+        );
+        expect(command, contains('--effort xhigh'));
+      });
+
+      test('maps permissions to permission-mode', () {
+        expect(
+          buildHeadlessCommand(
+            kind: AgentKind.claudeCode,
+            prompt: 'x',
+            permission: UnifiedPermission.readOnly,
+          ),
+          contains('--permission-mode default'),
+        );
+        expect(
+          buildHeadlessCommand(
+            kind: AgentKind.claudeCode,
+            prompt: 'x',
+            permission: UnifiedPermission.defaultPermissions,
+          ),
+          contains('--permission-mode acceptEdits'),
+        );
+        expect(
+          buildHeadlessCommand(
+            kind: AgentKind.claudeCode,
+            prompt: 'x',
+            permission: UnifiedPermission.autoReview,
+          ),
+          contains('--permission-mode auto'),
+        );
+        expect(
+          buildHeadlessCommand(
+            kind: AgentKind.claudeCode,
+            prompt: 'x',
+            permission: UnifiedPermission.fullAccess,
+          ),
+          contains('--permission-mode bypassPermissions'),
+        );
+      });
+
+      test('custom permission omits permission-mode (config file wins)', () {
+        final command = buildHeadlessCommand(
+          kind: AgentKind.claudeCode,
+          prompt: 'x',
+          permission: UnifiedPermission.custom,
+        );
+        expect(command, isNot(contains('--permission-mode')));
+      });
+
+      test('plan mode forces permission-mode plan', () {
+        final command = buildHeadlessCommand(
+          kind: AgentKind.claudeCode,
+          prompt: 'x',
+          permission: UnifiedPermission.fullAccess,
+          planMode: true,
+        );
+        expect(command, contains('--permission-mode plan'));
+        expect(command, isNot(contains('bypassPermissions')));
+      });
+
+      test('resumes with --resume', () {
+        final command = buildHeadlessCommand(
+          kind: AgentKind.claudeCode,
+          prompt: 'next',
+          resumeSessionId: 'sess-1',
+        );
+        expect(command, contains("--resume 'sess-1'"));
+      });
+    });
+
+    group('codex', () {
+      test('builds codex exec --json with prompt last', () {
+        final command = buildHeadlessCommand(
+          kind: AgentKind.codex,
+          prompt: 'triage',
+        );
+        expect(command, "codex exec --json 'triage'");
+      });
+
+      test('passes model and sandbox', () {
+        final command = buildHeadlessCommand(
+          kind: AgentKind.codex,
+          prompt: 'x',
+          model: 'gpt-5.6',
+          permission: UnifiedPermission.defaultPermissions,
+        );
+        expect(command, contains("-m 'gpt-5.6'"));
+        expect(command, contains('-s workspace-write'));
+      });
+
+      test('maps permissions to sandbox levels', () {
+        expect(
+          buildHeadlessCommand(
+            kind: AgentKind.codex,
+            prompt: 'x',
+            permission: UnifiedPermission.readOnly,
+          ),
+          contains('-s read-only'),
+        );
+        expect(
+          buildHeadlessCommand(
+            kind: AgentKind.codex,
+            prompt: 'x',
+            permission: UnifiedPermission.fullAccess,
+          ),
+          contains('-s danger-full-access'),
+        );
+      });
+
+      test('custom permission omits the sandbox flag', () {
+        final command = buildHeadlessCommand(
+          kind: AgentKind.codex,
+          prompt: 'x',
+          permission: UnifiedPermission.custom,
+        );
+        expect(command, isNot(contains('-s ')));
+      });
+
+      test('passes reasoning effort via config override', () {
+        final command = buildHeadlessCommand(
+          kind: AgentKind.codex,
+          prompt: 'x',
+          intelligence: UnifiedIntelligence.high,
+        );
+        expect(command, contains('-c \'model_reasoning_effort="high"\''));
+      });
+
+      test('clamps max effort to xhigh', () {
+        final command = buildHeadlessCommand(
+          kind: AgentKind.codex,
+          prompt: 'x',
+          intelligence: UnifiedIntelligence.max,
+        );
+        expect(command, contains('-c \'model_reasoning_effort="xhigh"\''));
+      });
+
+      test('resume uses the resume subcommand with config overrides', () {
+        final command = buildHeadlessCommand(
+          kind: AgentKind.codex,
+          prompt: 'fix it',
+          model: 'gpt-5.6',
+          permission: UnifiedPermission.readOnly,
+          intelligence: UnifiedIntelligence.low,
+          resumeSessionId: 'sess-9',
+        );
+        expect(
+          command,
+          "codex exec resume 'sess-9' --json"
+          " -c 'model=\"gpt-5.6\"'"
+          " -c 'sandbox_mode=\"read-only\"'"
+          " -c 'model_reasoning_effort=\"low\"'"
+          " 'fix it'",
+        );
+        // resume rejects -s/-C/-m, so they must never appear.
+        expect(command, isNot(contains(' -s ')));
+        expect(command, isNot(contains(' -m ')));
+      });
+    });
+
+    group('droid', () {
+      test('builds droid exec with stream-json output', () {
+        final command = buildHeadlessCommand(
+          kind: AgentKind.droid,
+          prompt: 'analyze',
+        );
+        expect(command, "droid exec -o stream-json 'analyze'");
+      });
+
+      test('maps permissions to --auto levels', () {
+        expect(
+          buildHeadlessCommand(
+            kind: AgentKind.droid,
+            prompt: 'x',
+            permission: UnifiedPermission.defaultPermissions,
+          ),
+          contains('--auto low'),
+        );
+        expect(
+          buildHeadlessCommand(
+            kind: AgentKind.droid,
+            prompt: 'x',
+            permission: UnifiedPermission.autoReview,
+          ),
+          contains('--auto medium'),
+        );
+        expect(
+          buildHeadlessCommand(
+            kind: AgentKind.droid,
+            prompt: 'x',
+            permission: UnifiedPermission.fullAccess,
+          ),
+          contains('--auto high'),
+        );
+      });
+
+      test('readOnly adds no autonomy flag (read-only is the default)', () {
+        final command = buildHeadlessCommand(
+          kind: AgentKind.droid,
+          prompt: 'x',
+          permission: UnifiedPermission.readOnly,
+        );
+        expect(command, isNot(contains('--auto')));
+      });
+
+      test('never emits --skip-permissions-unsafe', () {
+        final command = buildHeadlessCommand(
+          kind: AgentKind.droid,
+          prompt: 'x',
+          permission: UnifiedPermission.fullAccess,
+        );
+        expect(command, isNot(contains('--skip-permissions-unsafe')));
+      });
+
+      test('plan mode maps to --use-spec', () {
+        final command = buildHeadlessCommand(
+          kind: AgentKind.droid,
+          prompt: 'x',
+          planMode: true,
+        );
+        expect(command, contains('--use-spec'));
+      });
+
+      test('resumes with --session-id', () {
+        final command = buildHeadlessCommand(
+          kind: AgentKind.droid,
+          prompt: 'continue',
+          resumeSessionId: 'sess-7',
+        );
+        expect(command, contains("--session-id 'sess-7'"));
+      });
+
+      test('clamps effort above high to high', () {
+        final command = buildHeadlessCommand(
+          kind: AgentKind.droid,
+          prompt: 'x',
+          intelligence: UnifiedIntelligence.max,
+        );
+        expect(command, contains('-r high'));
+      });
+
+      test('passes model', () {
+        final command = buildHeadlessCommand(
+          kind: AgentKind.droid,
+          prompt: 'x',
+          model: 'claude-opus-4-7',
+        );
+        expect(command, contains("-m 'claude-opus-4-7'"));
+      });
+    });
+  });
+}


### PR DESCRIPTION
Refs #71

## Summary

Adds a new **Remote UI** tab: a Codex-app-style interface for controlling AI CLI agents (Claude Code, Codex CLI, Factory Droid) running on the connected server, built on mux-pod's existing SSH/tmux primitives.

Two modes:

- **Live-pane mode**: an agent process detected in a tmux pane gets model / intelligence / permission chips that apply changes through per-agent adapters (slash commands + atomic remote config writes; Codex restarts in-pane with `pane_current_command` polling).
- **Chat mode**: headless streaming sessions (`stream-json` / `--json`) with an NDJSON parser, cancel-safe `SshClient.execStream`, resumable session ids, and per-(connection, agent) local history.

Also included: Workspace/Worktree toggle, plan mode, photo upload over SFTP, sessions history sheet, agent picker. The mic/plugins placeholders from the reference UX were intentionally omitted (no backend exists for them).

## How it works

| Layer | Files |
|---|---|
| Pinned contracts | `lib/services/agent/agent_types.dart`, `agent_adapter.dart` |
| Adapters | `claude_code_adapter.dart`, `codex_adapter.dart`, `factory_droid_adapter.dart`, `agent_registry.dart` |
| Remote config | `agent_config_service.dart` (atomic base64 writes, `.muxpod-bak`, TOML/JSON helpers, newline-injection guard) |
| Headless streaming | `lib/services/agent/headless/` (events, NDJSON parser, command builders, session, store) |
| SSH | `SshClient.execStream` (cancel-safe, deadlock-free), `connection_credentials.dart` |
| Providers | `remote_ui_provider.dart` (live pane), `remote_ui_chat_provider.dart` (chat) |
| UI | `lib/screens/remote_ui/` (screen + 5 sheets), 6th tab via `HomeTabIndex` |

Pre-existing `setTab(3)` misroutes in `connections_screen.dart` / `keys_screen.dart` were fixed along the way, and the bottom nav items now use `Expanded` so six tabs fit narrow screens.

## Test plan

- `flutter analyze`: clean (37 pre-existing info-level issues, no new ones)
- `flutter test`: **496 passed** (164 new: adapters, config service, registry, NDJSON parser, command builders, headless session, session store, chat provider lifecycle, 12 widget tests for the screen)
- Manual: exercised against a live server with Claude Code and Codex CLI in tmux panes (Android emulator)

## Maintainer feedback wanted

This is a draft precisely because the design deserves your eyes before it lands:

1. Tab placement vs. per-connection entry point
2. Opt-in setting for writing to agent config files
3. Agent-detection heuristics on real-world tmux setups
4. Whether live-pane control and headless chat should share one tab

Nothing here is set in stone — happy to rework any part, and help debugging on your own setup would be great.

## Help wanted: iOS testing

I could only test on Android (no macOS in my environment). The code paths are platform-agnostic Dart/Flutter, but a quick smoke test of the new tab on iOS (navigation, bottom sheets, SFTP upload) would be much appreciated.
