### PR TITLE
ci: Support pre-release versions and use run_number for TestFlight build numbers

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -78,14 +78,17 @@ jobs:
             BUILD_NAME=$(sed -n 's/^version: *\([0-9.]*\)+.*/\1/p' pubspec.yaml)
           fi
 
-          if ! echo "$BUILD_NAME" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
-            echo "::error::バージョン '$BUILD_NAME' が x.y.z 形式ではありません"
+          # x.y.z または x.y.z-pre 等のプレリリース形式（-suffix）を許可する。
+          if ! echo "$BUILD_NAME" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z]+)?$'; then
+            echo "::error::バージョン '$BUILD_NAME' が x.y.z[-suffix] 形式ではありません"
             exit 1
           fi
 
-          MAJOR=$(echo "$BUILD_NAME" | cut -d. -f1)
-          MINOR=$(echo "$BUILD_NAME" | cut -d. -f2)
-          PATCH=$(echo "$BUILD_NAME" | cut -d. -f3)
+          # ビルド番号は x.y.z の数値部分のみから算出する（-suffix は無視）。
+          BUILD_CORE=$(echo "$BUILD_NAME" | sed 's/-.*$//')
+          MAJOR=$(echo "$BUILD_CORE" | cut -d. -f1)
+          MINOR=$(echo "$BUILD_CORE" | cut -d. -f2)
+          PATCH=$(echo "$BUILD_CORE" | cut -d. -f3)
           # 既存の release-ios.yml と同じ採番規則
           BUILD_NUMBER=$((MAJOR * 10000 + MINOR * 100 + PATCH))
 

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -84,13 +84,10 @@ jobs:
             exit 1
           fi
 
-          # ビルド番号は x.y.z の数値部分のみから算出する（-suffix は無視）。
-          BUILD_CORE=$(echo "$BUILD_NAME" | sed 's/-.*$//')
-          MAJOR=$(echo "$BUILD_CORE" | cut -d. -f1)
-          MINOR=$(echo "$BUILD_CORE" | cut -d. -f2)
-          PATCH=$(echo "$BUILD_CORE" | cut -d. -f3)
-          # 既存の release-ios.yml と同じ採番規則
-          BUILD_NUMBER=$((MAJOR * 10000 + MINOR * 100 + PATCH))
+          # ビルド番号は GitHub Actions の run_number（リポジトリ全体で単調増加・一意）を使う。
+          # バージョン（x.y.z[-suffix]）から機械算出すると、プレリリースと正式版が
+          # 同じビルド番号になり TestFlight で衝突するため、バージョン非依存の連番とする。
+          BUILD_NUMBER="${{ github.run_number }}"
 
           echo "build_name=$BUILD_NAME"     >> "$GITHUB_OUTPUT"
           echo "build_number=$BUILD_NUMBER" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- Allow pre-release version strings (e.g. `0.7.0-pre`) in TestFlight uploads
- Use GitHub Actions `run_number` (monotonically increasing, unique per repo) as the build number to avoid collisions between pre-release and release builds

## Background
The previous build-number scheme derived from the version (`MAJOR*10000+MINOR*100+PATCH`). This caused `0.7.0-pre` and `0.7.0` to share the same build number (`700`), which TestFlight rejects as a duplicate.

## Changes
- `.github/workflows/testflight.yml`
  - Version validation now accepts `x.y.z[-suffix]` (pre-release support)
  - Build number now uses `${{ github.run_number }}` (version-independent sequence)

## Test plan
- Version validation regex manually verified: `0.7.0-pre` allowed, `0.7.0` allowed, `v0.7.0` rejected (the `v` prefix is stripped for tags)
- Confirmed `0.7.0-pre` and `0.7.0` would no longer share a build number