### PR TITLE
ci: Fix TestFlight tag trigger for pre-release versions

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -3,7 +3,8 @@ name: Upload to TestFlight
 on:
   push:
     tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+'
+      # 正式版（v0.7.0）とプレリリース（v0.7.0-pre1）の両方を受け付ける
+      - 'v[0-9]+.[0-9]+.[0-9]+(-[0-9A-Za-z]+)?'
   workflow_dispatch:
     inputs:
       version:


### PR DESCRIPTION
## Summary
Fix the TestFlight tag trigger so pre-release tags (e.g. `v0.7.0-pre1`) fire the workflow.

## Background
The tag pattern `'v[0-9]+.[0-9]+.[0-9]+'` matched only release tags (`v0.7.0`). Pushing `v0.7.0-pre1` did not trigger the workflow.

## Changes
- `.github/workflows/testflight.yml`: tag pattern updated to `'v[0-9]+.[0-9]+.[0-9]+(-[0-9A-Za-z]+)?'`, matching both release and pre-release tags

## Test plan
- After merge, pushing `v0.7.0-pre1` should trigger the workflow