### PR TITLE
ci: Simplify TestFlight tag trigger to v*

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -3,8 +3,9 @@ name: Upload to TestFlight
 on:
   push:
     tags:
-      # 正式版（v0.7.0）とプレリリース（v0.7.0-pre1）の両方を受け付ける
-      - 'v[0-9]+.[0-9]+.[0-9]+(-[0-9A-Za-z]+)?'
+      # release.yml と同じ v* パターン。正式版（v0.7.0）も
+      # プレリリース（v0.7.0-pre1）も発火する
+      - 'v*'
   workflow_dispatch:
     inputs:
       version:


### PR DESCRIPTION
## Summary
Simplify the TestFlight tag trigger to `v*` so both release (`v0.7.0`) and pre-release (`v0.7.0-pre1`) tags fire the workflow.

## Background
GitHub Actions tag filters use glob patterns. The previous pattern `v[0-9]+.[0-9]+.[0-9]+(-[0-9A-Za-z]+)?` did not match pre-release tags because `(...)?` grouping is not supported in glob filters.

## Changes
- `.github/workflows/testflight.yml`: tag pattern simplified to `v*` (same as release.yml)

## Test plan
- After merge, pushing `v0.7.0-pre1` should trigger the TestFlight workflow