### PR TITLE
fix(connection): Remove Herdr read-only label to match tmux

### DIFF
--- a/lib/providers/active_session_provider.dart
+++ b/lib/providers/active_session_provider.dart
@@ -41,7 +41,7 @@ class ActiveSession {
   // inventory: LEGACY-0007
   final bool isAttached;
 
-  /// backend 種別（herdr は read-only のため Terminal 遷移不可）。
+  /// backend 種別（backend 固有の UI・操作分岐に使う）。
   final MultiplexerBackendKind backend;
 
   // inventory: PROV-ACTIVE-009

--- a/lib/screens/connections/connection_form_screen.dart
+++ b/lib/screens/connections/connection_form_screen.dart
@@ -560,26 +560,6 @@ class _ConnectionFormScreenState extends ConsumerState<ConnectionFormScreen> {
             color: mutedColor.withValues(alpha: 0.7),
           ),
         ),
-        if (isHerdr) ...[
-          const SizedBox(height: 8),
-          Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Icon(Icons.lock_outline, size: 14, color: mutedColor),
-              const SizedBox(width: 6),
-              Expanded(
-                child: Text(
-                  'Read-only: you can view workspaces, tabs and panes, '
-                  'but not modify them.',
-                  style: GoogleFonts.spaceGrotesk(
-                    fontSize: 11,
-                    color: mutedColor.withValues(alpha: 0.9),
-                  ),
-                ),
-              ),
-            ],
-          ),
-        ],
       ],
     );
   }
@@ -1081,7 +1061,7 @@ class _ConnectionFormScreenState extends ConsumerState<ConnectionFormScreen> {
         );
       } else if (_backend == BackendType.herdr) {
         final message = herdrReady
-            ? 'Connection successful! Herdr is available (read-only).'
+            ? 'Connection successful! Herdr is available.'
             : 'Connection successful! Warning: '
                 '${herdrWarning ?? 'herdr not found'}.';
         ScaffoldMessenger.of(context).showSnackBar(

--- a/lib/screens/connections/connections_screen.dart
+++ b/lib/screens/connections/connections_screen.dart
@@ -679,7 +679,7 @@ class _ConnectionCardState extends ConsumerState<_ConnectionCard> {
     );
   }
 
-  /// 接続の backend 種別（表示側の read-only 分岐用）。
+  /// 接続の backend 種別（表示側の backend 固有分岐用）。
   MultiplexerBackendKind get _backendKind {
     return switch (widget.connection.multiplexer.backend) {
       BackendType.tmux => MultiplexerBackendKind.tmux,
@@ -746,7 +746,7 @@ class _ConnectionCardState extends ConsumerState<_ConnectionCard> {
     try {
       client = await _connectSsh();
       if (_backendKind == MultiplexerBackendKind.herdr) {
-        // herdr: read-only スナップショットを取得して共通 domain に変換する。
+        // herdr: スナップショットを取得して共通 domain に変換する。
         final adapter = HerdrAdapter(client);
         final snapshot = await adapter.snapshot();
         if (!mounted) return;

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -397,7 +397,7 @@ class _TerminalTabState extends ConsumerState<_TerminalTab> {
 
           final isHerdr = connection.multiplexer.backend == BackendType.herdr;
           if (isHerdr) {
-            // herdr: read-only スナップショットを共通 domain に変換して登録
+            // herdr: スナップショットを共通 domain に変換して登録
             final adapter = HerdrAdapter(sshClient);
             final snapshot = await adapter.snapshot();
             ref.read(activeSessionsProvider.notifier).updateSessionsFromDomain(

--- a/lib/screens/terminal/terminal_screen.dart
+++ b/lib/screens/terminal/terminal_screen.dart
@@ -916,7 +916,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         throw Exception('Connection not found');
       }
 
-      // 1.5. backend 種別を確定（herdr は read-only 分岐に使う）
+      // 1.5. backend 種別を確定（backend 固有の操作・capability 判定に使う）
       final isHerdr = connection.multiplexer.backend == BackendType.herdr;
       _backendKind = isHerdr
           ? MultiplexerBackendKind.herdr
@@ -940,7 +940,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         throw Exception('SSH client is not available');
       }
 
-      // 3.4. herdr: read-only セッションを設定して終了
+      // 3.4. herdr: セッションを設定して終了
       if (isHerdr) {
         await _setupHerdrSession(client);
         if (!mounted || _isDisposed) return;
@@ -1196,7 +1196,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     };
   }
 
-  /// herdr の read-only セッションを設定する。
+  /// herdr のセッションを設定する。
   ///
   /// 表示対象 pane を解決し、ライブポーリングを開始する。mutation 系の
   /// tmux セットアップ（バージョン確認・セッション作成・ツリー取得・

--- a/lib/services/herdr/herdr_commands.dart
+++ b/lib/services/herdr/herdr_commands.dart
@@ -27,7 +27,7 @@ class HerdrCommands {
   static String preflightCommand() => 'herdr status --json';
 
   // inventory: HERDR-CMD-005
-  /// pane の内容を読み取る（read-only 表示用）。
+  /// pane の内容を読み取る（表示用）。
   ///
   /// コマンド形式:
   /// `herdr pane read <pane_id> --source <source> [--lines N] [--raw]`

--- a/test/screens/connections/connection_form_screen_test.dart
+++ b/test/screens/connections/connection_form_screen_test.dart
@@ -182,15 +182,12 @@ void main() {
       expect(find.text('Herdr'), findsOneWidget);
     });
 
-    testWidgets('selecting Herdr shows read-only notice and saves a herdr connection',
+    testWidgets('selecting Herdr saves a herdr connection',
         (tester) async {
       final harness = await _pumpForm(tester);
 
       await tester.tap(find.text('Herdr'));
       await tester.pumpAndSettle();
-
-      // read-only である旨の説明が表示される
-      expect(find.textContaining('Read-only'), findsOneWidget);
 
       await tester.enterText(find.byType(TextFormField).at(0), 'Herdr Host');
       await tester.enterText(find.byType(TextFormField).at(1), '192.168.1.2');
@@ -231,7 +228,7 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(
-        find.text('Connection successful! Herdr is available (read-only).'),
+        find.text('Connection successful! Herdr is available.'),
         findsOneWidget,
       );
       expect(harness.client!.lastOptions!.multiplexer!.backend, BackendType.herdr);


### PR DESCRIPTION
## Summary

- The Herdr connection form displayed a "read-only" label: a lock icon with the text *"Read-only: you can view workspaces, tabs and panes, but not modify them."*, and the TestConnection success message said *"Connection successful! Herdr is available (read-only)."*
- This was misleading. Herdr supports the same full set of mutation operations as tmux (send text/keys, split, close, rename, resize, paste, tab/workspace CRUD, etc.). The "read-only" wording was a leftover from an earlier development phase when only read operations were exposed.
- This PR removes the misleading read-only wording so that Herdr and tmux show consistent messaging, and updates stale comments and tests that still described Herdr as read-only.

## Changes

- `lib/screens/connections/connection_form_screen.dart`: Removed the read-only description block (lock icon + "Read-only: you can view workspaces...") and changed the Herdr success message to `Connection successful! Herdr is available.` — the same format as tmux.
- `lib/providers/active_session_provider.dart`: Updated the `backend` doc comment that claimed Herdr was read-only and could not open the Terminal screen.
- `lib/services/herdr/herdr_commands.dart`: Updated the `paneRead` doc comment.
- `lib/screens/connections/connections_screen.dart`: Updated the stale snapshot / backend-kind comments.
- `lib/screens/home_screen.dart`: Updated the stale snapshot comment.
- `lib/screens/terminal/terminal_screen.dart`: Updated the stale "read-only session" comments.
- `test/screens/connections/connection_form_screen_test.dart`: Updated the expected success message and test name.

## Test plan

- [x] `make analyze` (No issues found)
- [x] `make test` (All 1046 tests passed)