### PR TITLE
fix(ssh): restore SSH connections after dartssh2 2.22.5 upgrade

### DIFF
--- a/lib/services/ssh/ssh_client.dart
+++ b/lib/services/ssh/ssh_client.dart
@@ -192,6 +192,15 @@ class SshClient implements BackendAdapter {
   // inventory: SSH-020
   SshConnectOptions? _connectOptions;
 
+  /// 旧形式（MD5 hex）保存値からの移行保留。
+  ///
+  /// dartssh2 2.18.0+ でホスト鍵 fingerprint が `SHA256:<base64>` の UTF-8 バイトに
+  /// 変更された（BREAKING）。旧形式で保存済みの値は再検証できないため、
+  /// 接続実績のあるサーバーとして受理し、**ユーザー認証成功後にのみ**
+  /// 正規形式へ更新する（[connect] で保存）。
+  ({String host, int port, String type, String fingerprint})?
+  _pendingFingerprintMigration;
+
   // inventory: LEGACY-0138
   /// 接続時に使用したオプション
   SshConnectOptions? get connectOptions => _connectOptions;
@@ -319,6 +328,8 @@ class SshClient implements BackendAdapter {
 
     _state = SshConnectionState.connecting;
     _lastError = null;
+    // 前回接続の移行保留をリセット（成功・失敗どちらでも次回に持ち越さない）
+    _pendingFingerprintMigration = null;
 
     try {
       final connectionFactory = _connectionFactory;
@@ -390,6 +401,19 @@ class SshClient implements BackendAdapter {
       // 認証完了を待機
       await _client!.authenticated;
 
+      // 旧形式保存値からの移行: 認証が成功した場合のみ正規形式で保存する
+      // （認証失敗時は更新しない = 問題なければ SHA256 に Update）。
+      final pending = _pendingFingerprintMigration;
+      _pendingFingerprintMigration = null;
+      if (pending != null) {
+        await SecureStorageService().saveHostKeyFingerprint(
+          pending.host,
+          pending.port,
+          pending.type,
+          pending.fingerprint,
+        );
+      }
+
       _state = SshConnectionState.connected;
       _connectionStateController.add(_state);
 
@@ -451,8 +475,16 @@ class SshClient implements BackendAdapter {
   // inventory: SSH-LIFE-017
   /// ホスト鍵フィンガープリントを検証する。
   ///
-  /// 初回接続時は [acceptNewHostKeys] が true なら受け入れて保存し、
-  /// false なら拒否する。2回目以降は保存済みフィンガープリントと比較する。
+  /// dartssh2 2.18.0 以降は OpenSSH 形式 `SHA256:<base64>` 文字列の UTF-8 バイトが
+  /// 渡される（2.18.0 で BREAKING: それ以前は MD5 生バイト）。
+  ///
+  /// - 初回接続時: [acceptNewHostKeys] が true なら受け入れて保存し、
+  ///   false なら拒否する。
+  /// - 保存値が正規形式（`SHA256:` プレフィックス）: 比較して一致なら受理、
+  ///   不一致なら拒否。
+  /// - 保存値が旧形式（MD5 hex・`SHA256:` プレフィックスなし）: 再検証不能なため
+  ///   接続実績のあるサーバーとして受理し、[connect] がユーザー認証成功後に
+  ///   正規形式へ更新する（[_pendingFingerprintMigration]）。
   Future<bool> _onVerifyHostKey(
     String host,
     int port,
@@ -460,9 +492,7 @@ class SshClient implements BackendAdapter {
     Uint8List fingerprint, {
     required bool acceptNewHostKeys,
   }) async {
-    final formatted = fingerprint
-        .map((b) => b.toRadixString(16).padLeft(2, '0'))
-        .join(':');
+    final formatted = utf8.decode(fingerprint, allowMalformed: true);
 
     final storage = SecureStorageService();
     final known = await storage.getHostKeyFingerprint(host, port, type);
@@ -470,6 +500,21 @@ class SshClient implements BackendAdapter {
     if (known == null) {
       if (acceptNewHostKeys) {
         await storage.saveHostKeyFingerprint(host, port, type, formatted);
+        return true;
+      }
+      _lastError = 'Unknown host key: $host:$port ($type)';
+      return false;
+    }
+
+    if (!known.startsWith('SHA256:')) {
+      // 旧形式（MD5 hex）の保存値。認証成功後に正規形式へ更新する。
+      if (acceptNewHostKeys) {
+        _pendingFingerprintMigration = (
+          host: host,
+          port: port,
+          type: type,
+          fingerprint: formatted,
+        );
         return true;
       }
       _lastError = 'Unknown host key: $host:$port ($type)';

--- a/test/repro/repro_ssh_hostkey_fingerprint_test.dart
+++ b/test/repro/repro_ssh_hostkey_fingerprint_test.dart
@@ -1,0 +1,142 @@
+// Repro: ホスト鍵フィンガープリント形式変更で SSH 接続が失敗する
+//
+// dartssh2 2.18.0 で BREAKING: SSHHostkeyVerifyHandler に渡される
+// fingerprint が「MD5 生バイト」から「OpenSSH 形式 `SHA256:<base64>` 文字列の
+// UTF-8 バイト」に変更された（dartssh2 CHANGELOG 2.18.0）。
+//
+// アプリ側 _onVerifyHostKey（lib/services/ssh/ssh_client.dart）は MD5 生バイト
+// 前提で hex 連結していたため、dartssh2 2.22.5 では旧形式保存値（MD5 hex）と
+// 決して一致せず、ホスト鍵検証失敗 → 接続不可となっていた（ユーザー報告:
+// SSH接続ができなくなった・認証が通らない）。
+//
+// 修正方針（ユーザー承認済み）: 旧形式保存値は「接続実績のあるサーバー」として
+// 受理し、**ユーザー認証成功後にのみ**正規の SHA256 形式へ更新する。
+//
+// このテストはローカル sshd（127.0.0.1:22）に対する実接続で検証する。
+// 前提:
+//   - ローカル sshd が ed25519 ホスト鍵で稼働している
+//   - /tmp/bugfix-repro-key の公開鍵が authorized_keys に登録されている
+//   - /tmp/bugfix-repro-key-wrong は authorized_keys に未登録（認証失敗用）
+library;
+
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:crypto/crypto.dart';
+import 'package:flutter_muxpod/services/keychain/secure_storage.dart';
+import 'package:flutter_muxpod/services/ssh/ssh_client.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// ローカル sshd の ed25519 ホスト鍵 blob（KEX で渡される host key そのもの）。
+Uint8List _localHostKeyBlob() {
+  final pubLine =
+      File('/etc/ssh/ssh_host_ed25519_key.pub').readAsLinesSync().first;
+  return base64.decode(pubLine.split(' ')[1]);
+}
+
+/// 旧 dartssh2（<= 2.17）が onVerifyHostKey に渡していた MD5 生バイトを
+/// アプリの hex 連結形式にしたもの = 旧バージョンで保存された値。
+String _legacyFingerprint() {
+  return md5
+      .convert(_localHostKeyBlob())
+      .bytes
+      .map((b) => b.toRadixString(16).padLeft(2, '0'))
+      .join(':');
+}
+
+/// ローカル sshd の正規（SHA256）フィンガープリント。
+String _sha256Fingerprint() {
+  final digest = sha256.convert(_localHostKeyBlob()).bytes;
+  final encoded = base64Encode(digest).replaceAll('=', '');
+  return 'SHA256:$encoded';
+}
+
+void main() {
+  setUp(() => SecureStorageService.setTestValues({}));
+  tearDown(() => SecureStorageService.setTestValues(null));
+
+  test(
+    'REPRO: 対照実験 - 保存済みフィンガープリントなし（新規）なら接続できる',
+    () async {
+      final privateKey = File('/tmp/bugfix-repro-key').readAsStringSync();
+      final client = SshClient();
+      await client.connect(
+        host: '127.0.0.1',
+        port: 22,
+        username: Platform.environment['USER'] ?? 'mox',
+        options: SshConnectOptions(privateKey: privateKey),
+        lightweight: true,
+      );
+      expect(client.isConnected, isTrue);
+      await client.disconnect();
+    },
+    timeout: const Timeout(Duration(seconds: 60)),
+  );
+
+  test(
+    'REPRO: 旧形式（MD5 hex）保存済みでも接続でき、認証成功後に SHA256 へ更新される',
+    () async {
+      // 旧バージョンで接続済みのユーザーの保存済みフィンガープリントを再現
+      SecureStorageService.setTestValues({
+        'hostkey_127.0.0.1_22_ssh-ed25519': _legacyFingerprint(),
+      });
+
+      final privateKey = File('/tmp/bugfix-repro-key').readAsStringSync();
+      final client = SshClient();
+      await client.connect(
+        host: '127.0.0.1',
+        port: 22,
+        username: Platform.environment['USER'] ?? 'mox',
+        options: SshConnectOptions(privateKey: privateKey),
+        lightweight: true,
+      );
+      // 修正後: ホスト鍵検証が通って接続できる
+      expect(client.isConnected, isTrue);
+      // 認証成功後に正規の SHA256 形式へ更新されている
+      expect(
+        await SecureStorageService().getHostKeyFingerprint(
+          '127.0.0.1',
+          22,
+          'ssh-ed25519',
+        ),
+        _sha256Fingerprint(),
+      );
+      await client.disconnect();
+    },
+    timeout: const Timeout(Duration(seconds: 60)),
+  );
+
+  test(
+    'REPRO: 旧形式保存済みでも認証失敗時は SHA256 へ更新されない',
+    () async {
+      SecureStorageService.setTestValues({
+        'hostkey_127.0.0.1_22_ssh-ed25519': _legacyFingerprint(),
+      });
+
+      // authorized_keys に未登録の鍵で認証を失敗させる
+      final wrongKey = File('/tmp/bugfix-repro-key-wrong').readAsStringSync();
+      final client = SshClient();
+      await expectLater(
+        client.connect(
+          host: '127.0.0.1',
+          port: 22,
+          username: Platform.environment['USER'] ?? 'mox',
+          options: SshConnectOptions(privateKey: wrongKey),
+          lightweight: true,
+        ),
+        throwsA(isA<SshAuthenticationError>()),
+      );
+      // 認証失敗時は保存値が更新されない（旧形式のまま）
+      expect(
+        await SecureStorageService().getHostKeyFingerprint(
+          '127.0.0.1',
+          22,
+          'ssh-ed25519',
+        ),
+        _legacyFingerprint(),
+      );
+    },
+    timeout: const Timeout(Duration(seconds: 60)),
+  );
+}

--- a/test/services/ssh/ssh_client_test.dart
+++ b/test/services/ssh/ssh_client_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:dartssh2/dartssh2.dart';
@@ -762,7 +763,10 @@ void main() {
     test(
       'SSH-LIFE-017: host-key callback implements TOFU and rejects changes',
       () async {
-        final fingerprint = Uint8List.fromList([0x01, 0xab, 0xff]);
+        // dartssh2 2.18.0+ は OpenSSH 形式 "SHA256:<base64>" の UTF-8 バイトを渡す
+        var fingerprint = Uint8List.fromList(
+          utf8.encode('SHA256:testfingerprint123'),
+        );
         Future<({SSHSocket socket, SSHClient client})> factory(
           String host,
           int port,
@@ -793,11 +797,13 @@ void main() {
             2222,
             'ssh-ed25519',
           ),
-          '01:ab:ff',
+          'SHA256:testfingerprint123',
         );
         await first.disconnect();
 
-        fingerprint[0] = 0x02;
+        fingerprint = Uint8List.fromList(
+          utf8.encode('SHA256:changedfingerprint456'),
+        );
         final changed = SshClient(connectionFactory: factory);
         await expectLater(
           changed.connect(
@@ -810,6 +816,100 @@ void main() {
           throwsA(isA<SshAuthenticationError>()),
         );
         expect(changed.lastError, contains('Authentication failed'));
+      },
+    );
+
+    test(
+      'SSH-LIFE-017b: 旧形式（MD5 hex）保存値は認証成功後に SHA256 形式へ移行する',
+      () async {
+        // 旧 dartssh2（<= 2.17）で保存された MD5 hex 形式の値をシード
+        SecureStorageService.setTestValues({
+          'hostkey_example.test_2222_ssh-ed25519': '66:5d:56:0b:41:6a:22:c5',
+        });
+        final fingerprint = Uint8List.fromList(
+          utf8.encode('SHA256:newformatvalue789'),
+        );
+        Future<({SSHSocket socket, SSHClient client})> factory(
+          String host,
+          int port,
+          String username,
+          SshConnectOptions options,
+          void Function() onAuthenticated,
+          Future<bool> Function(String, Uint8List) verify,
+        ) async {
+          final accepted = await verify('ssh-ed25519', fingerprint);
+          if (!accepted) throw SSHAuthFailError('host key rejected');
+          final raw = _FakeRawSshClient();
+          onAuthenticated();
+          raw.authentication.complete();
+          return (socket: _FakeSocket(), client: raw);
+        }
+
+        final client = SshClient(connectionFactory: factory);
+        await client.connect(
+          host: 'example.test',
+          port: 2222,
+          username: 'user',
+          options: SshConnectOptions(password: 'pw'),
+          lightweight: true,
+        );
+        expect(client.isConnected, isTrue);
+        // 認証成功後に正規形式へ更新されている
+        expect(
+          await SecureStorageService().getHostKeyFingerprint(
+            'example.test',
+            2222,
+            'ssh-ed25519',
+          ),
+          'SHA256:newformatvalue789',
+        );
+        await client.disconnect();
+      },
+    );
+
+    test(
+      'SSH-LIFE-017c: 旧形式保存値は認証失敗時には更新されない',
+      () async {
+        SecureStorageService.setTestValues({
+          'hostkey_example.test_2222_ssh-ed25519': '66:5d:56:0b:41:6a:22:c5',
+        });
+        final fingerprint = Uint8List.fromList(
+          utf8.encode('SHA256:newformatvalue789'),
+        );
+        Future<({SSHSocket socket, SSHClient client})> factory(
+          String host,
+          int port,
+          String username,
+          SshConnectOptions options,
+          void Function() onAuthenticated,
+          Future<bool> Function(String, Uint8List) verify,
+        ) async {
+          final accepted = await verify('ssh-ed25519', fingerprint);
+          if (!accepted) throw SSHAuthFailError('host key rejected');
+          // 認証失敗: ホスト鍵検証は通るがユーザー認証が失敗する
+          throw SSHAuthFailError('auth failed');
+        }
+
+        final client = SshClient(connectionFactory: factory);
+        await expectLater(
+          client.connect(
+            host: 'example.test',
+            port: 2222,
+            username: 'user',
+            options: SshConnectOptions(password: 'pw'),
+            lightweight: true,
+          ),
+          throwsA(isA<SshAuthenticationError>()),
+        );
+        // 認証失敗時は保存値が更新されない（旧形式のまま）
+        expect(
+          await SecureStorageService().getHostKeyFingerprint(
+            'example.test',
+            2222,
+            'ssh-ed25519',
+          ),
+          '66:5d:56:0b:41:6a:22:c5',
+        );
       },
     );
 


### PR DESCRIPTION
## Summary

- Fix SSH connections to previously-used servers breaking after the dartssh2 2.22.5 upgrade (commit 9994a5e). Users report "SSH connection stopped working / authentication fails".
- Root cause: dartssh2 2.18.0 (BREAKING) changed the `SSHHostkeyVerifyHandler` fingerprint from raw MD5 bytes to UTF-8 bytes of the OpenSSH-style `SHA256:<base64>` string. The app still formatted and compared fingerprints as MD5 hex, so stored legacy fingerprints never matched and host key verification failed permanently before user authentication.
- Fix: decode the fingerprint to its canonical `SHA256:` string; treat a legacy (non-`SHA256:`-prefixed) stored value as a known server and migrate it to the canonical format **only after user authentication succeeds** (auth failure = no migration). Fresh installs keep the existing first-connect TOFU behavior.

## Changes

- `lib/services/ssh/ssh_client.dart` — `_onVerifyHostKey` decodes the fingerprint via `utf8.decode`; legacy stored values are accepted and queued for migration (`_pendingFingerprintMigration`); `connect()` persists the canonical SHA256 fingerprint only after `authenticated` completes successfully.
- `test/services/ssh/ssh_client_test.dart` — SSH-LIFE-017 updated to the new fingerprint contract; added SSH-LIFE-017b (legacy value migrates after auth success) and SSH-LIFE-017c (no migration on auth failure).
- `test/repro/repro_ssh_hostkey_fingerprint_test.dart` — new end-to-end repro against a real sshd (control / migration / auth-failure cases).

## Test plan

- [x] Repro E2E against a real sshd (legacy stored fingerprint): connect succeeds and the stored value is migrated to `SHA256:` format
- [x] Control (fresh install, no stored fingerprint): connect succeeds (unchanged TOFU)
- [x] Auth failure with legacy stored value: connect fails and the stored value is NOT migrated
- [x] `flutter analyze` (lib, test): no issues
- [x] Full test suite: 1184/1185 pass; the single failure (`repro_bug5_readonly_test.dart`) also fails on `main` (unrelated stale repro for the herdr read-only fix a903867)
- [x] Emulator E2E: fixed build connects to the real server 192.168.10.132:22 and migrates the stored fingerprint

## Related

- Fix plan (MDS): https://md-server.mox.run/d7288186-1835-45ea-8822-02663d1948c4/bugfix-plan-ssh-hostkey-fingerprint
- Bug fix report (MDS): https://md-server.mox.run/d7288186-1835-45ea-8822-02663d1948c4/bugfix-report-ssh-hostkey-fingerprint/