### PR TITLE
feat(terminal): run a command in a new window

### DIFF
--- a/lib/screens/terminal/terminal_screen.dart
+++ b/lib/screens/terminal/terminal_screen.dart
@@ -46,6 +46,7 @@ import '../../services/tmux/tmux_to_domain.dart';
 import '../../services/tmux/tmux_version.dart';
 import '../../widgets/dialogs/resize_dialog.dart';
 import '../../widgets/dialogs/rename_window_dialog.dart';
+import '../../widgets/dialogs/new_window_dialog.dart';
 import '../../theme/design_colors.dart';
 import '../../services/terminal/tmux_key_display.dart';
 import '../../widgets/key_overlay_widget.dart';
@@ -4078,20 +4079,24 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   /// ウィンドウ作成ダイアログを表示
   void _showCreateWindowDialog(TmuxSession session) {
     final existingNames = session.windows.map((w) => w.name).toList();
-    showDialog<String>(
+    showDialog<NewWindowRequest>(
       context: context,
       builder: (dialogContext) =>
-          _NewWindowDialog(existingWindowNames: existingNames),
-    ).then((windowName) {
-      if (windowName != null) {
+          NewWindowDialog(existingWindowNames: existingNames),
+    ).then((request) {
+      if (request != null) {
         // inventory: TERM-CRUD-001
-        _createWindow(windowName.isEmpty ? null : windowName);
+        _createWindow(request);
       }
     });
   }
 
-  /// 新しいウィンドウを作成
-  Future<void> _createWindow(String? windowName) async {
+  /// 新しいウィンドウを作成する。
+  ///
+  /// [NewWindowRequest.command] が指定された場合は、新ウィンドウの pane を
+  /// 選択した後に send-text + Enter で入力する（キーボードを開かずに
+  /// コマンドを実行できるようにするため）。
+  Future<void> _createWindow(NewWindowRequest request) async {
     if (_isCreatingWindow) return;
     _isCreatingWindow = true;
     try {
@@ -4110,10 +4115,13 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       await tmuxFacade.createWindow(
         sshClient.tmuxExecutor,
         sessionName: session.name,
-        windowName: windowName,
+        windowName: request.name,
       );
       await _refreshSessionTree();
       if (!mounted) return;
+
+      final command = request.command;
+      var commandDispatched = false;
 
       // active=1のウィンドウを検出して自動切替
       final updatedSession = ref.read(tmuxProvider).activeSession;
@@ -4127,7 +4135,19 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         final activePaneId = ref.read(tmuxProvider).activePaneId;
         if (activePaneId != null) {
           await _selectPane(activePaneId);
+          if (command != null) {
+            if (!mounted) return;
+            commandDispatched = true;
+            await _sendNewWindowCommand(activePaneId, command);
+          }
         }
+      }
+      if (command != null && !commandDispatched && mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('Window created, but the command could not be sent'),
+          ),
+        );
       }
       _boostPolling();
     } catch (e) {
@@ -4138,6 +4158,24 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       }
     } finally {
       _isCreatingWindow = false;
+    }
+  }
+
+  /// 新規ウィンドウ作成時の任意コマンドを PaneWriter 経由で入力する
+  /// （send-text + Enter）。送信失敗はウィンドウ作成の失敗として扱わない。
+  Future<void> _sendNewWindowCommand(String paneId, String command) async {
+    if (!_canSendText) return;
+    final writer = _paneWriter;
+    if (writer == null) return;
+    try {
+      await writer.sendText(paneId, command);
+      await writer.sendKey(paneId, 'Enter');
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Window created, but the command failed: $e')),
+        );
+      }
     }
   }
 
@@ -6929,110 +6967,6 @@ class _InputDialogContentState extends State<_InputDialogContent> {
           const SizedBox(height: 16),
         ],
       ),
-    );
-  }
-}
-
-/// ウィンドウ名入力ダイアログ
-class _NewWindowDialog extends StatefulWidget {
-  // inventory: LEGACY-0089
-  final List<String> existingWindowNames;
-
-  const _NewWindowDialog({required this.existingWindowNames});
-
-  @override
-  State<_NewWindowDialog> createState() => _NewWindowDialogState();
-}
-
-class _NewWindowDialogState extends State<_NewWindowDialog> {
-  final _formKey = GlobalKey<FormState>();
-  final _nameController = TextEditingController();
-
-  @override
-  void dispose() {
-    _nameController.dispose();
-    super.dispose();
-  }
-
-  String? _validateWindowName(String? value) {
-    if (value == null || value.isEmpty) {
-      return null; // 空入力はtmuxデフォルト名で許容
-    }
-    if (value.length > 50) {
-      return 'Window name must be 50 characters or less';
-    }
-    if (!RegExp(r'^[a-zA-Z0-9_-]+$').hasMatch(value)) {
-      return 'Only letters, numbers, - and _ allowed';
-    }
-    if (widget.existingWindowNames.contains(value)) {
-      return 'Window "$value" already exists';
-    }
-    return null;
-  }
-
-  void _submit() {
-    if (_formKey.currentState!.validate()) {
-      Navigator.pop(context, _nameController.text);
-    }
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final isDark = Theme.of(context).brightness == Brightness.dark;
-    final colorScheme = Theme.of(context).colorScheme;
-    return AlertDialog(
-      title: Text(
-        'New Window',
-        style: GoogleFonts.spaceGrotesk(fontWeight: FontWeight.w700),
-      ),
-      content: Form(
-        key: _formKey,
-        child: TextFormField(
-          controller: _nameController,
-          autofocus: true,
-          maxLength: 50,
-          decoration: InputDecoration(
-            labelText: 'Window Name',
-            hintText: 'Leave empty for default',
-            hintStyle: GoogleFonts.jetBrainsMono(
-              fontSize: 14,
-              color: isDark
-                  ? DesignColors.textMuted
-                  : DesignColors.textMutedLight,
-            ),
-            filled: true,
-            fillColor: isDark
-                ? DesignColors.inputDark
-                : DesignColors.inputLight,
-            border: OutlineInputBorder(
-              borderRadius: BorderRadius.circular(12),
-              borderSide: BorderSide.none,
-            ),
-            focusedBorder: OutlineInputBorder(
-              borderRadius: BorderRadius.circular(12),
-              borderSide: BorderSide(color: colorScheme.primary),
-            ),
-            errorBorder: OutlineInputBorder(
-              borderRadius: BorderRadius.circular(12),
-              borderSide: const BorderSide(color: DesignColors.error),
-            ),
-            focusedErrorBorder: OutlineInputBorder(
-              borderRadius: BorderRadius.circular(12),
-              borderSide: const BorderSide(color: DesignColors.error),
-            ),
-          ),
-          style: GoogleFonts.jetBrainsMono(fontSize: 14),
-          validator: _validateWindowName,
-          onFieldSubmitted: (_) => _submit(),
-        ),
-      ),
-      actions: [
-        TextButton(
-          onPressed: () => Navigator.pop(context),
-          child: const Text('Cancel'),
-        ),
-        FilledButton(onPressed: _submit, child: const Text('Create')),
-      ],
     );
   }
 }

--- a/lib/widgets/dialogs/new_window_dialog.dart
+++ b/lib/widgets/dialogs/new_window_dialog.dart
@@ -1,0 +1,168 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+import '../../theme/design_colors.dart';
+
+/// 新規ウィンドウ作成ダイアログの入力値
+///
+/// 未入力の項目は `null` になる。
+class NewWindowRequest {
+  final String? name;
+  final String? command;
+
+  const NewWindowRequest({this.name, this.command});
+}
+
+/// 新規ウィンドウ作成ダイアログ
+class NewWindowDialog extends StatefulWidget {
+  final List<String> existingWindowNames;
+
+  const NewWindowDialog({super.key, required this.existingWindowNames});
+
+  @override
+  State<NewWindowDialog> createState() => _NewWindowDialogState();
+}
+
+class _NewWindowDialogState extends State<NewWindowDialog> {
+  final _formKey = GlobalKey<FormState>();
+  final _nameController = TextEditingController();
+  final _commandController = TextEditingController();
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _commandController.dispose();
+    super.dispose();
+  }
+
+  String? _validateWindowName(String? value) {
+    if (value == null || value.isEmpty) {
+      return null; // 空入力はtmuxデフォルト名で許容
+    }
+    if (value.length > 50) {
+      return 'Window name must be 50 characters or less';
+    }
+    if (!RegExp(r'^[a-zA-Z0-9_-]+$').hasMatch(value)) {
+      return 'Only letters, numbers, - and _ allowed';
+    }
+    if (widget.existingWindowNames.contains(value)) {
+      return 'Window "$value" already exists';
+    }
+    return null;
+  }
+
+  String? _nullIfEmpty(String value) {
+    final trimmed = value.trim();
+    return trimmed.isEmpty ? null : trimmed;
+  }
+
+  void _submit() {
+    if (_formKey.currentState!.validate()) {
+      Navigator.pop(
+        context,
+        NewWindowRequest(
+          name: _nullIfEmpty(_nameController.text),
+          command: _nullIfEmpty(_commandController.text),
+        ),
+      );
+    }
+  }
+
+  InputDecoration _decoration({
+    required bool isDark,
+    required ColorScheme colorScheme,
+    required String labelText,
+    required String hintText,
+  }) {
+    return InputDecoration(
+      labelText: labelText,
+      hintText: hintText,
+      hintStyle: GoogleFonts.jetBrainsMono(
+        fontSize: 14,
+        color: isDark ? DesignColors.textMuted : DesignColors.textMutedLight,
+      ),
+      filled: true,
+      fillColor: isDark ? DesignColors.inputDark : DesignColors.inputLight,
+      border: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(12),
+        borderSide: BorderSide.none,
+      ),
+      focusedBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(12),
+        borderSide: BorderSide(color: colorScheme.primary),
+      ),
+      errorBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(12),
+        borderSide: const BorderSide(color: DesignColors.error),
+      ),
+      focusedErrorBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(12),
+        borderSide: const BorderSide(color: DesignColors.error),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final colorScheme = Theme.of(context).colorScheme;
+    final fieldStyle = GoogleFonts.jetBrainsMono(fontSize: 14);
+    return AlertDialog(
+      title: Text(
+        'New Window',
+        style: GoogleFonts.spaceGrotesk(fontWeight: FontWeight.w700),
+      ),
+      content: Form(
+        key: _formKey,
+        child: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              TextFormField(
+                controller: _nameController,
+                autofocus: true,
+                maxLength: 50,
+                maxLines: 1,
+                textInputAction: TextInputAction.next,
+                decoration: _decoration(
+                  isDark: isDark,
+                  colorScheme: colorScheme,
+                  labelText: 'Window Name',
+                  hintText: 'Leave empty for default',
+                ),
+                style: fieldStyle,
+                validator: _validateWindowName,
+                onFieldSubmitted: (_) => _submit(),
+              ),
+              const SizedBox(height: 12),
+              TextFormField(
+                controller: _commandController,
+                maxLines: 1,
+                autocorrect: false,
+                enableSuggestions: false,
+                keyboardType: TextInputType.text,
+                textInputAction: TextInputAction.done,
+                decoration: _decoration(
+                  isDark: isDark,
+                  colorScheme: colorScheme,
+                  labelText: 'Command',
+                  hintText: 'npm run dev (optional)',
+                ),
+                style: fieldStyle,
+                onFieldSubmitted: (_) => _submit(),
+              ),
+            ],
+          ),
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(onPressed: _submit, child: const Text('Create')),
+      ],
+    );
+  }
+}

--- a/test/screens/terminal/terminal_screen_crud_test.dart
+++ b/test/screens/terminal/terminal_screen_crud_test.dart
@@ -40,7 +40,8 @@ void main() {
         await tester.tap(find.byTooltip('New Window'));
         await tester.pump(const Duration(milliseconds: 250));
         await tester.pumpAndSettle();
-        await tester.enterText(find.byType(TextFormField), 'build');
+        // .at(0)=Window Name, .at(1)=Command
+        await tester.enterText(find.byType(TextFormField).at(0), 'build');
         await tester.tap(find.text('Create'));
         await tester.pumpAndSettle();
 
@@ -52,6 +53,42 @@ void main() {
           client.execCommands
               .skip(create + 1)
               .any((c) => c.contains('list-panes -a')),
+          isTrue,
+        );
+      },
+    );
+
+    testWidgets(
+      'TERM-CRUD-001b creates a window and runs a command',
+      (tester) async {
+        final client = await TerminalTestScaffold.pumpTerminalScreen(tester);
+
+        await tester.tap(find.text('shell'));
+        await tester.pumpAndSettle();
+        await tester.tap(find.byTooltip('New Window'));
+        await tester.pump(const Duration(milliseconds: 250));
+        await tester.pumpAndSettle();
+        // .at(0)=Window Name, .at(1)=Command
+        await tester.enterText(find.byType(TextFormField).at(0), 'deploy');
+        await tester.enterText(find.byType(TextFormField).at(1), 'make deploy');
+        await tester.tap(find.text('Create'));
+        await tester.pumpAndSettle();
+
+        final create = client.execCommands.indexWhere(
+          (c) => c.contains('new-window') && c.contains('deploy'),
+        );
+        expect(create, greaterThanOrEqualTo(0));
+
+        // PaneWriter sends key input through the no-wait channel, not exec.
+        final sendText = client.sendKeysCommands.indexWhere(
+          (c) => c.contains('send-keys') && c.contains('make deploy'),
+        );
+        expect(sendText, greaterThanOrEqualTo(0));
+
+        expect(
+          client.sendKeysCommands
+              .skip(sendText + 1)
+              .any((c) => c.contains('send-keys') && c.contains('Enter')),
           isTrue,
         );
       },

--- a/test/widgets/new_window_dialog_test.dart
+++ b/test/widgets/new_window_dialog_test.dart
@@ -1,0 +1,141 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_muxpod/widgets/dialogs/new_window_dialog.dart';
+
+void main() {
+  group('NewWindowDialog', () {
+    Future<void> openDialog(
+      WidgetTester tester, {
+      required void Function(NewWindowRequest?) onResult,
+    }) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (context) => ElevatedButton(
+                onPressed: () async {
+                  final result = await showDialog<NewWindowRequest>(
+                    context: context,
+                    builder: (_) => const NewWindowDialog(
+                      existingWindowNames: ['logs', 'build'],
+                    ),
+                  );
+                  onResult(result);
+                },
+                child: const Text('Open'),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets('renders name and command fields only', (tester) async {
+      await openDialog(tester, onResult: (_) {});
+
+      expect(find.text('Window Name'), findsOneWidget);
+      expect(find.text('Command'), findsOneWidget);
+      expect(find.text('Start Directory'), findsNothing);
+    });
+
+    testWidgets('blank form pops a request with both fields null',
+        (tester) async {
+      NewWindowRequest? result;
+      var completed = false;
+      await openDialog(tester, onResult: (r) {
+        result = r;
+        completed = true;
+      });
+
+      await tester.tap(find.text('Create'));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(NewWindowDialog), findsNothing);
+      expect(completed, isTrue);
+      expect(result, isNotNull);
+      expect(result!.name, isNull);
+      expect(result!.command, isNull);
+    });
+
+    testWidgets('carries both values and trims whitespace', (tester) async {
+      NewWindowRequest? result;
+      await openDialog(tester, onResult: (r) => result = r);
+
+      await tester.enterText(find.byType(TextFormField).at(0), 'editor');
+      await tester.enterText(find.byType(TextFormField).at(1), ' make test ');
+      await tester.tap(find.text('Create'));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(NewWindowDialog), findsNothing);
+      expect(result, isNotNull);
+      expect(result!.name, 'editor');
+      expect(result!.command, 'make test');
+    });
+
+    testWidgets('empty command becomes null', (tester) async {
+      NewWindowRequest? result;
+      await openDialog(tester, onResult: (r) => result = r);
+
+      await tester.enterText(find.byType(TextFormField).at(0), 'build2');
+      await tester.tap(find.text('Create'));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(NewWindowDialog), findsNothing);
+      expect(result, isNotNull);
+      expect(result!.name, 'build2');
+      expect(result!.command, isNull);
+    });
+
+    testWidgets('invalid name shows error and keeps dialog open',
+        (tester) async {
+      NewWindowRequest? result;
+      var completed = false;
+      await openDialog(tester, onResult: (r) {
+        result = r;
+        completed = true;
+      });
+
+      await tester.enterText(find.byType(TextFormField).at(0), 'bad name');
+      await tester.tap(find.text('Create'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Only letters, numbers, - and _ allowed'), findsOneWidget);
+      expect(find.byType(NewWindowDialog), findsOneWidget);
+      expect(completed, isFalse);
+      expect(result, isNull);
+    });
+
+    testWidgets('duplicate name shows already exists error', (tester) async {
+      var completed = false;
+      await openDialog(tester, onResult: (_) => completed = true);
+
+      await tester.enterText(find.byType(TextFormField).at(0), 'logs');
+      await tester.tap(find.text('Create'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Window "logs" already exists'), findsOneWidget);
+      expect(find.byType(NewWindowDialog), findsOneWidget);
+      expect(completed, isFalse);
+    });
+
+    testWidgets('cancel pops null', (tester) async {
+      NewWindowRequest? result;
+      var completed = false;
+      await openDialog(tester, onResult: (r) {
+        result = r;
+        completed = true;
+      });
+
+      await tester.enterText(find.byType(TextFormField).at(0), 'editor');
+      await tester.tap(find.text('Cancel'));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(NewWindowDialog), findsNothing);
+      expect(completed, isTrue);
+      expect(result, isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

The New Window dialog only asked for a name, so "open a window and run something in it" was a two-stage job: create the window, then open the command input and type the command with the on-screen keyboard up. On a phone that is several taps for something you already know when you create the window.

This adds an optional **`Command`** field to that dialog. When set, the command is executed in the new window as soon as it opens — no keyboard, no second dialog. Left empty, everything behaves exactly as before.

## Why it types the command instead of passing it to `new-window`

`tmux new-window <shell-command>` looked like the obvious route, but it replaces the shell: the window dies the moment the command exits (unless `remain-on-exit` is set), and the command runs without the user's interactive shell, so aliases, functions and rc-derived `PATH` are missing.

So the command is instead typed into the new window's pane once its pane is selected, via the existing `PaneWriter` abstraction — `sendText(paneId, command)` then `sendKey(paneId, 'Enter')`. The interactive shell stays alive after the command finishes, the command lands in shell history, and shell aliases/functions resolve exactly as if the user had typed it.

Emitted order for a window with a command:

```
new-window ... -> list-panes -a (tree refresh) -> select-pane ... -> send-keys ... -l -- <command> -> send-keys ... Enter
```

Because it goes through `PaneWriter`, it is backend-agnostic: `TmuxPaneWriter` maps it to `send-keys`, `HerdrPaneWriter` to its own send-text path.

## Notes for review

- **No changes to `TmuxContract`, `TmuxFacade`, `tmux_command_builder.dart` or any `PaneWriter` implementation.** Everything needed already existed; the only new code is UI plus the wiring in `_createWindow`.
- The command send is wrapped in its own `try/catch`: a failed command reports `Window created, but the command failed: ...` and is never surfaced as a window-creation failure. If no pane can be resolved, a distinct `Window created, but the command could not be sent` is shown instead of swallowing it.
- Sending is guarded by the existing `_canSendText` capability, so read-only backends do not send.
- The dialog moved out of `terminal_screen.dart` into `lib/widgets/dialogs/new_window_dialog.dart`, following the existing `rename_window_dialog.dart` convention (public widget + sibling test in `test/widgets/`). The old private `_NewWindowDialog` is deleted, not left behind. Window-name validation and the field styling are carried over unchanged.

## Tests

- `test/widgets/new_window_dialog_test.dart` — 7 widget tests: fields render, blank form yields an all-null request, values are trimmed, empty command becomes `null`, invalid and duplicate names keep the dialog open, Cancel yields `null`.
- `test/screens/terminal/terminal_screen_crud_test.dart` — new `TERM-CRUD-001b` asserts the ordering above: `new-window`, then `send-keys` carrying the command, then `Enter`. Note the command assertions read the fake client's `sendKeysCommands`, since `PaneWriter` routes key input through the no-wait channel rather than `exec`.
- The pre-existing `TERM-CRUD-001..002` needed its bare `find.byType(TextFormField)` disambiguated to `.at(0)`, now that the dialog has two fields.

`flutter analyze lib test` is clean. Full suite: 1053 pass; `terminal_screen_herdr_test.dart` "re-resolve propagates the snapshot tabId/workspaceId into the display state (T3)" fails, but it fails identically on a clean `main` checkout (verified by stashing this branch's changes), so it is pre-existing and unrelated.

Exercised on a real phone with a release build against a live tmux session over SSH.
