### PR TITLE
fix: herdr swipe focus sync, control char delivery, and iPad Cmd key

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -27,12 +27,12 @@ jobs:
       # fastlane / CocoaPods は UTF-8 ロケールを要求する
       LANG: en_US.UTF-8
       LC_ALL: en_US.UTF-8
-      # リポジトリの .mise.toml は flutter = "3.38.6-stable" を指定しているが、
+      # リポジトリの .mise.toml は flutter = "3.44.9-stable" を指定しているが、
       # これは古い mise (asdf プラグイン) 向けの表記。ビルドマシンの
       # mise 2026.7.x はここから URL を組み立てる際に -stable を二重に付けて
       # しまい 404 になる。ローカル開発環境では動作している表記なので
       # .mise.toml は変更せず、CI 側でのみバージョンを上書きする。
-      MISE_FLUTTER_VERSION: '3.38.6'
+      MISE_FLUTTER_VERSION: '3.44.9'
       FASTLANE_SKIP_UPDATE_CHECK: '1'
       FASTLANE_HIDE_CHANGELOG: '1'
       # xcodebuild のログを CI 向けに抑制する

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,2 +1,2 @@
 [tools]
-flutter = "3.38.6-stable"
+flutter = "3.44.9-stable"

--- a/docs/ci-testflight.md
+++ b/docs/ci-testflight.md
@@ -29,7 +29,7 @@ git tag v0.2.2 && git push origin v0.2.2
 | OS | macOS 15.6 / Apple Silicon |
 | 実行ユーザ | `muxpod-ci`（標準ユーザ。管理者権限なし） |
 | Xcode | 26.1.1 |
-| Flutter | 3.38.6（mise 管理） |
+| Flutter | 3.44.9（mise 管理） |
 | Ruby | 3.3.12（mise 管理） |
 | fastlane / CocoaPods | 2.237.0 / 1.17.0 |
 | runner | `muxpod-mac-mini` / labels `self-hosted,macOS,ARM64,xcode,muxpod` |
@@ -40,19 +40,19 @@ CI の実行に sudo は不要。
 ### 注意点
 
 - **Flutter のバージョン指定**: リポジトリの `.mise.toml` は
-  `flutter = "3.38.6-stable"` を指定しているが、これは古い mise
+  `flutter = "3.44.9-stable"` を指定しているが、これは古い mise
   (asdf プラグイン方式) 向けの表記。ビルドマシンの mise 2026.7.x は
   ここから URL を組み立てる際に `-stable` を二重に付けてしまい 404 になる。
 
   ```
-  flutter_macos_arm64_3.38.6-stable-stable.zip  ← 存在しない
+  flutter_macos_arm64_3.44.9-stable-stable.zip  ← 存在しない
   ```
 
   ローカル開発環境 (mise 2024.9.x) では現在の表記で動作しているため
-  `.mise.toml` は変更せず、workflow の `MISE_FLUTTER_VERSION: '3.38.6'` で
+  `.mise.toml` は変更せず、workflow の `MISE_FLUTTER_VERSION: '3.44.9'` で
   CI 側だけ上書きしている。環境変数は設定ファイルより優先される。
 
-  将来ローカルの mise を更新した際は `.mise.toml` を `3.38.6` に直し、
+  将来ローカルの mise を更新した際は `.mise.toml` を `3.44.9` に直し、
   この上書きを削除してよい。
 - **libyaml**: macOS には libyaml のヘッダが無いため、mise の Ruby ビルドで
   psych が入らない。`~/.local` に libyaml 0.2.5 を自前ビルドし、
@@ -171,7 +171,7 @@ sudo bash scripts/ci/create-muxpod-ci-user.sh
 # 2. ツールチェーン（muxpod-ci として実行）
 curl -fsSL https://mise.run | sh
 export PATH=$HOME/.local/bin:$PATH
-mise use -g flutter@3.38.6
+mise use -g flutter@3.44.9
 
 #    Ruby は libyaml を先に用意してからでないと psych が入らない
 curl -fsSL -o yaml.tar.gz https://github.com/yaml/libyaml/releases/download/0.2.5/yaml-0.2.5.tar.gz

--- a/lib/screens/terminal/terminal_screen.dart
+++ b/lib/screens/terminal/terminal_screen.dart
@@ -2828,8 +2828,8 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   /// （「その方向に pane はありません」・S4/T19）。
   Future<void> _focusHerdrPaneDirection(SwipeDirection direction) async {
     final writer = _paneWriter;
-    final paneId = _targetSource?.currentPaneId;
-    if (writer == null || paneId == null) return;
+    final beforePane = _targetSource?.currentPaneId;
+    if (writer == null || beforePane == null) return;
 
     final directionName = switch (direction) {
       SwipeDirection.up => 'up',
@@ -2841,10 +2841,15 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     // ポーリング停止（SSH競合回避・mutation 実行中は既存方針）
     _pollTimer?.cancel();
     try {
-      await writer.focusPaneDirection(paneId, directionName);
+      await writer.focusPaneDirection(beforePane, directionName);
       if (!mounted || _isDisposed) return;
       // H5/T18 単一経路: 強制再取得 → 再解決 → ターゲット変化時のみ切替コミット。
-      await _syncAfterHerdrMutation(eventLabel: 'focus sync');
+      // スワイプはフォーカス移動を伴う操作のため、snapshot の focused pane へ
+      // 表示を追従させる（preserveCurrent では旧 pane 維持となり表示が変わらない）。
+      await _syncAfterHerdrMutation(
+        eventLabel: 'focus sync',
+        policy: HerdrSyncTargetPolicy.followBackendFocus,
+      );
     } on PaneOperationNoopException catch (e) {
       // 隣接 pane なし（soft 失敗・情報通知）。
       _showHerdrMutationNoopSnackBar(e);

--- a/lib/screens/terminal/terminal_screen.dart
+++ b/lib/screens/terminal/terminal_screen.dart
@@ -2860,9 +2860,24 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   /// 現在のペインからナビゲーション可能な方向を取得
   Map<SwipeDirection, bool>? _getNavigableDirections() {
     // 方向フォーカス不可（read-only）では tmuxProvider を読まない（R3）。
-    // herdr では tmuxProvider が clear() されているため null を返し、
-    // スワイプヒントは非表示になる（方向 focus の herdr 配線は T12/T18）。
     if (!_canFocusDirection) return null;
+
+    // herdr: snapshot の layout（pane rect）から隣接判定する。
+    // tmux と同様に navigableDirections を提供し、隣接 pane が無い方向の
+    // 2 本指スワイプでエッジフラッシュ（赤）を表示できるようにする（バグ4）。
+    if (_backendKind == MultiplexerBackendKind.herdr) {
+      final herdrDirections = _herdrNavigableDirections();
+      if (herdrDirections == null) return null;
+      final settings = ref.read(settingsProvider);
+      if (settings.invertPaneNavigation) {
+        return {
+          for (final dir in SwipeDirection.values)
+            dir: herdrDirections[dir.inverted] ?? false,
+        };
+      }
+      return herdrDirections;
+    }
+
     final tmuxState = ref.read(tmuxProvider);
     final window = tmuxState.activeWindow;
     final activePane = tmuxState.activePane;
@@ -2884,6 +2899,81 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
 
     return rawDirections;
   }
+
+  /// herdr: 現在表示中の pane の各方向に隣接 pane が存在するかを返す。
+  ///
+  /// snapshot の layout（pane の絶対座標 rect）から、[PaneNavigator] と
+  /// 同様の隣接判定を行う。snapshot 未取得時は null（スワイプヒント非表示）。
+  Map<SwipeDirection, bool>? _herdrNavigableDirections() {
+    final paneId = _targetSource?.currentPaneId;
+    final cache = _herdrSnapshotCache;
+    if (paneId == null || cache == null) return null;
+    final snapshot = cache.cachedSnapshot;
+    if (snapshot == null) return null;
+
+    // 現在の pane が属する layout（tab）を探す
+    HerdrLayout? layout;
+    for (final l in snapshot.layouts) {
+      if (l.panes.any((p) => p.paneId == paneId)) {
+        layout = l;
+        break;
+      }
+    }
+    if (layout == null) return null;
+
+    final current = layout.panes
+        .where((p) => p.paneId == paneId)
+        .firstOrNull;
+    if (current == null) return null;
+
+    return {
+      for (final dir in SwipeDirection.values)
+        dir: _herdrHasAdjacentPane(layout.panes, current, dir),
+    };
+  }
+
+  /// herdr layout 内で [current] の [direction] 方向に隣接 pane があるか判定。
+  bool _herdrHasAdjacentPane(
+    List<HerdrLayoutPane> panes,
+    HerdrLayoutPane current,
+    SwipeDirection direction,
+  ) {
+    if (panes.length <= 1) return false;
+    for (final pane in panes) {
+      if (pane.paneId == current.paneId) continue;
+      final r = pane.rect;
+      final c = current.rect;
+      switch (direction) {
+        case SwipeDirection.right:
+          // 右: 左端が現在の右端以上 + 垂直方向の重なり
+          if (r.x >= c.x + c.width && _herdrVerticalOverlap(c, r)) {
+            return true;
+          }
+        case SwipeDirection.left:
+          // 左: 右端が現在の左端以下 + 垂直方向の重なり
+          if (r.x + r.width <= c.x && _herdrVerticalOverlap(c, r)) {
+            return true;
+          }
+        case SwipeDirection.down:
+          // 下: 上端が現在の下端以上 + 水平方向の重なり
+          if (r.y >= c.y + c.height && _herdrHorizontalOverlap(c, r)) {
+            return true;
+          }
+        case SwipeDirection.up:
+          // 上: 下端が現在の上端以下 + 水平方向の重なり
+          if (r.y + r.height <= c.y && _herdrHorizontalOverlap(c, r)) {
+            return true;
+          }
+      }
+    }
+    return false;
+  }
+
+  bool _herdrVerticalOverlap(HerdrRect a, HerdrRect b) =>
+      a.y < b.y + b.height && b.y < a.y + a.height;
+
+  bool _herdrHorizontalOverlap(HerdrRect a, HerdrRect b) =>
+      a.x < b.x + b.width && b.x < a.x + a.width;
 
   /// キーデータを PaneWriter 経由で送信（tmux: send-keys -l / herdr: send-text）
   Future<void> _sendKeyData(String data) async {

--- a/lib/screens/terminal/widgets/ansi_text_view.dart
+++ b/lib/screens/terminal/widgets/ansi_text_view.dart
@@ -139,6 +139,7 @@ class AnsiTextViewState extends ConsumerState<AnsiTextView> {
   bool _ctrlPressed = false;
   bool _altPressed = false;
   bool _shiftPressed = false;
+  bool _metaPressed = false;
 
   /// ホールド+スワイプ用の状態
   bool _isLongPressing = false;
@@ -983,6 +984,11 @@ class AnsiTextViewState extends ConsumerState<AnsiTextView> {
         _shiftPressed = true;
         return KeyEventResult.handled;
       }
+      if (key == LogicalKeyboardKey.metaLeft ||
+          key == LogicalKeyboardKey.metaRight) {
+        _metaPressed = true;
+        return KeyEventResult.handled;
+      }
 
       // 特殊キーの処理
       String? data;
@@ -1120,6 +1126,11 @@ class AnsiTextViewState extends ConsumerState<AnsiTextView> {
         if (_altPressed) {
           data = '\x1b$data';
         }
+
+        // Meta(Cmd)+文字の処理（xterm の ESC 前置・ユーザー要望）
+        if (_metaPressed) {
+          data = '\x1b$data';
+        }
       }
 
       if (data != null) {
@@ -1143,6 +1154,9 @@ class AnsiTextViewState extends ConsumerState<AnsiTextView> {
       } else if (key == LogicalKeyboardKey.shiftLeft ||
           key == LogicalKeyboardKey.shiftRight) {
         _shiftPressed = false;
+      } else if (key == LogicalKeyboardKey.metaLeft ||
+          key == LogicalKeyboardKey.metaRight) {
+        _metaPressed = false;
       }
     }
 

--- a/lib/services/herdr/herdr_commands.dart
+++ b/lib/services/herdr/herdr_commands.dart
@@ -262,12 +262,38 @@ class HerdrCommands {
     return 'herdr workspace focus $workspaceId';
   }
 
-  /// シェル引用符（単一引用符）で囲む。`'` は `'\''` にエスケープする。
+  /// シェル引用符で囲む。`'` は `'\''` にエスケープする。
   ///
   /// コマンドは SSH 経由でシェルに渡るため、空白・改行・unicode を含む
   /// テキスト（send-text / rename label / split cwd）を安全に転送する。
-  static String _shellQuote(String value) =>
-      "'${value.replaceAll("'", r"'\''")}'";
+  ///
+  /// **制御文字（0x00-0x1F / 0x7F）を含む場合は bash の ANSI-C quoting
+  /// （`$'...'`）で送る**。通常の単一引用符で囲むと、コマンドライン内の
+  /// 制御文字（Ctrl+A = 行頭移動、Ctrl+O = 履歴操作、Ctrl+E = 行末移動等）
+  /// を、対話シェルの readline が解釈して失うため。`$'...'` 形式なら
+  /// 制御文字を `\xHH` のリテラル表現で送り、実行時に bash が制御文字へ
+  /// 復元する（readline に吸われない）。
+  static String _shellQuote(String value) {
+    if (value.codeUnits.any((c) => c < 0x20 || c == 0x7f)) {
+      final buffer = StringBuffer("\$'");
+      for (final rune in value.runes) {
+        if (rune < 0x20 || rune == 0x7f) {
+          buffer.write('\\x${rune.toRadixString(16).padLeft(2, '0')}');
+        } else if (rune == 0x5c) {
+          // backslash
+          buffer.write(r'\\');
+        } else if (rune == 0x27) {
+          // single quote
+          buffer.write(r"\'");
+        } else {
+          buffer.writeCharCode(rune);
+        }
+      }
+      buffer.write("'");
+      return buffer.toString();
+    }
+    return "'${value.replaceAll("'", r"'\''")}'";
+  }
 }
 
 // inventory: HERDR-ERR-001

--- a/lib/services/ssh/persistent_shell.dart
+++ b/lib/services/ssh/persistent_shell.dart
@@ -132,21 +132,24 @@ class PersistentShell implements TmuxInputTransport {
     // シェル初期化を待つ（プロンプトが出力されるまで少し待機）
     await Future.delayed(const Duration(milliseconds: 100));
 
-    // ヒストリー記録を無効化（Bash/Zsh/fish対応）し、プロンプトを抑制
-    // - export HISTFILE=... : Bash/Zsh用（スタートアップファイル後に上書き）
-    // - set +H : Bashのヒストリー展開を無効化（入力中のリテラル`!`が
-    //   展開されて入力行全体が中断されるのを防ぐ）
-    // - set fish_history ... : fish用（exportはfishで構文エラーになるため別途）
-    // - 2>/dev/null で未対応シェルのエラーを抑制
+    // SSHログイン時にfishへ切り替える設定があっても、以降の制御文字を
+    // BashのANSI-C quotingで送信できるよう、内部シェルをbashに固定する。
+    // fishのWelcomeバナーなど、exec前に届いた初期出力は破棄する。
+    _sharedScanner.reset();
+    _session!.write(utf8.encode('exec bash --norc\n'));
+    await Future.delayed(const Duration(milliseconds: 100));
+
+    // Bashのヒストリー記録を無効化し、プロンプトを抑制する。
+    // - export HISTFILE=... : スタートアップファイル後にも履歴を保存しない
+    // - set +H : 入力中のリテラル`!`のヒストリー展開を無効化
     _session!.write(utf8.encode(
       'export HISTFILE=/dev/null HISTSIZE=0 HISTFILESIZE=0 SAVEHIST=0 2>/dev/null;'
       ' set +H 2>/dev/null;'
-      ' set fish_history "" 2>/dev/null; true;'
       ' export PS1="" PS2="" 2>/dev/null; stty -echo -onlcr -opost\n',
     ));
     await Future.delayed(const Duration(milliseconds: 100));
 
-    // バッファをクリア（初期化出力を破棄）
+    // バッファをクリア（bash起動・初期化コマンドのエコーを破棄）
     _sharedScanner.reset();
   }
 

--- a/lib/services/tmux/tmux_command_builder.dart
+++ b/lib/services/tmux/tmux_command_builder.dart
@@ -504,6 +504,30 @@ class TmuxCommands {
   // inventory: TMUX-ESC-001
   /// 引数をエスケープ
   static String _escapeArg(String arg) {
+    // 制御文字（0x00-0x1F / 0x7F）を含む場合は bash の ANSI-C quoting
+    // （$'...'）で送る。ダブルクォート等の通常の引用符では、コマンドライン
+    // 内の制御文字（Ctrl+A = 行頭移動、Ctrl+O = 履歴操作等）を対話シェルの
+    // readline が解釈して失うため（herdr の _shellQuote と同様）。
+    if (arg.codeUnits.any((c) => c < 0x20 || c == 0x7f)) {
+      final buffer = StringBuffer("\$");
+      buffer.write("'");
+      for (final rune in arg.runes) {
+        if (rune < 0x20 || rune == 0x7f) {
+          buffer.write('\\x${rune.toRadixString(16).padLeft(2, '0')}');
+        } else if (rune == 0x5c) {
+          // backslash
+          buffer.write(r'\\');
+        } else if (rune == 0x27) {
+          // single quote
+          buffer.write(r"\'");
+        } else {
+          buffer.writeCharCode(rune);
+        }
+      }
+      buffer.write("'");
+      return buffer.toString();
+    }
+
     // シェルの特殊文字をエスケープ
     // 特殊文字: スペース、クォート、バックスラッシュ、変数展開、バッククォート、
     // グロブ（*?）、チルダ（~）、コメント（#）、その他

--- a/lib/widgets/special_keys_bar.dart
+++ b/lib/widgets/special_keys_bar.dart
@@ -272,9 +272,9 @@ class _SpecialKeysBarState extends State<SpecialKeysBar> {
   /// 外付けキーボードの修飾子を検出してtmux形式キー名に変換
   String _applyHardwareModifiers(String baseKey) {
     final isShift = HardwareKeyboard.instance.isShiftPressed;
-    final isCtrl = HardwareKeyboard.instance.isControlPressed ||
-        HardwareKeyboard.instance.isMetaPressed;
+    final isCtrl = HardwareKeyboard.instance.isControlPressed;
     final isAlt = HardwareKeyboard.instance.isAltPressed;
+    final isMeta = HardwareKeyboard.instance.isMetaPressed;
 
     // 特殊ケース: Shift+Tab → BTab
     if (isShift && baseKey == 'Tab') return 'BTab';
@@ -283,6 +283,7 @@ class _SpecialKeysBarState extends State<SpecialKeysBar> {
     if (isShift) mods.add('S');
     if (isCtrl) mods.add('C');
     if (isAlt) mods.add('M');
+    if (isMeta) mods.add('M');
     if (mods.isEmpty) return baseKey;
     return '${mods.join('-')}-$baseKey';
   }
@@ -349,9 +350,8 @@ class _SpecialKeysBarState extends State<SpecialKeysBar> {
 
     final key = event.logicalKey;
 
-    // Ctrl/Meta + A-Z のショートカット処理
-    final isCtrlPressed = HardwareKeyboard.instance.isControlPressed ||
-        HardwareKeyboard.instance.isMetaPressed;
+    // Ctrl + A-Z のショートカット処理（Cmd/Meta は Ctrl として扱わない）
+    final isCtrlPressed = HardwareKeyboard.instance.isControlPressed;
     if (isCtrlPressed) {
       final keyLabel = key.keyLabel;
       if (keyLabel.length == 1 && RegExp(r'^[A-Za-z]$').hasMatch(keyLabel)) {
@@ -360,6 +360,21 @@ class _SpecialKeysBarState extends State<SpecialKeysBar> {
           HapticFeedback.lightImpact();
         }
         widget.onSpecialKeyPressed('C-${keyLabel.toLowerCase()}');
+        _resetSoftwareModifiers();
+        return KeyEventResult.handled;
+      }
+    }
+
+    // Cmd/Meta + A-Z は M- として送信（ユーザー要望: Meta/Super として伝える）
+    final isMetaPressed = HardwareKeyboard.instance.isMetaPressed;
+    if (isMetaPressed) {
+      final keyLabel = key.keyLabel;
+      if (keyLabel.length == 1 && RegExp(r'^[A-Za-z]$').hasMatch(keyLabel)) {
+        _markKeyEventHandled();
+        if (widget.hapticFeedback) {
+          HapticFeedback.lightImpact();
+        }
+        widget.onSpecialKeyPressed('M-${keyLabel.toLowerCase()}');
         _resetSoftwareModifiers();
         return KeyEventResult.handled;
       }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -61,10 +61,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -109,18 +109,18 @@ packages:
     dependency: "direct main"
     description:
       name: connectivity_plus
-      sha256: b5e72753cf63becce2c61fd04dfe0f1c430cc5278b53a1342dc5ad839eab29ec
+      sha256: "762c99f890ca8bf87f7337236f99edd42793843bc6c3631da294a76653a54bd0"
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.5"
+    version: "7.3.1"
   connectivity_plus_platform_interface:
     dependency: transitive
     description:
       name: connectivity_plus_platform_interface
-      sha256: "42657c1715d48b167930d5f34d00222ac100475f73d10162ddf43e714932f204"
+      sha256: "3c09627c536d22fd24691a905cdd8b14520de69da52c7a97499c8be5284a32ed"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "2.1.0"
   convert:
     dependency: transitive
     description:
@@ -552,14 +552,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.5"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      sha256: "53385261521cc4a0c4658fd0ad07a7d14591cf8fc33abbceae306ddb974888dc"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.7.2"
   json_annotation:
     dependency: transitive
     description:
@@ -652,26 +644,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:
@@ -729,13 +721,13 @@ packages:
     source: hosted
     version: "1.9.1"
   path_provider:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: path_provider
-      sha256: "50c5dd5b6e1aaf6fb3a78b33f6aa3afca52bf903a8a5298f53101fdaee55bbcd"
+      sha256: a7f4874f987173da295a61c181b8ee71dab59b332a486b391babf26a1b884825
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.5"
+    version: "2.1.6"
   path_provider_android:
     dependency: transitive
     description:
@@ -1009,26 +1001,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
+      sha256: "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20"
       url: "https://pub.dev"
     source: hosted
-    version: "1.26.3"
+    version: "1.31.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.11"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
+      sha256: "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.12"
+    version: "0.6.17"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -59,9 +59,10 @@ dependencies:
   # Display refresh-rate control (max FPS setting)
   flutter_displaymode: ^0.6.0
   # Network connectivity monitoring
-  connectivity_plus: ^6.0.0
+  connectivity_plus: ^7.3.1
   path: ^1.9.1
   intl: ^0.20.2
+  path_provider: ^2.1.6
 
 dev_dependencies:
   flutter_test:

--- a/test/screens/terminal/terminal_screen_herdr_mutation_sync_test.dart
+++ b/test/screens/terminal/terminal_screen_herdr_mutation_sync_test.dart
@@ -335,14 +335,17 @@ void main() {
     );
 
     testWidgets(
-      'focus 成功後は単一経路（force 再取得）で同期される',
+      'focus 成功後は単一経路（force 再取得）で同期され、フォーカス先の pane へ表示が切り替わる',
       (tester) async {
         final client = await _pumpHerdrTerminal(
           tester,
+          // 接続時: w1:t1（w1:p1）/ focus 後の force 再取得: 旧 pane は残存しつつ
+          // フォーカスは w1:p2 へ移動（S0 実測形状）。スワイプ（方向フォーカス）は
+          // フォーカス移動を伴う操作のため followBackendFocus で追従すること。
           execOutputQueues: {
             'herdr api snapshot': [
               kHerdrSnapshotFixture,
-              kHerdrSnapshotFixture,
+              kHerdrSnapshotNewTabFixture,
             ],
           },
         );
@@ -368,6 +371,20 @@ void main() {
           greaterThanOrEqualTo(2),
           reason: 'focus 成功後も _syncAfterHerdrMutation 単一経路が走ること',
         );
+        // スワイプはフォーカス移動を伴うため、旧 pane（w1:p1）が snapshot に
+        // 残存していても followBackendFocus でフォーカス先（w1:p2）へ表示切替。
+        final events = herdrSwitchEvents(tester);
+        expect(
+          events.any((e) => e.contains('focus sync -> w1:p2')),
+          isTrue,
+          reason: 'focus 後は _syncAfterHerdrMutation（focus sync）が走ること',
+        );
+        expect(
+          events.any((e) => e.contains('switch target -> w1:p2')),
+          isTrue,
+          reason: '方向フォーカスは snapshot の focused pane へ表示を追従すること',
+        );
+        expect(find.text('Pane 2'), findsOneWidget);
 
         await tester.pump(const Duration(milliseconds: 200));
       },

--- a/test/screens/terminal/terminal_screen_herdr_test.dart
+++ b/test/screens/terminal/terminal_screen_herdr_test.dart
@@ -1714,7 +1714,7 @@ void main() {
           client.execCommands.any(
             (c) =>
                 c.startsWith('herdr pane send-text w1:p1') &&
-                c.contains('\x1b[5~'),
+                c.contains(r'\x1b[5~'),
           ),
           isTrue,
           reason: '拒否キー（PgUp）は send-text でエスケープシーケンスが送られること',
@@ -1751,7 +1751,7 @@ void main() {
           client.execCommands.any(
             (c) =>
                 c.startsWith('herdr pane send-text w1:p1') &&
-                c.codeUnits.contains(0x04),
+                c.contains(r'\x04'),
           ),
           isTrue,
           reason: '制御文字（C-d）は send-text で制御文字そのものが送られること',

--- a/test/services/backend/domain/herdr_pane_writer_test.dart
+++ b/test/services/backend/domain/herdr_pane_writer_test.dart
@@ -76,13 +76,15 @@ void main() {
     test('sendKey: 拒否キーは send-text でエスケープシーケンスを送信する', () async {
       await writer.sendKey('w1:p1', 'Home');
       expect(backend.commands.single, contains('herdr pane send-text w1:p1'));
-      expect(backend.commands.single, contains('\x1b[H'));
+      // エスケープシーケンスは ANSI-C quoting（$'...'）で送る
+      expect(backend.commands.single, contains(r'\x1b[H'));
     });
 
     test('sendKey: 制御文字は send-text で制御文字そのものを送信する', () async {
       await writer.sendKey('w1:p1', 'C-d');
       expect(backend.commands.single, contains('herdr pane send-text w1:p1'));
-      expect(backend.commands.single.codeUnits, contains(0x04));
+      // 制御文字は ANSI-C quoting（$'...'）の \x04 リテラルで送る
+      expect(backend.commands.single, contains(r'\x04'));
     });
 
     test(
@@ -249,7 +251,7 @@ void main() {
       await writer.pasteText('w1:p1', 'a\nb');
       expect(
         backend.commands.single,
-        contains("herdr pane send-text w1:p1 'a"),
+        contains(r"herdr pane send-text w1:p1 $'a\x0ab'"),
       );
     });
 

--- a/test/services/herdr/herdr_adapter_test.dart
+++ b/test/services/herdr/herdr_adapter_test.dart
@@ -435,9 +435,10 @@ void main() {
       final adapter = HerdrAdapter(client);
       await adapter.sendText('w1:p1', 'line1\nline2 \u3042');
 
+      // 改行（0x0A）は制御文字のため ANSI-C quoting（$'...'）で送る
       expect(
         client.execCommands,
-        contains("herdr pane send-text w1:p1 'line1\nline2 \u3042'"),
+        contains(r"herdr pane send-text w1:p1 $'line1\x0aline2 あ'"),
       );
     });
 

--- a/test/services/herdr/herdr_commands_test.dart
+++ b/test/services/herdr/herdr_commands_test.dart
@@ -55,9 +55,38 @@ void main() {
     });
 
     test('paneSendText handles multi-line and unicode text', () {
+      // 改行（0x0A）は制御文字のため ANSI-C quoting（$'...'）で送る
       expect(
         HerdrCommands.paneSendText('w1:p1', 'line1\nline2 \u3042'),
-        "herdr pane send-text w1:p1 'line1\nline2 \u3042'",
+        r"herdr pane send-text w1:p1 $'line1\x0aline2 あ'",
+      );
+    });
+
+    test('paneSendText escapes control chars with ANSI-C quoting', () {
+      // 制御文字（Ctrl+O = 0x0F など）は readline に吸われないよう \xHH で送る
+      expect(
+        HerdrCommands.paneSendText('w1:p1', '\x0f'),
+        r"herdr pane send-text w1:p1 $'\x0f'",
+      );
+    });
+
+    test('paneSendText escapes all Ctrl+A-Z control chars (0x01-0x1A)', () {
+      // Ctrl+[A-Z] の制御文字（0x01-0x1A）がすべて $'\xHH' 形式で送られること
+      for (var i = 1; i <= 26; i++) {
+        final ctrl = String.fromCharCode(i);
+        final hex = i.toRadixString(16).padLeft(2, '0');
+        expect(
+          HerdrCommands.paneSendText('w1:p1', ctrl),
+          "herdr pane send-text w1:p1 \$'\\x$hex'",
+          reason: 'Ctrl+${String.fromCharCode(0x40 + i)} (0x$hex) のエスケープ',
+        );
+      }
+    });
+
+    test('paneSendText ANSI-C quoting escapes backslash and quote', () {
+      expect(
+        HerdrCommands.paneSendText('w1:p1', '\\\x01'),
+        r"herdr pane send-text w1:p1 $'\\\x01'",
       );
     });
 

--- a/test/services/ssh/persistent_shell_test.dart
+++ b/test/services/ssh/persistent_shell_test.dart
@@ -107,8 +107,13 @@ void main() {
       expect(client.lastPty?.type, 'dumb');
       expect(client.lastPty?.width, 200);
       expect(client.lastPty?.height, 50);
+      expect(client._session.written, hasLength(2));
+      expect(
+        String.fromCharCodes(client._session.written.first),
+        'exec bash --norc\n',
+      );
       final initialization = String.fromCharCodes(
-        client._session.written.single,
+        client._session.written.last,
       );
       expect(initialization, contains('HISTFILE=/dev/null'));
       expect(initialization, contains('stty -echo'));
@@ -210,7 +215,7 @@ void main() {
       final shell = PersistentShell(client);
       await shell.start();
       shell.sendNoWait('C-c');
-      expect(client._session.written, hasLength(2));
+      expect(client._session.written, hasLength(3));
       final last = String.fromCharCodes(client._session.written.last);
       expect(last, 'C-c\n');
       await shell.dispose();
@@ -404,7 +409,9 @@ void main() {
       await shell.start();
       final newSession = client._session;
       final newWrites = newSession.written.where(
-        (w) => !String.fromCharCodes(w).contains('HISTFILE=/dev/null'),
+        (w) =>
+            !String.fromCharCodes(w).contains('HISTFILE=/dev/null') &&
+            String.fromCharCodes(w) != 'exec bash --norc\n',
       );
       expect(
         newWrites,


### PR DESCRIPTION
## Summary
- Fix herdr 2-finger swipe: the display now follows the focused pane after direction focus (previously the old pane stayed visible)
- Fix control character delivery to herdr/tmux: control chars are sent via bash ANSI-C quoting (`$'...'`) so interactive readline does not swallow them (e.g. Ctrl+A/Ctrl+O/Ctrl+E); the SSH inner shell is pinned to `bash --norc` so quoting works regardless of the user's login shell (fish)
- Fix iPad external-keyboard Cmd key: Cmd is no longer treated as Ctrl; Cmd+A-Z is sent as an `M-` modifier, and Meta+letter produces the xterm ESC-prefixed sequence
- Also: show the red edge flash on swipe toward a direction with no adjacent pane in herdr (layout rect-based adjacency), and upgrade to Flutter 3.44.9 / connectivity_plus 7.3.1 (+ path_provider)

## Changes
- `lib/screens/terminal/terminal_screen.dart`: use `followBackendFocus` sync policy for swipe focus so the snapshot's focused pane becomes the display target; add herdr navigable-direction detection from snapshot pane rects (edge flash)
- `lib/screens/terminal/widgets/ansi_text_view.dart`: track Meta key state and emit `\x1b`-prefixed sequences for Meta+char
- `lib/widgets/special_keys_bar.dart`: drop Meta from the Ctrl shortcut path; send Cmd+A-Z as `M-<key>`; include Meta in hardware modifier mapping
- `lib/services/herdr/herdr_commands.dart` / `lib/services/tmux/tmux_command_builder.dart`: escape control chars (0x00-0x1F/0x7F) with ANSI-C quoting (`$'...'` + `\xHH`)
- `lib/services/ssh/persistent_shell.dart`: `exec bash --norc` after login, discard pre-exec banner output, keep history off
- `test/`: updated and added tests for quoting, swipe focus sync, and bash exec
- `.mise.toml`, `.github/workflows/testflight.yml`, `docs/ci-testflight.md`: Flutter 3.44.9
- `pubspec.yaml` / `pubspec.lock`: connectivity_plus 7.3.1, add path_provider 2.1.6

## Test plan
- [ ] `flutter analyze`
- [ ] `flutter test`
- [ ] Manual: herdr 2-finger swipe switches display to the focused pane
- [ ] Manual: swipe toward a direction with no adjacent pane shows the red edge flash
- [ ] Manual: control chars (e.g. Ctrl+A, Ctrl+O) reach the shell even with fish login shell
- [ ] Manual: iPad external keyboard Cmd+A-Z is sent as M- sequences