### PR TITLE
fix: append colon to tmux new-window session name to prevent numeric session name misinterpretation

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,2 +1,6 @@
 org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
+# This builtInKotlin flag was added automatically by Flutter migrator
+android.builtInKotlin=false
+# This newDsl flag was added automatically by Flutter migrator
+android.newDsl=false

--- a/lib/services/tmux/tmux_command_builder.dart
+++ b/lib/services/tmux/tmux_command_builder.dart
@@ -118,7 +118,11 @@ class TmuxCommands {
     String? startDirectory,
     bool background = false,
   }) {
-    final parts = ['tmux', 'new-window', '-t', _escapeArg(sessionName)];
+    // セッション名にコロンを付与し、数値セッション名（例: "1"）が
+    // tmux によりウィンドウインデックスと誤解釈されるのを防ぐ。
+    // （`tmux new-window -t 1` は「現在セッションのウィンドウ番号1」を指す。
+    //   `-t 1:` とすればセッション「1」として正しく解決される）
+    final parts = ['tmux', 'new-window', '-t', _escapeArg('$sessionName:')];
     if (background) parts.add('-d');
     if (windowName != null) parts.addAll(['-n', _escapeArg(windowName)]);
     if (startDirectory != null) parts.addAll(['-c', _escapeArg(startDirectory)]);

--- a/test/services/tmux/tmux_commands_test.dart
+++ b/test/services/tmux/tmux_commands_test.dart
@@ -603,14 +603,14 @@ void main() {
     test('generates new-window command with defaults', () {
       expect(
         TmuxCommands.newWindow(sessionName: 'main'),
-        'tmux new-window -t main',
+        'tmux new-window -t main:',
       );
     });
 
     test('generates new-window command with background flag', () {
       expect(
         TmuxCommands.newWindow(sessionName: 'main', background: true),
-        'tmux new-window -t main -d',
+        'tmux new-window -t main: -d',
       );
     });
 
@@ -621,7 +621,7 @@ void main() {
           windowName: 'build',
           startDirectory: '/home/user',
         ),
-        'tmux new-window -t main -n build -c /home/user',
+        'tmux new-window -t main: -n build -c /home/user',
       );
     });
   });


### PR DESCRIPTION
## Summary
- Fix an issue where `tmux new-window -t <session>` misinterprets a numeric session name (e.g. `1`) as a window index
- Append a colon to the session name (`-t <session>:`) so it is correctly resolved as a session name
- Add Kotlin/DSL flags to `android/gradle.properties` via the Flutter migrator

## Changes
- **lib/services/tmux/tmux_command_builder.dart**: Append `:` to the session name in the target argument of `newWindow()` (`-t <session>:`)
- **test/services/tmux/tmux_commands_test.dart**: Update expected `newWindow` commands to include the trailing colon
- **android/gradle.properties**: Add `android.builtInKotlin=false` / `android.newDsl=false` (auto-added by the Flutter migrator)

## Test plan
- [ ] `flutter test test/services/tmux/tmux_commands_test.dart` (verify updated expectations)
- [ ] `flutter analyze`
- [ ] Manually verify that new-window creates a window inside the correct session for a numeric session name (e.g. session `1`)