### PR TITLE
fix: detect damaged SSH keys and guide re-import instead of raw errors

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -17,7 +17,8 @@
     <application
         android:label="MuxPod"
         android:name="${applicationName}"
-        android:icon="@mipmap/ic_launcher">
+        android:icon="@mipmap/ic_launcher"
+        android:allowBackup="false">
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/lib/providers/key_provider.dart
+++ b/lib/providers/key_provider.dart
@@ -23,6 +23,7 @@ class SshKeyMeta {
   final DateTime createdAt;
   final String? comment;
   final KeySource source; // 鍵の由来
+  final bool isAvailable; // 秘密鍵が復号可能か（false = 破損鍵）
 
   const SshKeyMeta({
     required this.id,
@@ -34,6 +35,7 @@ class SshKeyMeta {
     required this.createdAt,
     this.comment,
     this.source = KeySource.generated,
+    this.isAvailable = true,
   });
 
   SshKeyMeta copyWith({
@@ -46,6 +48,7 @@ class SshKeyMeta {
     DateTime? createdAt,
     String? comment,
     KeySource? source,
+    bool? isAvailable,
   }) {
     return SshKeyMeta(
       id: id ?? this.id,
@@ -57,6 +60,7 @@ class SshKeyMeta {
       createdAt: createdAt ?? this.createdAt,
       comment: comment ?? this.comment,
       source: source ?? this.source,
+      isAvailable: isAvailable ?? this.isAvailable,
     );
   }
 
@@ -71,6 +75,7 @@ class SshKeyMeta {
       'createdAt': createdAt.toIso8601String(),
       'comment': comment,
       'source': source.name,
+      'isAvailable': isAvailable,
     };
   }
 
@@ -88,6 +93,7 @@ class SshKeyMeta {
         (e) => e.name == (json['source'] as String?),
         orElse: () => KeySource.generated,
       ),
+      isAvailable: json['isAvailable'] as bool? ?? true,
     );
   }
 }
@@ -97,22 +103,26 @@ class KeysState {
   final List<SshKeyMeta> keys;
   final bool isLoading;
   final String? error;
+  final List<SshKeyMeta> damagedKeys; // 破損鍵（モーダル表示用）
 
   const KeysState({
     this.keys = const [],
     this.isLoading = false,
     this.error,
+    this.damagedKeys = const [],
   });
 
   KeysState copyWith({
     List<SshKeyMeta>? keys,
     bool? isLoading,
     String? error,
+    List<SshKeyMeta>? damagedKeys,
   }) {
     return KeysState(
       keys: keys ?? this.keys,
       isLoading: isLoading ?? this.isLoading,
       error: error,
+      damagedKeys: damagedKeys ?? this.damagedKeys,
     );
   }
 }
@@ -121,15 +131,21 @@ class KeysState {
 class KeysNotifier extends Notifier<KeysState> {
   static const String _storageKey = 'ssh_keys_meta';
 
+  bool _disposed = false;
+  int _loadGeneration = 0;
+
   @override
   KeysState build() {
+    ref.onDispose(() => _disposed = true);
     _loadKeys();
     return const KeysState(isLoading: true);
   }
 
   Future<void> _loadKeys() async {
+    final generation = ++_loadGeneration;
     try {
       final prefs = await SharedPreferences.getInstance();
+      if (_disposed || generation != _loadGeneration) return;
       final jsonString = prefs.getString(_storageKey);
 
       if (jsonString != null) {
@@ -141,24 +157,42 @@ class KeysNotifier extends Notifier<KeysState> {
         // 作成日時で並び替え（降順）
         keys.sort((a, b) => b.createdAt.compareTo(a.createdAt));
 
-        state = KeysState(keys: keys);
+        // 秘密鍵の可用性をチェック（破損鍵の検出）
+        final storage = SecureStorageService();
+        for (var i = 0; i < keys.length; i++) {
+          final privateKey = await storage.getPrivateKey(keys[i].id);
+          if (_disposed || generation != _loadGeneration) return;
+          // 可用性は保存済み値ではなく、各ロード時の読み取り結果から上書きする
+          keys[i] = keys[i].copyWith(isAvailable: privateKey != null);
+        }
+
+        final damagedKeys = keys.where((k) => !k.isAvailable).toList();
+        if (_disposed || generation != _loadGeneration) return;
+        state = KeysState(keys: keys, damagedKeys: damagedKeys);
       } else {
+        if (_disposed || generation != _loadGeneration) return;
         state = const KeysState();
       }
     } catch (e) {
-      state = KeysState(error: e.toString());
+      if (!_disposed && generation == _loadGeneration) {
+        state = KeysState(error: e.toString());
+      }
     }
   }
 
   Future<void> _saveKeys() async {
     final prefs = await SharedPreferences.getInstance();
-    final jsonList = state.keys.map((k) => k.toJson()).toList();
+    // 作成日時で並び替え（降順）
+    final keys = [...state.keys]
+      ..sort((a, b) => b.createdAt.compareTo(a.createdAt));
+    final jsonList = keys.map((k) => k.toJson()).toList();
     await prefs.setString(_storageKey, jsonEncode(jsonList));
   }
 
   /// 鍵を追加
   Future<void> add(SshKeyMeta key) async {
-    final keys = [...state.keys, key];
+    final keys = [...state.keys, key]
+      ..sort((a, b) => b.createdAt.compareTo(a.createdAt));
     state = state.copyWith(keys: keys);
     await _saveKeys();
   }

--- a/lib/providers/key_provider.dart
+++ b/lib/providers/key_provider.dart
@@ -229,6 +229,12 @@ class KeysNotifier extends Notifier<KeysState> {
   }
 }
 
+/// 指定の鍵IDが破損鍵（秘密鍵を読み出せない）かどうかを返す。
+bool isKeyDamaged(KeysState state, String? keyId) {
+  if (keyId == null) return false;
+  return state.keys.any((k) => k.id == keyId && !k.isAvailable);
+}
+
 /// SSH鍵プロバイダー
 final keysProvider = NotifierProvider<KeysNotifier, KeysState>(() {
   return KeysNotifier();

--- a/lib/screens/connections/connection_form_screen.dart
+++ b/lib/screens/connections/connection_form_screen.dart
@@ -965,7 +965,9 @@ class _ConnectionFormScreenState extends ConsumerState<ConnectionFormScreen> {
         privateKey = await storage.getPrivateKey(_selectedKeyId!);
         passphrase = await storage.getPassphrase(_selectedKeyId!);
         if (privateKey == null) {
-          throw SshAuthenticationError('Private key not found');
+          throw SshAuthenticationError(
+            'Private key is not readable. Please re-import the key.',
+          );
         }
       }
 

--- a/lib/screens/connections/connection_form_screen.dart
+++ b/lib/screens/connections/connection_form_screen.dart
@@ -837,9 +837,16 @@ class _ConnectionFormScreenState extends ConsumerState<ConnectionFormScreen> {
           dropdownColor: colorScheme.surface,
           style: GoogleFonts.spaceGrotesk(fontSize: 14, color: colorScheme.onSurface),
           items: keysState.keys.map((key) {
+            final damaged = !key.isAvailable;
             return DropdownMenuItem(
               value: key.id,
-              child: Text(key.name),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(key.name),
+                  if (damaged) ...[const SizedBox(width: 6), Icon(Icons.warning_amber, size: 14, color: colorScheme.error)],
+                ],
+              ),
             );
           }).toList(),
           onChanged: (value) => setState(() => _selectedKeyId = value),
@@ -854,17 +861,30 @@ class _ConnectionFormScreenState extends ConsumerState<ConnectionFormScreen> {
             style: GoogleFonts.spaceGrotesk(color: mutedColor),
           ),
         ),
-        if (_authMethod == 'key' && keysState.keys.isEmpty) ...[
-          const SizedBox(height: 8),
-          Text(
-            'No SSH keys found. Add keys in the Keys section.',
-            style: GoogleFonts.spaceGrotesk(
-              fontSize: 12,
-              color: colorScheme.error,
-            ),
-          ),
-        ],
+        if (_authMethod == 'key' && keysState.keys.isEmpty) ...[const SizedBox(height: 8), Text('No SSH keys found. Add keys in the Keys section.', style: GoogleFonts.spaceGrotesk(fontSize: 12, color: colorScheme.error))],
+        if (_authMethod == 'key' &&
+            _selectedKeyId != null &&
+            isKeyDamaged(keysState, _selectedKeyId)) ...[const SizedBox(height: 8), _buildDamagedKeyWarning(context)],
       ],
+    );
+  }
+
+  /// 破損キー選択中の警告表示
+  Widget _buildDamagedKeyWarning(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
+      decoration: BoxDecoration(
+        color: colorScheme.errorContainer,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Text(
+        '選択中の鍵は破損しています（秘密鍵を読み出せません）。別の鍵を選択するか、鍵を再インポートしてください。',
+        style: Theme.of(context).textTheme.bodySmall?.copyWith(
+              fontSize: 12,
+              color: colorScheme.onErrorContainer,
+            ),
+      ),
     );
   }
 

--- a/lib/screens/connections/connections_screen.dart
+++ b/lib/screens/connections/connections_screen.dart
@@ -712,6 +712,11 @@ class _ConnectionCardState extends ConsumerState<_ConnectionCard> {
     SshConnectOptions options;
     if (connection.authMethod == 'key' && connection.keyId != null) {
       final privateKey = await storage.getPrivateKey(connection.keyId!);
+      if (privateKey == null) {
+        throw SshAuthenticationError(
+          'Private key is not readable. Please re-import the key.',
+        );
+      }
       final passphrase = await storage.getPassphrase(connection.keyId!);
       options = SshConnectOptions(
         privateKey: privateKey,

--- a/lib/screens/connections/connections_screen.dart
+++ b/lib/screens/connections/connections_screen.dart
@@ -6,6 +6,7 @@ import 'package:google_fonts/google_fonts.dart';
 
 import '../../providers/active_session_provider.dart';
 import '../../providers/connection_provider.dart';
+import '../../providers/key_provider.dart';
 import '../home_screen.dart';
 import '../../services/backend/backend_type.dart';
 import '../../services/backend/domain/multiplexer_backend.dart';
@@ -557,6 +558,10 @@ class _ConnectionCardState extends ConsumerState<_ConnectionCard> {
         activeSessionsState.getSessionsForConnection(widget.connection.id);
     final hasActiveSessions = activeSessions.isNotEmpty;
 
+    // 破損キー（秘密鍵を読み出せない鍵）を参照している接続かどうか
+    final keysState = ref.watch(keysProvider);
+    final hasDamagedKey = isKeyDamaged(keysState, widget.connection.keyId);
+
     // 接続状態の判定（アクティブセッションがあるか、lastConnectedAtがあるか）
     final isConnected = hasActiveSessions || widget.connection.lastConnectedAt != null;
     final statusColor = hasActiveSessions
@@ -643,14 +648,21 @@ class _ConnectionCardState extends ConsumerState<_ConnectionCard> {
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
-                        Text(
-                          widget.connection.name,
-                          style: GoogleFonts.spaceGrotesk(
-                            fontSize: 16,
-                            fontWeight: FontWeight.w700,
-                            color: colorScheme.onSurface,
-                            letterSpacing: 0.3,
-                          ),
+                        Row(
+                          children: [
+                            Flexible(
+                              child: Text(
+                                widget.connection.name,
+                                style: GoogleFonts.spaceGrotesk(
+                                  fontSize: 16,
+                                  fontWeight: FontWeight.w700,
+                                  color: colorScheme.onSurface,
+                                  letterSpacing: 0.3,
+                                ),
+                              ),
+                            ),
+                            if (hasDamagedKey) ...[const SizedBox(width: 6), Icon(Icons.warning_amber, size: 16, color: colorScheme.error)],
+                          ],
                         ),
                         const SizedBox(height: 2),
                         Text(
@@ -660,6 +672,7 @@ class _ConnectionCardState extends ConsumerState<_ConnectionCard> {
                             color: isDark ? DesignColors.textMuted : DesignColors.textMutedLight,
                           ),
                         ),
+                        if (hasDamagedKey) ...[const SizedBox(height: 4), _buildDamagedKeyBadge(context)],
                       ],
                     ),
                   ),
@@ -1283,6 +1296,25 @@ class _ConnectionCardState extends ConsumerState<_ConnectionCard> {
         ),
       );
     }).toList();
+  }
+
+  /// 破損キー使用中のバッジ
+  Widget _buildDamagedKeyBadge(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 1),
+      decoration: BoxDecoration(
+        color: colorScheme.errorContainer,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Text(
+        '破損した鍵を使用中',
+        style: Theme.of(context).textTheme.labelSmall?.copyWith(
+              fontSize: 9,
+              color: colorScheme.onErrorContainer,
+            ),
+      ),
+    );
   }
 }
 

--- a/lib/screens/dashboard/dashboard_screen.dart
+++ b/lib/screens/dashboard/dashboard_screen.dart
@@ -3,6 +3,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:google_fonts/google_fonts.dart';
 
 import '../../providers/active_session_provider.dart';
+import '../../providers/connection_provider.dart';
+import '../../providers/key_provider.dart';
 import '../../providers/session_history_provider.dart';
 import '../../theme/design_colors.dart';
 import '../connections/connection_form_screen.dart';
@@ -169,7 +171,7 @@ class DashboardScreen extends ConsumerWidget {
 }
 
 /// セッション履歴カード
-class _SessionHistoryCard extends StatelessWidget {
+class _SessionHistoryCard extends ConsumerWidget {
   final ActiveSession session;
   final VoidCallback onTap;
   final VoidCallback onRemove;
@@ -181,10 +183,22 @@ class _SessionHistoryCard extends StatelessWidget {
   });
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final colorScheme = Theme.of(context).colorScheme;
     final isAttached = session.isAttached;
+
+    // このセッションの接続が破損キー（秘密鍵を読み出せない鍵）を参照しているか
+    final connectionsState = ref.watch(connectionsProvider);
+    String? connectionKeyId;
+    for (final c in connectionsState.connections) {
+      if (c.id == session.connectionId) {
+        connectionKeyId = c.keyId;
+        break;
+      }
+    }
+    final keysState = ref.watch(keysProvider);
+    final hasDamagedKey = isKeyDamaged(keysState, connectionKeyId);
 
     return Dismissible(
       key: Key(session.key),
@@ -302,16 +316,23 @@ class _SessionHistoryCard extends StatelessWidget {
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
                     // Session Name with Connection Name
-                    Text(
-                      '${session.connectionName}: ${session.sessionName}',
-                      style: GoogleFonts.spaceGrotesk(
-                        fontSize: 16,
-                        fontWeight: FontWeight.w700,
-                        color: colorScheme.onSurface,
-                        letterSpacing: 0.3,
-                      ),
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
+                    Row(
+                      children: [
+                        Flexible(
+                          child: Text(
+                            '${session.connectionName}: ${session.sessionName}',
+                            style: GoogleFonts.spaceGrotesk(
+                              fontSize: 16,
+                              fontWeight: FontWeight.w700,
+                              color: colorScheme.onSurface,
+                              letterSpacing: 0.3,
+                            ),
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                        ),
+                        if (hasDamagedKey) ...[const SizedBox(width: 6), Icon(Icons.warning_amber, size: 16, color: colorScheme.error)],
+                      ],
                     ),
                     const SizedBox(height: 4),
                     // Host and relative time
@@ -344,6 +365,7 @@ class _SessionHistoryCard extends StatelessWidget {
                         ),
                       ],
                     ),
+                    if (hasDamagedKey) ...[const SizedBox(height: 4), _buildDamagedKeyBadge(context)],
                     const SizedBox(height: 4),
                     // Window count and last position
                     Row(
@@ -412,6 +434,25 @@ class _SessionHistoryCard extends StatelessWidget {
       final weeks = (diff.inDays / 7).floor();
       return '$weeks week${weeks > 1 ? 's' : ''} ago';
     }
+  }
+
+  /// 破損キー使用中のバッジ
+  Widget _buildDamagedKeyBadge(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 1),
+      decoration: BoxDecoration(
+        color: colorScheme.errorContainer,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Text(
+        '破損した鍵を使用中',
+        style: Theme.of(context).textTheme.labelSmall?.copyWith(
+              fontSize: 9,
+              color: colorScheme.onErrorContainer,
+            ),
+      ),
+    );
   }
 }
 

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -379,6 +379,11 @@ class _TerminalTabState extends ConsumerState<_TerminalTab> {
           SshConnectOptions options;
           if (connection.authMethod == 'key' && connection.keyId != null) {
             final privateKey = await storage.getPrivateKey(connection.keyId!);
+            if (privateKey == null) {
+              throw SshAuthenticationError(
+                'Private key is not readable. Please re-import the key.',
+              );
+            }
             final passphrase = await storage.getPassphrase(connection.keyId!);
             options = SshConnectOptions(privateKey: privateKey, passphrase: passphrase, multiplexer: connection.multiplexer);
           } else {

--- a/lib/screens/keys/keys_screen.dart
+++ b/lib/screens/keys/keys_screen.dart
@@ -11,12 +11,30 @@ import 'key_import_screen.dart';
 import 'widgets/key_tile.dart';
 
 /// SSH鍵一覧画面
-class KeysScreen extends ConsumerWidget {
+class KeysScreen extends ConsumerStatefulWidget {
   const KeysScreen({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<KeysScreen> createState() => _KeysScreenState();
+}
+
+class _KeysScreenState extends ConsumerState<KeysScreen> {
+  /// 破損鍵モーダルを表示済みか（同一セッション内で一度だけ表示する）
+  bool _damagedKeysDialogShown = false;
+
+  @override
+  Widget build(BuildContext context) {
     final keysState = ref.watch(keysProvider);
+
+    // 破損鍵が検出された場合、起動時に一度だけモーダルを表示する
+    ref.listen(keysProvider, (prev, next) {
+      if (!_damagedKeysDialogShown && next.damagedKeys.isNotEmpty) {
+        _damagedKeysDialogShown = true;
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          _showDamagedKeysDialog(next.damagedKeys);
+        });
+      }
+    });
 
     return Scaffold(
       body: CustomScrollView(
@@ -290,5 +308,108 @@ class KeysScreen extends ConsumerWidget {
         ),
       ),
     );
+  }
+
+  /// 破損鍵検出モーダル（削除 or 保持を選択）
+  Future<void> _showDamagedKeysDialog(List<SshKeyMeta> damagedKeys) async {
+    if (!mounted) return;
+    final selected = <String>{};
+
+    await showDialog<void>(
+      context: context,
+      builder: (dialogContext) {
+        return StatefulBuilder(
+          builder: (dialogContext, setDialogState) {
+            return AlertDialog(
+              title: const Text('破損した鍵が見つかりました'),
+              content: SizedBox(
+                width: double.maxFinite,
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    const Text(
+                      '秘密鍵を読み出せない鍵があります。削除するか、そのまま残すかを選択してください。',
+                    ),
+                    const SizedBox(height: 12),
+                    Flexible(
+                      child: ListView(
+                        shrinkWrap: true,
+                        children: damagedKeys.map((key) {
+                          return CheckboxListTile(
+                            dense: true,
+                            title: Text(key.name),
+                            subtitle: Text(
+                              '${key.type} · ${_shortFingerprint(key.fingerprint)}',
+                            ),
+                            value: selected.contains(key.id),
+                            onChanged: (checked) {
+                              setDialogState(() {
+                                if (checked == true) {
+                                  selected.add(key.id);
+                                } else {
+                                  selected.remove(key.id);
+                                }
+                              });
+                            },
+                          );
+                        }).toList(),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              actions: [
+                TextButton(
+                  onPressed: () => Navigator.pop(dialogContext),
+                  child: const Text('そのままにする'),
+                ),
+                FilledButton(
+                  onPressed: selected.isEmpty
+                      ? null
+                      : () async {
+                          await _deleteDamagedKeys(selected.toList());
+                          if (dialogContext.mounted) {
+                            Navigator.pop(dialogContext);
+                          }
+                        },
+                  child: const Text('選択した鍵を削除'),
+                ),
+              ],
+            );
+          },
+        );
+      },
+    );
+  }
+
+  /// 選択された破損鍵（メタデータ + 秘密鍵）を削除する
+  Future<void> _deleteDamagedKeys(List<String> keyIds) async {
+    final storage = ref.read(secureStorageProvider);
+    final keysNotifier = ref.read(keysProvider.notifier);
+    try {
+      for (final id in keyIds) {
+        await storage.deletePrivateKey(id);
+        await storage.deletePassphrase(id);
+        await keysNotifier.remove(id);
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('Failed to delete key: $e'),
+            backgroundColor: Theme.of(context).colorScheme.error,
+          ),
+        );
+      }
+    }
+  }
+
+  /// フィンガープリントの先頭を短縮表示する
+  String _shortFingerprint(String? fingerprint) {
+    if (fingerprint == null) return '';
+    return fingerprint.length > 12
+        ? fingerprint.substring(0, 12)
+        : fingerprint;
   }
 }

--- a/lib/screens/keys/widgets/key_tile.dart
+++ b/lib/screens/keys/widgets/key_tile.dart
@@ -35,6 +35,7 @@ class KeyTile extends StatelessWidget {
               ),
               const SizedBox(width: 8),
               _buildSourceBadge(context),
+              if (!keyMeta.isAvailable) ...[const SizedBox(width: 4), _buildUnavailableBadge(context)],
               if (keyMeta.hasPassphrase) ...[
                 const SizedBox(width: 4),
                 Icon(
@@ -133,6 +134,25 @@ class KeyTile extends StatelessWidget {
               color: isGenerated
                   ? Theme.of(context).colorScheme.onPrimaryContainer
                   : Theme.of(context).colorScheme.onSecondaryContainer,
+            ),
+      ),
+    );
+  }
+
+  /// 破損鍵（秘密鍵を読み出せない鍵）のバッジ
+  Widget _buildUnavailableBadge(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 1),
+      decoration: BoxDecoration(
+        color: colorScheme.errorContainer,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Text(
+        '使用不可',
+        style: Theme.of(context).textTheme.labelSmall?.copyWith(
+              fontSize: 9,
+              color: colorScheme.onErrorContainer,
             ),
       ),
     );

--- a/lib/screens/terminal/terminal_screen.dart
+++ b/lib/screens/terminal/terminal_screen.dart
@@ -2376,6 +2376,11 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   Future<SshConnectOptions> _getAuthOptions(Connection connection) async {
     if (connection.authMethod == 'key' && connection.keyId != null) {
       final privateKey = await _secureStorage.getPrivateKey(connection.keyId!);
+      if (privateKey == null) {
+        throw SshAuthenticationError(
+          'Private key is not readable. Please re-import the key.',
+        );
+      }
       final passphrase = await _secureStorage.getPassphrase(connection.keyId!);
       return SshConnectOptions(
         privateKey: privateKey,

--- a/lib/services/keychain/secure_storage.dart
+++ b/lib/services/keychain/secure_storage.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
 /// セキュアストレージサービス
@@ -7,10 +9,19 @@ class SecureStorageService {
   /// テスト用のインメモリストレージ。
   static Map<String, String>? _testValues;
 
+  /// テスト用: 読み取り時に例外（復号不能）を投げるキー一覧。
+  static Set<String>? _testThrowKeys;
+
   /// テスト用のストレージ値をセットする。
   /// null を渡すとテストモードを解除する。
   static void setTestValues(Map<String, String>? values) {
     _testValues = values != null ? Map.of(values) : null;
+  }
+
+  /// テスト用: 読み取り時に例外（PlatformException: 復号不能）を投げるキーを指定する。
+  /// null を渡すと解除する。
+  static void setTestThrowKeys(Set<String>? keys) {
+    _testThrowKeys = keys != null ? Set.of(keys) : null;
   }
 
   SecureStorageService()
@@ -41,8 +52,21 @@ class SecureStorageService {
   }
 
   /// 秘密鍵を取得
+  ///
+  /// 復号不能（Keystore キー欠如など）の場合は例外を捕捉して null を返す。
+  /// それ以外の例外（一時障害・実装エラー）は再スローし、破損と誤判定しない。
   Future<String?> getPrivateKey(String keyId) async {
-    return await _readValue('privatekey_$keyId');
+    try {
+      return await _readValue('privatekey_$keyId');
+    } on PlatformException catch (e) {
+      // Keystore 復号不能（Failed to unwrap key）など → 破損鍵として null 扱い
+      debugPrint('[SecureStorage] getPrivateKey failed for id=$keyId: ${e.code}');
+      return null;
+    } catch (e) {
+      // 一時障害・実装エラーは再スロー（破損と誤判定しない）
+      debugPrint('[SecureStorage] getPrivateKey unexpected error for id=$keyId: $e');
+      rethrow;
+    }
   }
 
   /// 秘密鍵を削除
@@ -95,6 +119,12 @@ class SecureStorageService {
 
   Future<String?> _readValue(String key) async {
     if (_testValues != null) {
+      if (_testThrowKeys?.contains(key) ?? false) {
+        throw PlatformException(
+          code: 'invalid_key',
+          message: 'Failed to unwrap key',
+        );
+      }
       return _testValues![key];
     }
     return await _storage.read(key: key);

--- a/test/config/android_manifest_test.dart
+++ b/test/config/android_manifest_test.dart
@@ -1,0 +1,16 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('AndroidManifest.xml disables backup with allowBackup=false', () {
+    final manifest =
+        File('android/app/src/main/AndroidManifest.xml').readAsStringSync();
+
+    expect(
+      manifest,
+      contains('android:allowBackup="false"'),
+      reason: '鍵データのバックアップ復元（破損鍵の発生）を防ぐため allowBackup="false" が必要',
+    );
+  });
+}

--- a/test/providers/key_provider_test.dart
+++ b/test/providers/key_provider_test.dart
@@ -1,0 +1,164 @@
+import 'dart:convert';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_muxpod/providers/key_provider.dart';
+import 'package:flutter_muxpod/services/keychain/secure_storage.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  group('SshKeyMeta', () {
+    test('defaults isAvailable to true when missing from json', () {
+      final meta = SshKeyMeta.fromJson({
+        'id': 'k1',
+        'name': 'test',
+        'type': 'ed25519',
+        'createdAt': '2026-01-01T00:00:00.000',
+      });
+
+      expect(meta.isAvailable, isTrue);
+    });
+
+    test('reads isAvailable from json', () {
+      final meta = SshKeyMeta.fromJson({
+        'id': 'k1',
+        'name': 'test',
+        'type': 'ed25519',
+        'createdAt': '2026-01-01T00:00:00.000',
+        'isAvailable': false,
+      });
+
+      expect(meta.isAvailable, isFalse);
+    });
+
+    test('round-trips isAvailable through toJson/fromJson', () {
+      final meta = SshKeyMeta(
+        id: 'k1',
+        name: 'test',
+        type: 'ed25519',
+        createdAt: DateTime(2026, 1, 1),
+        isAvailable: false,
+      );
+
+      final restored = SshKeyMeta.fromJson(meta.toJson());
+      expect(restored.isAvailable, isFalse);
+    });
+  });
+
+  group('KeysNotifier', () {
+    setUp(() {
+      SharedPreferences.setMockInitialValues({});
+      SecureStorageService.setTestValues({});
+    });
+
+    test('add sorts keys by createdAt descending (newest first)', () async {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      final notifier = container.read(keysProvider.notifier);
+      // 非同期ロードを明示的に完了させてから操作する
+      await notifier.reload();
+
+      final older = SshKeyMeta(
+        id: 'a',
+        name: 'older',
+        type: 'ed25519',
+        createdAt: DateTime(2026, 1, 1),
+      );
+      final newer = SshKeyMeta(
+        id: 'b',
+        name: 'newer',
+        type: 'ed25519',
+        createdAt: DateTime(2026, 1, 2),
+      );
+
+      // 古い鍵を先に追加 → 新しい鍵を後から追加
+      await notifier.add(older);
+      await notifier.add(newer);
+
+      final keys = container.read(keysProvider).keys;
+      expect(keys.map((k) => k.id).toList(), ['b', 'a'],
+          reason: 'add 直後に createdAt 降順（新しい鍵が先頭）でなければならない');
+    });
+
+    test('marks key as damaged when private key is missing', () async {
+      SharedPreferences.setMockInitialValues({
+        'ssh_keys_meta': jsonEncode([
+          {
+            'id': 'k1',
+            'name': 'damaged-key',
+            'type': 'ed25519',
+            'createdAt': '2026-01-01T00:00:00.000',
+          },
+        ]),
+      });
+      // 秘密鍵が保存されていない → 復号不能（破損鍵）と判定される
+      SecureStorageService.setTestValues({});
+
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      final notifier = container.read(keysProvider.notifier);
+      // 非同期ロードを明示的に完了させてから確認する
+      await notifier.reload();
+
+      final state = container.read(keysProvider);
+      expect(state.keys, hasLength(1));
+      expect(state.keys.single.isAvailable, isFalse);
+      expect(state.damagedKeys, hasLength(1));
+      expect(state.damagedKeys.single.id, 'k1');
+    });
+
+    test('does not mark key as damaged when private key exists', () async {
+      SharedPreferences.setMockInitialValues({
+        'ssh_keys_meta': jsonEncode([
+          {
+            'id': 'k1',
+            'name': 'healthy-key',
+            'type': 'ed25519',
+            'createdAt': '2026-01-01T00:00:00.000',
+          },
+        ]),
+      });
+      SecureStorageService.setTestValues({'privatekey_k1': 'PRIVATE_KEY'});
+
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      final notifier = container.read(keysProvider.notifier);
+      // 非同期ロードを明示的に完了させてから確認する
+      await notifier.reload();
+
+      final state = container.read(keysProvider);
+      expect(state.keys.single.isAvailable, isTrue);
+      expect(state.damagedKeys, isEmpty);
+    });
+
+    test('recovers isAvailable to true when private key becomes readable',
+        () async {
+      // 保存済み JSON に isAvailable=false が残っていても、読み取り成功なら true に戻す
+      SharedPreferences.setMockInitialValues({
+        'ssh_keys_meta': jsonEncode([
+          {
+            'id': 'k1',
+            'name': 'recovered-key',
+            'type': 'ed25519',
+            'createdAt': '2026-01-01T00:00:00.000',
+            'isAvailable': false,
+          },
+        ]),
+      });
+      SecureStorageService.setTestValues({'privatekey_k1': 'PRIVATE_KEY'});
+
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      final notifier = container.read(keysProvider.notifier);
+      await notifier.reload();
+
+      final state = container.read(keysProvider);
+      expect(state.keys.single.isAvailable, isTrue);
+      expect(state.damagedKeys, isEmpty);
+    });
+  });
+}

--- a/test/screens/connections/connection_form_screen_test.dart
+++ b/test/screens/connections/connection_form_screen_test.dart
@@ -360,5 +360,41 @@ void main() {
       );
       expect(find.textContaining('Failed to unwrap key'), findsNothing);
     });
+
+    testWidgets('shows damaged key warning when broken key is selected',
+        (tester) async {
+      SharedPreferences.setMockInitialValues({
+        'ssh_keys_meta': jsonEncode([
+          {
+            'id': 'k1',
+            'name': 'broken-key',
+            'type': 'ed25519',
+            'createdAt': '2026-01-01T00:00:00.000',
+          },
+        ]),
+      });
+      // 秘密鍵なし → 破損キーとして検出される
+      SecureStorageService.setTestValues({});
+
+      await _pumpForm(tester);
+
+      await tester.enterText(find.byType(TextFormField).at(0), 'Test');
+      await tester.enterText(find.byType(TextFormField).at(1), 'host');
+      await tester.enterText(find.byType(TextFormField).at(3), 'user');
+      await tester.pump();
+
+      // 認証方式を Private Key に切り替え
+      await tester.tap(find.text('Private Key'));
+      await tester.pumpAndSettle();
+
+      // 破損キーを選択
+      await tester.tap(find.byType(DropdownButtonFormField<String>));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('broken-key').last);
+      await tester.pumpAndSettle();
+
+      // 破損キー選択中の警告が表示される
+      expect(find.textContaining('破損しています'), findsOneWidget);
+    });
   });
 }

--- a/test/screens/connections/connection_form_screen_test.dart
+++ b/test/screens/connections/connection_form_screen_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -312,6 +314,51 @@ void main() {
       expect(multiplexer.backend, BackendType.tmux);
       expect(multiplexer.executablePath, '/usr/local/bin/tmux');
       expect(harness.client!.disposed, isTrue);
+    });
+
+    testWidgets(
+        'connection test with unreadable key shows re-import error',
+        (tester) async {
+      // 鍵メタデータはあるが秘密鍵が読めない（破損鍵）状態を用意
+      SharedPreferences.setMockInitialValues({
+        'ssh_keys_meta': jsonEncode([
+          {
+            'id': 'k1',
+            'name': 'broken-key',
+            'type': 'ed25519',
+            'createdAt': '2026-01-01T00:00:00.000',
+          },
+        ]),
+      });
+      // 秘密鍵なし → getPrivateKey が null（破損鍵）
+      SecureStorageService.setTestValues({});
+
+      await _pumpForm(tester);
+
+      await tester.enterText(find.byType(TextFormField).at(0), 'Test');
+      await tester.enterText(find.byType(TextFormField).at(1), 'host');
+      await tester.enterText(find.byType(TextFormField).at(3), 'user');
+      await tester.pump();
+
+      // 認証方式を Private Key に切り替え
+      await tester.tap(find.text('Private Key'));      await tester.pumpAndSettle();
+
+      // 鍵を選択（破損鍵）
+      await tester.tap(find.byType(DropdownButtonFormField<String>));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('broken-key').last);
+      await tester.pumpAndSettle();
+
+      // 接続テスト
+      await tester.tap(find.text('TEST CONNECTION'));
+      await tester.pumpAndSettle();
+
+      // 統一エラーが表示される（生の Keystore エラーではなく再インポート案内）
+      expect(
+        find.textContaining('Private key is not readable'),
+        findsOneWidget,
+      );
+      expect(find.textContaining('Failed to unwrap key'), findsNothing);
     });
   });
 }

--- a/test/screens/connections/connections_screen_damaged_key_test.dart
+++ b/test/screens/connections/connections_screen_damaged_key_test.dart
@@ -1,0 +1,159 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:flutter_muxpod/providers/active_session_provider.dart';
+import 'package:flutter_muxpod/providers/connection_provider.dart';
+import 'package:flutter_muxpod/providers/settings_provider.dart';
+import 'package:flutter_muxpod/providers/ssh_provider.dart';
+import 'package:flutter_muxpod/providers/tmux_provider.dart';
+import 'package:flutter_muxpod/screens/connections/connections_screen.dart';
+import 'package:flutter_muxpod/services/backend/multiplexer_config.dart';
+import 'package:flutter_muxpod/services/keychain/secure_storage.dart';
+
+import '../../helpers/fake_settings_notifier.dart';
+import '../../helpers/fake_ssh_client.dart';
+import '../../helpers/fake_ssh_notifier.dart';
+import '../../helpers/fake_tmux_notifier.dart';
+
+class _StaticConnectionsNotifier extends ConnectionsNotifier {
+  _StaticConnectionsNotifier(this.connection);
+
+  final Connection connection;
+
+  @override
+  ConnectionsState build() => ConnectionsState(connections: [connection]);
+}
+
+class _EmptyActiveSessionsNotifier extends ActiveSessionsNotifier {
+  @override
+  ActiveSessionsState build() => const ActiveSessionsState();
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    SecureStorageService.setTestValues(const {});
+    addTearDown(() => SecureStorageService.setTestValues(null));
+  });
+
+  testWidgets(
+      'shows damaged key badge for connection using a broken key',
+      (tester) async {
+    // 鍵メタデータはあるが秘密鍵が読めない（破損鍵）状態を用意
+    SharedPreferences.setMockInitialValues({
+      'ssh_keys_meta': jsonEncode([
+        {
+          'id': 'broken-key-id',
+          'name': 'broken-key',
+          'type': 'ed25519',
+          'createdAt': '2026-01-01T00:00:00.000',
+        },
+      ]),
+    });
+    // 秘密鍵なし → 破損鍵として検出される
+    SecureStorageService.setTestValues(const {});
+
+    final connection = Connection(
+      id: 'conn-1',
+      name: 'Server with broken key',
+      host: '192.168.1.1',
+      username: 'user',
+      authMethod: 'key',
+      keyId: 'broken-key-id',
+      multiplexer: MultiplexerConfig.tmux(),
+      createdAt: DateTime(2026, 1, 1),
+    );
+
+    final client = FakeSshClient();
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          connectionsProvider.overrideWith(
+            () => _StaticConnectionsNotifier(connection),
+          ),
+          activeSessionsProvider.overrideWith(
+            () => _EmptyActiveSessionsNotifier(),
+          ),
+          sshProvider.overrideWith(() => FakeSshNotifier(client: client)),
+          settingsProvider.overrideWith(
+            () => FakeSettingsNotifier(
+              settings: const AppSettings(keepScreenOn: false),
+            ),
+          ),
+          tmuxProvider.overrideWith(
+            () => FakeTmuxNotifier(initialState: const TmuxState()),
+          ),
+        ],
+        child: MaterialApp(
+          home: ConnectionsScreen(sshClientFactory: (_) async => client),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // 破損キー使用中のバッジと警告アイコンが表示される
+    expect(find.text('破損した鍵を使用中'), findsOneWidget);
+    expect(find.byIcon(Icons.warning_amber), findsWidgets);
+  });
+
+  testWidgets('does not show damaged key badge for healthy key connection',
+      (tester) async {
+    SharedPreferences.setMockInitialValues({
+      'ssh_keys_meta': jsonEncode([
+        {
+          'id': 'healthy-key-id',
+          'name': 'healthy-key',
+          'type': 'ed25519',
+          'createdAt': '2026-01-01T00:00:00.000',
+        },
+      ]),
+    });
+    SecureStorageService.setTestValues({'privatekey_healthy-key-id': 'K'});
+
+    final connection = Connection(
+      id: 'conn-1',
+      name: 'Server with healthy key',
+      host: '192.168.1.1',
+      username: 'user',
+      authMethod: 'key',
+      keyId: 'healthy-key-id',
+      multiplexer: MultiplexerConfig.tmux(),
+      createdAt: DateTime(2026, 1, 1),
+    );
+
+    final client = FakeSshClient();
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          connectionsProvider.overrideWith(
+            () => _StaticConnectionsNotifier(connection),
+          ),
+          activeSessionsProvider.overrideWith(
+            () => _EmptyActiveSessionsNotifier(),
+          ),
+          sshProvider.overrideWith(() => FakeSshNotifier(client: client)),
+          settingsProvider.overrideWith(
+            () => FakeSettingsNotifier(
+              settings: const AppSettings(keepScreenOn: false),
+            ),
+          ),
+          tmuxProvider.overrideWith(
+            () => FakeTmuxNotifier(initialState: const TmuxState()),
+          ),
+        ],
+        child: MaterialApp(
+          home: ConnectionsScreen(sshClientFactory: (_) async => client),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('破損した鍵を使用中'), findsNothing);
+  });
+}

--- a/test/screens/dashboard/dashboard_screen_damaged_key_test.dart
+++ b/test/screens/dashboard/dashboard_screen_damaged_key_test.dart
@@ -1,0 +1,101 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:flutter_muxpod/providers/active_session_provider.dart';
+import 'package:flutter_muxpod/providers/connection_provider.dart';
+import 'package:flutter_muxpod/screens/dashboard/dashboard_screen.dart';
+import 'package:flutter_muxpod/services/backend/domain/multiplexer_backend.dart';
+import 'package:flutter_muxpod/services/backend/multiplexer_config.dart';
+import 'package:flutter_muxpod/services/keychain/secure_storage.dart';
+
+class _StaticConnectionsNotifier extends ConnectionsNotifier {
+  _StaticConnectionsNotifier(this.connection);
+
+  final Connection connection;
+
+  @override
+  ConnectionsState build() => ConnectionsState(connections: [connection]);
+}
+
+class _StaticActiveSessionsNotifier extends ActiveSessionsNotifier {
+  _StaticActiveSessionsNotifier(this.session);
+
+  final ActiveSession session;
+
+  @override
+  ActiveSessionsState build() => ActiveSessionsState(sessions: [session]);
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    SecureStorageService.setTestValues(const {});
+    addTearDown(() => SecureStorageService.setTestValues(null));
+  });
+
+  testWidgets('shows damaged key badge for session using a broken key',
+      (tester) async {
+    // 鍵メタデータはあるが秘密鍵が読めない（破損鍵）状態を用意
+    SharedPreferences.setMockInitialValues({
+      'ssh_keys_meta': jsonEncode([
+        {
+          'id': 'broken-key-id',
+          'name': 'broken-key',
+          'type': 'ed25519',
+          'createdAt': '2026-01-01T00:00:00.000',
+        },
+      ]),
+    });
+    // 秘密鍵なし → 破損鍵として検出される
+    SecureStorageService.setTestValues(const {});
+
+    final connection = Connection(
+      id: 'conn-1',
+      name: 'Server with broken key',
+      host: '192.168.1.1',
+      username: 'user',
+      authMethod: 'key',
+      keyId: 'broken-key-id',
+      multiplexer: MultiplexerConfig.tmux(),
+      createdAt: DateTime(2026, 1, 1),
+    );
+
+    final session = ActiveSession(
+      connectionId: 'conn-1',
+      connectionName: 'Server with broken key',
+      host: '192.168.1.1',
+      sessionName: '0',
+      windowCount: 1,
+      connectedAt: DateTime(2026, 1, 1),
+      isAttached: true,
+      backend: MultiplexerBackendKind.tmux,
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          connectionsProvider.overrideWith(
+            () => _StaticConnectionsNotifier(connection),
+          ),
+          activeSessionsProvider.overrideWith(
+            () => _StaticActiveSessionsNotifier(session),
+          ),
+        ],
+        child: const MaterialApp(
+          home: DashboardScreen(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // 破損キー使用中のバッジと警告アイコンが表示される
+    expect(find.text('破損した鍵を使用中'), findsOneWidget);
+    expect(find.byIcon(Icons.warning_amber), findsWidgets);
+  });
+}

--- a/test/screens/keys/keys_screen_test.dart
+++ b/test/screens/keys/keys_screen_test.dart
@@ -1,0 +1,116 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_muxpod/screens/keys/keys_screen.dart';
+import 'package:flutter_muxpod/services/keychain/secure_storage.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    SecureStorageService.setTestValues({});
+  });
+
+  Future<void> pumpKeysScreen(WidgetTester tester) async {
+    await tester.pumpWidget(
+      const ProviderScope(
+        child: MaterialApp(home: KeysScreen()),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('shows damaged keys dialog when a damaged key exists',
+      (tester) async {
+    SharedPreferences.setMockInitialValues({
+      'ssh_keys_meta': jsonEncode([
+        {
+          'id': 'k1',
+          'name': 'damaged-key',
+          'type': 'ed25519',
+          'createdAt': '2026-01-01T00:00:00.000',
+        },
+      ]),
+    });
+    // 秘密鍵が保存されていない → 破損鍵として検出される
+    SecureStorageService.setTestValues({});
+
+    await pumpKeysScreen(tester);
+
+    expect(find.text('破損した鍵が見つかりました'), findsOneWidget);
+    expect(find.text('damaged-key'), findsWidgets);
+  });
+
+  testWidgets('does not show damaged keys dialog when all keys are healthy',
+      (tester) async {
+    SharedPreferences.setMockInitialValues({
+      'ssh_keys_meta': jsonEncode([
+        {
+          'id': 'k1',
+          'name': 'healthy-key',
+          'type': 'ed25519',
+          'createdAt': '2026-01-01T00:00:00.000',
+        },
+      ]),
+    });
+    SecureStorageService.setTestValues({'privatekey_k1': 'PRIVATE_KEY'});
+
+    await pumpKeysScreen(tester);
+
+    expect(find.text('破損した鍵が見つかりました'), findsNothing);
+  });
+
+  testWidgets('deleting a damaged key from the dialog removes it',
+      (tester) async {
+    SharedPreferences.setMockInitialValues({
+      'ssh_keys_meta': jsonEncode([
+        {
+          'id': 'k1',
+          'name': 'damaged-key',
+          'type': 'ed25519',
+          'createdAt': '2026-01-01T00:00:00.000',
+        },
+      ]),
+    });
+    SecureStorageService.setTestValues({});
+
+    await pumpKeysScreen(tester);
+
+    // 破損鍵を選択して削除
+    await tester.tap(find.byType(CheckboxListTile));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('選択した鍵を削除'));
+    await tester.pumpAndSettle();
+
+    // モーダルが閉じ、一覧から削除される
+    expect(find.text('破損した鍵が見つかりました'), findsNothing);
+    expect(find.text('damaged-key'), findsNothing);
+    expect(SecureStorageService().getPrivateKey('k1'), completion(isNull));
+  });
+
+  testWidgets('keeping a damaged key from the dialog leaves it in the list',
+      (tester) async {
+    SharedPreferences.setMockInitialValues({
+      'ssh_keys_meta': jsonEncode([
+        {
+          'id': 'k1',
+          'name': 'damaged-key',
+          'type': 'ed25519',
+          'createdAt': '2026-01-01T00:00:00.000',
+        },
+      ]),
+    });
+    SecureStorageService.setTestValues({});
+
+    await pumpKeysScreen(tester);
+
+    // そのままにする → モーダルが閉じ、鍵は一覧に残る
+    await tester.tap(find.text('そのままにする'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('破損した鍵が見つかりました'), findsNothing);
+    expect(find.text('damaged-key'), findsWidgets);
+  });
+}

--- a/test/services/keychain/secure_storage_test.dart
+++ b/test/services/keychain/secure_storage_test.dart
@@ -1,0 +1,43 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_muxpod/services/keychain/secure_storage.dart';
+
+void main() {
+  tearDown(() {
+    SecureStorageService.setTestValues(null);
+    SecureStorageService.setTestThrowKeys(null);
+  });
+
+  group('SecureStorageService.getPrivateKey', () {
+    test('returns null when key is not stored', () async {
+      SecureStorageService.setTestValues({});
+      final storage = SecureStorageService();
+
+      expect(await storage.getPrivateKey('missing-id'), isNull);
+    });
+
+    test('returns stored private key', () async {
+      SecureStorageService.setTestValues({'privatekey_k1': 'PRIVATE_KEY'});
+      final storage = SecureStorageService();
+
+      expect(await storage.getPrivateKey('k1'), 'PRIVATE_KEY');
+    });
+
+    test('returns null when read throws PlatformException (unreadable key)',
+        () async {
+      // 復号不能（Keystore キー欠如）をシミュレート
+      SecureStorageService.setTestValues({'privatekey_k1': 'X'});
+      SecureStorageService.setTestThrowKeys({'privatekey_k1'});
+      final storage = SecureStorageService();
+
+      expect(await storage.getPrivateKey('k1'), isNull);
+    });
+
+    test('returns stored key when not in throw keys', () async {
+      SecureStorageService.setTestValues({'privatekey_k1': 'PRIVATE_KEY'});
+      SecureStorageService.setTestThrowKeys({'privatekey_other'});
+      final storage = SecureStorageService();
+
+      expect(await storage.getPrivateKey('k1'), 'PRIVATE_KEY');
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Detect SSH keys whose private key can no longer be decrypted (e.g. Android Keystore loss after a backup restore) and treat them as "damaged keys" instead of failing with raw `PlatformException`s
- Surface damaged-key warnings across the UI: badges/icons on connection cards, dashboard session cards and key tiles, a warning banner in the connection form, and a one-time dialog on the Keys screen offering delete-or-keep
- Disable Android auto-backup (`allowBackup="false"`) so encrypted key material can no longer be restored into an undecryptable state

Relates to #69.

## How this addresses #69
Issue #69 reported that after uninstall/reinstall, "Generate" silently handed back a byte-identical key restored by Android Auto Backup, with no way to tell a fresh key from a restored one. The issue suggested three possible fixes; this PR covers them as follows:

| #69 suggestion | This PR |
|---|---|
| Exclude key storage from Auto Backup (`allowBackup="false"` or `dataExtractionRules`) | **Done.** `android:allowBackup="false"` is now set in the manifest (guarded by a test), so key material will no longer be restored via Auto Backup on reinstall |
| If an existing/restored key is detected, say so in the UI instead of presenting it the same as a fresh one | **Done for unreadable keys.** Keys whose private key cannot be read are detected on load (`isAvailable=false`) and surfaced everywhere: an "unavailable" badge on key tiles, warning icons/badges on connection cards and dashboard session cards, a warning banner in the connection form, and a one-time delete-or-keep dialog on the Keys screen. Connecting with such a key now shows re-import guidance instead of a raw Keystore error |
| Always generate a genuinely new key no matter what's already in storage | **Not addressed here.** A restored key that is still readable would remain indistinguishable from a fresh one. With `allowBackup="false"`, future reinstalls should no longer restore old key material, but this PR does not change Generate's behavior itself |

## Changes
- `android/app/src/main/AndroidManifest.xml`: set `android:allowBackup="false"` to prevent broken key restoration via backup
- `lib/services/keychain/secure_storage.dart`: `getPrivateKey()` now catches decryption `PlatformException`s and returns `null` (damaged); unexpected errors are rethrown to avoid false positives. Added test hooks to simulate unreadable keys
- `lib/providers/key_provider.dart`: added `SshKeyMeta.isAvailable` and `KeysState.damagedKeys`; availability is re-checked on every load (so a key recovers when it becomes readable again); load is guarded against use-after-dispose and stale generations; keys are sorted by `createdAt` on add/save; added `isKeyDamaged()` helper
- `lib/screens/keys/keys_screen.dart` + `widgets/key_tile.dart`: damaged-key dialog (select and delete, or keep) shown once per session, and an "unavailable" badge on damaged key tiles
- `lib/screens/connections/connection_form_screen.dart`: warning icon next to damaged keys in the key dropdown, damaged-key warning banner when a broken key is selected, and a clear re-import error on connection test
- `lib/screens/connections/connections_screen.dart` / `dashboard/dashboard_screen.dart`: "damaged key in use" badge and warning icon on connection cards and session history cards
- `lib/screens/home_screen.dart` / `terminal/terminal_screen.dart`: fail fast with `Private key is not readable. Please re-import the key.` when a stored key is unreadable
- Tests: added/extended tests for the key provider, secure storage, Keys screen dialog, connection form, connections screen and dashboard badges, plus a manifest test asserting `allowBackup="false"`

## Test plan
- [ ] `make analyze` (flutter analyze) passes
- [ ] `make test` (flutter test) passes
- [ ] Manual: import a key, remove its secure-storage entry to simulate damage, relaunch and verify the Keys screen dialog offers delete/keep
- [ ] Manual: connect with a damaged key and verify the re-import guidance appears instead of a raw Keystore error