### PR TITLE
fix: source Ed25519 checkint from OS CSPRNG instead of wall clock

### DIFF
--- a/lib/services/keychain/ssh_key_service.dart
+++ b/lib/services/keychain/ssh_key_service.dart
@@ -288,7 +288,10 @@ class SshKeyService {
     // private key section
     final privateSection = BytesBuilder();
     // checkint (random, same twice)
-    final checkInt = DateTime.now().millisecondsSinceEpoch & 0xffffffff;
+    // OpenSSH仕様ではcheckintは乱数と規定されている。旧実装は壁時計由来
+    // (DateTime.now)だったため、Issue #68と同じ乱数欠陥パターンだった。
+    // OSのCSPRNGから32bit値を取る(nextInt(2^32)は0..2^32-1を返す)。
+    final checkInt = Random.secure().nextInt(0x100000000);
     privateSection.add(_encodeUint32(checkInt));
     privateSection.add(_encodeUint32(checkInt));
     // keytype

--- a/test/services/keychain/ssh_key_service_test.dart
+++ b/test/services/keychain/ssh_key_service_test.dart
@@ -1,3 +1,6 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_muxpod/services/keychain/ssh_key_service.dart';
 
@@ -37,6 +40,58 @@ void main() {
 
       expect(keyPair1.fingerprint, isNot(equals(keyPair2.fingerprint)));
       expect(keyPair1.privateKeyBytes, isNot(equals(keyPair2.privateKeyBytes)));
+    });
+
+    test('checkint is random, not clock-derived', () async {
+      // OpenSSH秘密鍵形式をデコードしてcheckint(同一PEM内に2回出現)を抽出する
+      (int, int) extractCheckints(String pem) {
+        final b64 = pem
+            .replaceAll('-----BEGIN OPENSSH PRIVATE KEY-----', '')
+            .replaceAll('-----END OPENSSH PRIVATE KEY-----', '')
+            .replaceAll('\n', '')
+            .trim();
+        final bytes = base64Decode(b64);
+        var offset = 0;
+
+        int readUint32() {
+          final v =
+              (bytes[offset] << 24) |
+              (bytes[offset + 1] << 16) |
+              (bytes[offset + 2] << 8) |
+              bytes[offset + 3];
+          offset += 4;
+          return v;
+        }
+
+        Uint8List readString() {
+          final len = readUint32();
+          final s = bytes.sublist(offset, offset + len);
+          offset += len;
+          return s;
+        }
+
+        offset += 'openssh-key-v1'.length + 1; // AUTH_MAGIC + NUL終端
+        readString(); // ciphername
+        readString(); // kdfname
+        readString(); // kdfoptions
+        readUint32(); // number of keys
+        readString(); // public key blob
+        readUint32(); // private section length
+        return (readUint32(), readUint32()); // (checkint1, checkint2)
+      }
+
+      final keyPair1 = await service.generateEd25519();
+      final keyPair2 = await service.generateEd25519();
+
+      final (check1a, check1b) = extractCheckints(keyPair1.privatePem);
+      final (check2a, check2b) = extractCheckints(keyPair2.privatePem);
+
+      // 同一PEM内の2つのcheckintは一致する(整合性チェック用ペア)
+      expect(check1a, equals(check1b));
+      expect(check2a, equals(check2b));
+      // 連続生成でもcheckintは異なる(乱数由来)。
+      // 旧実装は壁時計由来のため同一ミリ秒内の連続生成で同一値になった
+      expect(check1a, isNot(equals(check2a)));
     });
   });
 


### PR DESCRIPTION
## Summary
- The OpenSSH private key format specifies the `checkint` as a random value, but `_buildEd25519Pem` derived it from `DateTime.now().millisecondsSinceEpoch` — the same weak-entropy pattern that affected RSA key generation (Issue #68, RSA side fixed in b88e0e0).
- Source the 32-bit checkint from `Random.secure()` (OS CSPRNG), matching the RSA seeding fix.

## Changes
- `lib/services/keychain/ssh_key_service.dart`: replace the wall-clock-derived checkint with `Random.secure().nextInt(0x100000000)`, plus a comment documenting the rationale.
- `test/services/keychain/ssh_key_service_test.dart`: add a regression test that decodes the OpenSSH private key section and asserts (1) the checkint pair within one PEM is self-consistent, and (2) consecutive generations produce different checkints (the old implementation produced identical values within the same millisecond).

## Test plan
- [x] `flutter analyze` — no issues
- [x] `flutter test test/services/keychain/ssh_key_service_test.dart` — all 25 tests pass, including the new `checkint is random, not clock-derived`
- [x] Verified the 3 failing tests in `test/repro/repro_ssh_hostkey_fingerprint_test.dart` also fail on unmodified `main` (pre-existing, unrelated to this change)
- [ ] Manual: generate an Ed25519 key in-app and confirm it still parses / connects

Refs #68 (RSA side already fixed; this applies the same CSPRNG sourcing to the Ed25519 checkint)