### PR TITLE
fix: terminal caret row/column drift (Issue #70)

### DIFF
--- a/lib/screens/terminal/widgets/ansi_text_view.dart
+++ b/lib/screens/terminal/widgets/ansi_text_view.dart
@@ -772,34 +772,19 @@ class AnsiTextViewState extends ConsumerState<AnsiTextView> {
               cursorLineIndex = widget.cursorY;
             }
 
-            // 現在の行がカーソル位置と一致する場合、Stackでカーソルを重ねる
+            // カーソル行: キャレットをStack+Positionedで「合成」せず、
+            // テキストレイアウト内の正確な位置に直接挿入する（Issue #70 根本対応）。
+            // キャレットはゼロ幅インライン要素として文字境界に置かれ、
+            // テキストエンジンが決定する描画位置にそのまま乗る。
             if (index == cursorLineIndex &&
                 widget.mode == TerminalMode.normal &&
                 settings.showTerminalCursor) {
-              // TextPainter.getOffsetForCaretを使用して、レンダリングエンジンが計算した正確なカーソル位置を取得
-              double cursorLeft;
-              double charWidth;
-
-              // 行全体のテキストとスタイルを使用してTextPainterを作成
-              final textSpanFull = _parser.lineToTextSpan(
-                line,
-                fontSize: fontSize,
-                fontFamily: settings.fontFamily,
-              );
-
-              final painter = TextPainter(
-                text: textSpanFull,
-                textDirection: TextDirection.ltr,
-                textScaler: TextScaler.noScaling,
-              )..layout();
-
               // 行のプレーンテキストを取得
               final lineText = line.segments.map((s) => s.text).join();
-              final lineTextLength = lineText.length;
 
               // 全角文字を考慮してカラム位置を文字オフセットに変換
               // tmuxのcursor_xはカラム位置（全角=2）だが、
-              // TextPositionは文字オフセット（全角=1）を期待する
+              // テキスト内位置は文字オフセット（全角=1）で扱う
               final lineDisplayWidth = FontCalculator.getTextDisplayWidth(
                 lineText,
               );
@@ -808,63 +793,30 @@ class AnsiTextViewState extends ConsumerState<AnsiTextView> {
                 widget.cursorX,
               );
 
-              if (widget.cursorX <= lineDisplayWidth) {
-                // カーソルが行内にある場合、getOffsetForCaretで位置を取得
-                final offset = painter.getOffsetForCaret(
-                  TextPosition(offset: charOffset),
-                  Rect.zero,
-                );
-                cursorLeft = offset.dx;
+              // キャレットが行テキスト終端より先にある場合（空行や行末以降）の埋めセル数
+              final padColumns = widget.cursorX > lineDisplayWidth
+                  ? widget.cursorX - lineDisplayWidth
+                  : 0;
 
-                // カーソル幅も現在の文字の位置から取得（次の文字までの幅）
-                // 行末の場合は標準幅を使用
-                if (charOffset < lineTextLength) {
-                  final nextOffset = painter.getOffsetForCaret(
-                    TextPosition(offset: charOffset + 1),
-                    Rect.zero,
+              lineWidget = ValueListenableBuilder<bool>(
+                valueListenable: _caretVisible,
+                builder: (context, visible, _) {
+                  return Text.rich(
+                    _parser.lineToTextSpanWithCaret(
+                      line,
+                      fontSize: fontSize,
+                      fontFamily: settings.fontFamily,
+                      caretCharOffset: charOffset,
+                      padColumns: padColumns,
+                      caret: visible ? _buildCaretSpan(fontSize) : null,
+                    ),
+                    style: baseTextStyle,
+                    textScaler: TextScaler.noScaling,
+                    maxLines: 1,
+                    softWrap: false,
+                    overflow: TextOverflow.visible,
                   );
-                  charWidth = nextOffset.dx - offset.dx;
-                } else {
-                  charWidth = FontCalculator.measureCharWidth(
-                    settings.fontFamily,
-                    fontSize,
-                  );
-                }
-              } else {
-                // カーソルが行末より先にある場合（空行や行末以降のスペース）
-                // 行末の位置を取得し、超過分を加算
-                cursorLeft = painter.width;
-                charWidth = FontCalculator.measureCharWidth(
-                  settings.fontFamily,
-                  fontSize,
-                );
-                cursorLeft += (widget.cursorX - lineDisplayWidth) * charWidth;
-              }
-
-              lineWidget = Stack(
-                clipBehavior: Clip.none,
-                children: [
-                  lineWidget,
-                  ValueListenableBuilder<bool>(
-                    valueListenable: _caretVisible,
-                    builder: (context, visible, child) {
-                      if (!visible) {
-                        return const SizedBox.shrink();
-                      }
-                      // キャレットの高さを文字サイズに合わせる（行間を含めない）
-                      final caretHeight = fontSize;
-                      // 行内で垂直方向に中央寄せ
-                      final caretTop = (_lineHeight - caretHeight) / 2;
-                      return Positioned(
-                        left: cursorLeft,
-                        top: caretTop,
-                        width: 2,
-                        height: caretHeight,
-                        child: Container(color: DesignColors.primary),
-                      );
-                    },
-                  ),
-                ],
+                },
               );
             }
 
@@ -953,6 +905,31 @@ class AnsiTextViewState extends ConsumerState<AnsiTextView> {
           ),
         );
       },
+    );
+  }
+
+  /// キャレット（細い縦バー）のインライン要素を構築する。
+  ///
+  /// ゼロ幅のプレースホルダ（[WidgetSpan]）としてテキスト内の正確な文字境界に
+  /// 挿入され、[OverflowBox] で次の文字に重ねて描画する。テキスト幅を一切
+  /// 変えないため、以降の文字の描画位置はターミナル格子のまま保たれる。
+  WidgetSpan _buildCaretSpan(double fontSize) {
+    return WidgetSpan(
+      alignment: PlaceholderAlignment.middle,
+      child: SizedBox(
+        width: 0,
+        height: 0,
+        child: OverflowBox(
+          maxWidth: 2,
+          maxHeight: fontSize,
+          alignment: Alignment.center,
+          child: SizedBox(
+            width: 2,
+            height: fontSize,
+            child: const ColoredBox(color: DesignColors.primary),
+          ),
+        ),
+      ),
     );
   }
 

--- a/lib/services/terminal/ansi_parser.dart
+++ b/lib/services/terminal/ansi_parser.dart
@@ -385,47 +385,57 @@ class AnsiParser {
     required String fontFamily,
   }) {
     return TextSpan(
-      children: segments.map((segment) {
-        final style = segment.style;
-        var fg = style.foreground ?? defaultForeground;
-        var bg = style.background ?? defaultBackground;
+      children: segments
+          .map(
+            (segment) =>
+                _segmentToTextSpan(segment, fontSize: fontSize, fontFamily: fontFamily),
+          )
+          .toList(),
+    );
+  }
 
-        // 反転
-        if (style.inverse) {
-          final temp = fg;
-          fg = bg;
-          bg = temp;
-        }
+  /// 1セグメントを描画スタイル適用済みのTextSpanに変換
+  TextSpan _segmentToTextSpan(
+    AnsiSegment segment, {
+    required double fontSize,
+    required String fontFamily,
+  }) {
+    final style = segment.style;
+    var fg = style.foreground ?? defaultForeground;
+    var bg = style.background ?? defaultBackground;
 
-        // 薄暗い
-        if (style.dim) {
-          fg = fg.withValues(alpha: 0.5);
-        }
+    // 反転
+    if (style.inverse) {
+      final temp = fg;
+      fg = bg;
+      bg = temp;
+    }
 
-        // 反転時のスペースは背景色が描画されないことがあるため、No-Break Spaceに置換
-        String text = segment.text;
-        if (style.inverse) {
-          text = text.replaceAll(' ', '\u00A0');
-        }
+    // 薄暗い
+    if (style.dim) {
+      fg = fg.withValues(alpha: 0.5);
+    }
 
-        return TextSpan(
-          text: text,
-          style: TerminalFontStyles.getTextStyle(
-            fontFamily,
-            fontSize: fontSize,
-            color: fg,
-            backgroundColor: (style.inverse || bg != defaultBackground)
-                ? bg
-                : null,
-            fontWeight: style.bold ? FontWeight.bold : FontWeight.normal,
-            fontStyle: style.italic ? FontStyle.italic : FontStyle.normal,
-            decoration: TextDecoration.combine([
-              if (style.underline) TextDecoration.underline,
-              if (style.strikethrough) TextDecoration.lineThrough,
-            ]),
-          ),
-        );
-      }).toList(),
+    // 反転時のスペースは背景色が描画されないことがあるため、No-Break Spaceに置換
+    String text = segment.text;
+    if (style.inverse) {
+      text = text.replaceAll(' ', '\u00A0');
+    }
+
+    return TextSpan(
+      text: text,
+      style: TerminalFontStyles.getTextStyle(
+        fontFamily,
+        fontSize: fontSize,
+        color: fg,
+        backgroundColor: (style.inverse || bg != defaultBackground) ? bg : null,
+        fontWeight: style.bold ? FontWeight.bold : FontWeight.normal,
+        fontStyle: style.italic ? FontStyle.italic : FontStyle.normal,
+        decoration: TextDecoration.combine([
+          if (style.underline) TextDecoration.underline,
+          if (style.strikethrough) TextDecoration.lineThrough,
+        ]),
+      ),
     );
   }
 
@@ -525,5 +535,82 @@ class AnsiParser {
     );
     _spanCache[line] = _LineSpan(span, fontSize, fontFamily);
     return span;
+  }
+
+  /// キャレット（任意のインライン要素）を指定文字位置に直接挿入した行スパンを構築する。
+  ///
+  /// テキストレイアウト中の正確な位置にキャレットを「合成（Stack+Positioned）」
+  /// せず直接埋め込むための API（Issue #70 根本対応）。
+  ///
+  /// - [caretCharOffset]: キャレットを挿入するコードユニットオフセット。
+  ///   セグメント境界・行末・空行のいずれでもよい（クランプされる）。
+  /// - [padColumns]: 行テキスト終端よりさらに右のカラムにキャレットを置く場合の
+  ///   埋めセル数（No-Break Space で埋める）。
+  /// - [caret]: 挿入するインライン要素。null の場合はキャッシュ済みの通常行スパンを返す。
+  TextSpan lineToTextSpanWithCaret(
+    ParsedLine line, {
+    required double fontSize,
+    required String fontFamily,
+    required int caretCharOffset,
+    required int padColumns,
+    InlineSpan? caret,
+  }) {
+    if (caret == null) {
+      return lineToTextSpan(
+        line,
+        fontSize: fontSize,
+        fontFamily: fontFamily,
+      );
+    }
+
+    final spans = <InlineSpan>[];
+    var consumed = 0;
+    var inserted = false;
+
+    for (final segment in line.segments) {
+      final segLen = segment.text.length;
+      if (!inserted && caretCharOffset <= consumed + segLen) {
+        final local = (caretCharOffset - consumed).clamp(0, segLen);
+        if (local > 0) {
+          spans.add(
+            _segmentToTextSpan(
+              AnsiSegment(segment.text.substring(0, local), segment.style),
+              fontSize: fontSize,
+              fontFamily: fontFamily,
+            ),
+          );
+        }
+        spans.add(caret);
+        if (local < segLen) {
+          spans.add(
+            _segmentToTextSpan(
+              AnsiSegment(segment.text.substring(local), segment.style),
+              fontSize: fontSize,
+              fontFamily: fontFamily,
+            ),
+          );
+        }
+        inserted = true;
+      } else {
+        spans.add(
+          _segmentToTextSpan(
+            segment,
+            fontSize: fontSize,
+            fontFamily: fontFamily,
+          ),
+        );
+      }
+      consumed += segLen;
+    }
+
+    if (!inserted) {
+      // キャレットが行テキスト終端より先にある場合: 埋めセルで位置を再現してから挿入
+      if (padColumns > 0) {
+        spans.add(TextSpan(text: '\u00A0' * padColumns));
+      }
+      spans.add(caret);
+    }
+
+    return TextSpan(children: spans);
   }
 }

--- a/lib/services/terminal/ansi_parser.dart
+++ b/lib/services/terminal/ansi_parser.dart
@@ -387,8 +387,11 @@ class AnsiParser {
     return TextSpan(
       children: segments
           .map(
-            (segment) =>
-                _segmentToTextSpan(segment, fontSize: fontSize, fontFamily: fontFamily),
+            (segment) => _segmentToTextSpan(
+              segment,
+              fontSize: fontSize,
+              fontFamily: fontFamily,
+            ),
           )
           .toList(),
     );
@@ -556,11 +559,7 @@ class AnsiParser {
     InlineSpan? caret,
   }) {
     if (caret == null) {
-      return lineToTextSpan(
-        line,
-        fontSize: fontSize,
-        fontFamily: fontFamily,
-      );
+      return lineToTextSpan(line, fontSize: fontSize, fontFamily: fontFamily);
     }
 
     final spans = <InlineSpan>[];

--- a/lib/services/tmux/tmux_facade.dart
+++ b/lib/services/tmux/tmux_facade.dart
@@ -5,6 +5,7 @@
 library;
 
 import 'dart:async';
+import 'dart:math';
 
 import '../../l10n/app_localizations.dart';
 import '../../l10n/l10n_lookup.dart';
@@ -21,6 +22,17 @@ export 'ssh_tmux_command_executor.dart';
 // inventory: TMUX-FACADE-001
 final TmuxContract tmuxFacade = TmuxFacade();
 
+/// pollPane セクション区切りマーカーのパターン。
+/// コマンド埋め込み時はランダムIDだが、パース側はパターン一致で抽出する
+/// （テストfixtureは任意のIDでマーカーを構築できる）。
+final RegExp _pollSeparatorPattern = RegExp(
+  r'\x01###POLL_[0-9a-f]+###\x01',
+);
+
+/// pollPane のテスト・本番共通ヘルパ: 区切りマーカー文字列（バイト列版）。
+/// [id] には16進文字列を渡す。
+String tmuxPollSeparator(String id) => '\x01###POLL_$id###\x01';
+
 // inventory: TMUX-FACADE-002
 class TmuxFacade implements TmuxContract {
   /// 任意のローカライズ文字列。null の場合は英語フォールバック（テスト互換）。
@@ -28,6 +40,13 @@ class TmuxFacade implements TmuxContract {
   final AppLocalizations? _l10n;
 
   TmuxFacade({AppLocalizations? l10n}) : _l10n = l10n;
+
+  /// pollPane 用マーカーID（呼び出しごとにランダム生成）。
+  static String _generatePollMarkerId() {
+    final rng = Random.secure();
+    final bytes = List<int>.generate(8, (_) => rng.nextInt(256));
+    return bytes.map((b) => b.toRadixString(16).padLeft(2, '0')).join();
+  }
 
   @override
   List<TmuxSession> parseSessions(String output) =>
@@ -369,10 +388,24 @@ class TmuxFacade implements TmuxContract {
     required String target,
     int historyLines = -120,
   }) async {
+    // セクション区切りマーカー（ランダムID入り）でコンテンツ/カーソル/モードを
+    // 正確に区分けする。改行の数で逆から切る方式は、capture-pane 出力の最終行が
+    // 空行のときにその改行が「カーソル行との区切り」として消費され、最終空行が
+    // ドロップしてキャレット位置が1行上にズレる（Issue #70 のデータ層の原因）。
+    // マーカーは \x01（SOH）で挟み、PersistentShell と同じくシェルのエコーバック
+    // （リテラル `\x01` 4文字）と実出力（バイト 0x01）を区別できるようにする。
+    final markerId = _generatePollMarkerId();
+    final printfSep = r'\x01###POLL_'
+        '$markerId'
+        r'###\x01';
     final combined =
+        "printf '$printfSep\\n'; "
         '${TmuxCommands.capturePane(target, escapeSequences: true, startLine: historyLines)}; '
+        "printf '$printfSep'; "
         '${TmuxCommands.getCursorPosition(target)}; '
-        '${TmuxCommands.getPaneMode(target)}';
+        "printf '$printfSep'; "
+        '${TmuxCommands.getPaneMode(target)}; '
+        "printf '$printfSep'";
     final result = await executor.execute(
       CommandRequest(
         command: combined,
@@ -382,12 +415,41 @@ class TmuxFacade implements TmuxContract {
     );
     final output = result.primaryOutput;
 
-    final modeCut = output.lastIndexOf('\n');
-    final paneModeOutput = modeCut >= 0 ? output.substring(modeCut + 1) : '';
-    final beforeMode = modeCut >= 0 ? output.substring(0, modeCut) : '';
-    final curCut = beforeMode.lastIndexOf('\n');
-    final cursorOutput = curCut >= 0 ? beforeMode.substring(curCut + 1) : '';
-    final contentOutput = curCut >= 0 ? beforeMode.substring(0, curCut) : '';
+    String contentOutput;
+    String cursorOutput;
+    String paneModeOutput;
+
+    // 出力中の区切りマーカーをパターンマッチで抽出（IDは呼び出しごとにランダム）。
+    final sepMatches = _pollSeparatorPattern.allMatches(output).toList();
+    if (sepMatches.length >= 3) {
+      // マーカー区切り: [\n+capture] [cursor\n] [mode\n]
+      // - コンテンツ: 先頭の printf 由来の \n を1つだけ除去し、末尾の capture 最終行の
+      //   改行を1つだけ除去する（split の空要素アーティファクト対策。空行は保持される）
+      // - cursor/mode: 各セクション末尾の改行を除去
+      var capture = output.substring(
+        sepMatches[0].end,
+        sepMatches[1].start,
+      );
+      if (capture.startsWith('\n')) capture = capture.substring(1);
+      if (capture.endsWith('\n')) {
+        capture = capture.substring(0, capture.length - 1);
+      }
+      contentOutput = capture;
+      cursorOutput = output
+          .substring(sepMatches[1].end, sepMatches[2].start)
+          .trimRight();
+      var mode = output.substring(sepMatches[2].end, sepMatches[3].start);
+      if (mode.startsWith('\n')) mode = mode.substring(1);
+      paneModeOutput = mode;
+    } else {
+      // フォールバック（テストfixture等の非マーカー出力）: 従来の逆方向切割り。
+      final modeCut = output.lastIndexOf('\n');
+      paneModeOutput = modeCut >= 0 ? output.substring(modeCut + 1) : '';
+      final beforeMode = modeCut >= 0 ? output.substring(0, modeCut) : '';
+      final curCut = beforeMode.lastIndexOf('\n');
+      cursorOutput = curCut >= 0 ? beforeMode.substring(curCut + 1) : '';
+      contentOutput = curCut >= 0 ? beforeMode.substring(0, curCut) : '';
+    }
 
     var cursorX = 0, cursorY = 0, paneWidth = 0, paneHeight = 0;
     final cursorTrimmed = cursorOutput.trim();
@@ -400,11 +462,8 @@ class TmuxFacade implements TmuxContract {
         paneHeight = int.tryParse(parts[3]) ?? 0;
       }
     }
-    final processedContent = contentOutput.endsWith('\n')
-        ? contentOutput.substring(0, contentOutput.length - 1)
-        : contentOutput;
     final content = TmuxParser.parsePaneContent(
-      processedContent,
+      contentOutput,
       width: paneWidth,
       height: paneHeight,
       stripTrailingEmptyLines: false,

--- a/lib/services/tmux/tmux_facade.dart
+++ b/lib/services/tmux/tmux_facade.dart
@@ -25,9 +25,7 @@ final TmuxContract tmuxFacade = TmuxFacade();
 /// pollPane セクション区切りマーカーのパターン。
 /// コマンド埋め込み時はランダムIDだが、パース側はパターン一致で抽出する
 /// （テストfixtureは任意のIDでマーカーを構築できる）。
-final RegExp _pollSeparatorPattern = RegExp(
-  r'\x01###POLL_[0-9a-f]+###\x01',
-);
+final RegExp _pollSeparatorPattern = RegExp(r'\x01###POLL_[0-9a-f]+###\x01');
 
 /// pollPane のテスト・本番共通ヘルパ: 区切りマーカー文字列（バイト列版）。
 /// [id] には16進文字列を渡す。
@@ -395,7 +393,8 @@ class TmuxFacade implements TmuxContract {
     // マーカーは \x01（SOH）で挟み、PersistentShell と同じくシェルのエコーバック
     // （リテラル `\x01` 4文字）と実出力（バイト 0x01）を区別できるようにする。
     final markerId = _generatePollMarkerId();
-    final printfSep = r'\x01###POLL_'
+    final printfSep =
+        r'\x01###POLL_'
         '$markerId'
         r'###\x01';
     final combined =
@@ -426,10 +425,7 @@ class TmuxFacade implements TmuxContract {
       // - コンテンツ: 先頭の printf 由来の \n を1つだけ除去し、末尾の capture 最終行の
       //   改行を1つだけ除去する（split の空要素アーティファクト対策。空行は保持される）
       // - cursor/mode: 各セクション末尾の改行を除去
-      var capture = output.substring(
-        sepMatches[0].end,
-        sepMatches[1].start,
-      );
+      var capture = output.substring(sepMatches[0].end, sepMatches[1].start);
       if (capture.startsWith('\n')) capture = capture.substring(1);
       if (capture.endsWith('\n')) {
         capture = capture.substring(0, capture.length - 1);

--- a/test/screens/terminal/ansi_text_view_test.dart
+++ b/test/screens/terminal/ansi_text_view_test.dart
@@ -4,6 +4,9 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_muxpod/providers/settings_provider.dart';
 import 'package:flutter_muxpod/providers/terminal_display_provider.dart';
 import 'package:flutter_muxpod/screens/terminal/widgets/ansi_text_view.dart';
+import 'package:flutter_muxpod/services/terminal/font_calculator.dart';
+import 'package:flutter_muxpod/services/terminal/terminal_font_styles.dart';
+import 'package:flutter_muxpod/theme/design_colors.dart';
 
 import '../../helpers/fake_settings_notifier.dart';
 
@@ -195,5 +198,158 @@ void main() {
     final listView = tester.widget<ListView>(find.byType(ListView));
     final padding = (listView.padding as EdgeInsets).top;
     expect(padding, 0.0);
+  });
+
+  // ===== Issue #70: キャレットのテキストレイアウト直接挿入（合成廃止） =====
+
+  Widget buildCaretSubject(
+    String text, {
+    int cursorX = 0,
+    int cursorY = 0,
+    int paneHeight = 3,
+  }) {
+    return ProviderScope(
+      overrides: [
+        settingsProvider.overrideWith(
+          () => FakeSettingsNotifier(
+            settings: const AppSettings(
+              keepScreenOn: false,
+              adjustMode: 'manual',
+              fontSize: 14.0,
+            ),
+          ),
+        ),
+        terminalDisplayProvider.overrideWith(
+          () => _FixedTerminalDisplayNotifier(),
+        ),
+      ],
+      child: MaterialApp(
+        home: Scaffold(
+          body: SizedBox(
+            height: 400.0,
+            child: AnsiTextView(
+              text: text,
+              paneWidth: 20,
+              paneHeight: paneHeight,
+              cursorX: cursorX,
+              cursorY: cursorY,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  final caretFinder = find.byWidgetPredicate(
+    (w) => w is ColoredBox && w.color == DesignColors.primary,
+  );
+
+  testWidgets('caret is rendered inline inside the RichText (not composited)', (tester) async {
+    await tester.pumpWidget(
+      buildCaretSubject('abc\ndef\nghi', cursorX: 2, cursorY: 1),
+    );
+    await tester.pumpAndSettle();
+
+    expect(caretFinder, findsOneWidget);
+    // 合成（Stack+Positioned）ではなく RichText の子として存在する
+    expect(
+      find.ancestor(of: caretFinder, matching: find.byType(RichText)),
+      findsOneWidget,
+    );
+    expect(find.byType(Positioned), findsNothing);
+  });
+
+  testWidgets('caret sits on the cursor row and within the text extent', (tester) async {
+    // 1行目の2文字目の直後にキャレット（行スパンが xx + caret + def に分割される）
+    await tester.pumpWidget(
+      buildCaretSubject('xxdef\nabcdefgh\nzz', cursorX: 2, cursorY: 0),
+    );
+    await tester.pumpAndSettle();
+
+    final caretRect = tester.getRect(caretFinder);
+    final below = tester.getRect(find.textContaining('abcdefgh'));
+    const fontSize = 14.0;
+    final lineHeight = FontCalculator.lineHeightRatio * fontSize;
+
+    // 縦: キャレットの中心は1行目（下の行から1行分上）にいる＝行がズレていない
+    expect(caretRect.center.dy, closeTo(below.center.dy - lineHeight, 2.0));
+    // 横: アプリと同じ文字幅測定で2文字分進んだ位置（テキスト描画位置と一致）
+    final charWidth = FontCalculator.measureCharWidth('JetBrains Mono', 14.0);
+    expect(caretRect.left, closeTo(below.left + charWidth * 2, 1.0));
+  });
+
+  testWidgets('caret is a thin vertical bar of fontSize height', (tester) async {
+    await tester.pumpWidget(
+      buildCaretSubject('abc\ndef\nghi', cursorX: 2, cursorY: 1),
+    );
+    await tester.pumpAndSettle();
+
+    final rect = tester.getRect(caretFinder);
+    expect(rect.width, 2.0);
+    // FakeSettingsNotifier の既定 fontSize は14
+    expect(rect.height, 14.0);
+  });
+
+  testWidgets('caret blinks off after 500ms and back on', (tester) async {
+    await tester.pumpWidget(
+      buildCaretSubject('abc\ndef\nghi', cursorX: 2, cursorY: 1),
+    );
+    await tester.pumpAndSettle();
+    expect(caretFinder, findsOneWidget);
+
+    // 時計を正確に進める（pumpAndSettle は時刻を進めるので使わない）
+    await tester.pump(const Duration(milliseconds: 600));
+    expect(caretFinder, findsNothing);
+
+    await tester.pump(const Duration(milliseconds: 600));
+    expect(caretFinder, findsOneWidget);
+  });
+
+  testWidgets('caret on empty line renders at line start', (tester) async {
+    await tester.pumpWidget(
+      buildCaretSubject('abc\n\nghi', cursorX: 0, cursorY: 1),
+    );
+    await tester.pumpAndSettle();
+
+    expect(caretFinder, findsOneWidget);
+    // 空行の行頭: 高さ方向は2行目の位置
+    final caretRect = tester.getRect(caretFinder);
+    final firstRow = tester.getRect(find.textContaining('abc'));
+    final lineHeight = FontCalculator.lineHeightRatio * 14.0;
+    expect(caretRect.center.dy, closeTo(firstRow.center.dy + lineHeight, 3.0));
+    // 行頭: 1行目のテキスト左端と同じ位置
+    expect(caretRect.left, closeTo(firstRow.left, 2.0));
+  });
+
+  testWidgets('caret beyond line end is padded to the cursor column', (tester) async {
+    // 空行で cursorX=3: 3セル分のパディングの後にキャレット
+    await tester.pumpWidget(
+      buildCaretSubject('abc\n\nghi', cursorX: 3, cursorY: 1),
+    );
+    await tester.pumpAndSettle();
+
+    expect(caretFinder, findsOneWidget);
+  });
+
+  testWidgets('caret lands after a full-width character (column boundary)', (tester) async {
+    // 「あ」は2カラム幅: cursorX=2 は「あ」の直後の文字境界
+    await tester.pumpWidget(
+      buildCaretSubject('あb\nxx\nzz', cursorX: 2, cursorY: 0),
+    );
+    await tester.pumpAndSettle();
+
+    final caretRect = tester.getRect(caretFinder);
+    final below = tester.getRect(find.textContaining('xx'));
+    // 全角1文字 = 半角2文字分の幅の位置にキャレットがある
+    // （実際のフォールバックフォントの描画幅に追随するのが直接挿入方式の 本質）
+    final painter = TextPainter(
+      text: TextSpan(
+        text: 'あ',
+        style: TerminalFontStyles.getTextStyle('JetBrains Mono', fontSize: 14.0),
+      ),
+      textDirection: TextDirection.ltr,
+      textScaler: TextScaler.noScaling,
+    )..layout();
+    expect(caretRect.left, closeTo(below.left + painter.width, 1.0));
   });
 }

--- a/test/screens/terminal/ansi_text_view_test.dart
+++ b/test/screens/terminal/ansi_text_view_test.dart
@@ -244,7 +244,9 @@ void main() {
     (w) => w is ColoredBox && w.color == DesignColors.primary,
   );
 
-  testWidgets('caret is rendered inline inside the RichText (not composited)', (tester) async {
+  testWidgets('caret is rendered inline inside the RichText (not composited)', (
+    tester,
+  ) async {
     await tester.pumpWidget(
       buildCaretSubject('abc\ndef\nghi', cursorX: 2, cursorY: 1),
     );
@@ -259,7 +261,9 @@ void main() {
     expect(find.byType(Positioned), findsNothing);
   });
 
-  testWidgets('caret sits on the cursor row and within the text extent', (tester) async {
+  testWidgets('caret sits on the cursor row and within the text extent', (
+    tester,
+  ) async {
     // 1行目の2文字目の直後にキャレット（行スパンが xx + caret + def に分割される）
     await tester.pumpWidget(
       buildCaretSubject('xxdef\nabcdefgh\nzz', cursorX: 2, cursorY: 0),
@@ -278,7 +282,9 @@ void main() {
     expect(caretRect.left, closeTo(below.left + charWidth * 2, 1.0));
   });
 
-  testWidgets('caret is a thin vertical bar of fontSize height', (tester) async {
+  testWidgets('caret is a thin vertical bar of fontSize height', (
+    tester,
+  ) async {
     await tester.pumpWidget(
       buildCaretSubject('abc\ndef\nghi', cursorX: 2, cursorY: 1),
     );
@@ -321,7 +327,9 @@ void main() {
     expect(caretRect.left, closeTo(firstRow.left, 2.0));
   });
 
-  testWidgets('caret beyond line end is padded to the cursor column', (tester) async {
+  testWidgets('caret beyond line end is padded to the cursor column', (
+    tester,
+  ) async {
     // 空行で cursorX=3: 3セル分のパディングの後にキャレット
     await tester.pumpWidget(
       buildCaretSubject('abc\n\nghi', cursorX: 3, cursorY: 1),
@@ -331,7 +339,9 @@ void main() {
     expect(caretFinder, findsOneWidget);
   });
 
-  testWidgets('caret lands after a full-width character (column boundary)', (tester) async {
+  testWidgets('caret lands after a full-width character (column boundary)', (
+    tester,
+  ) async {
     // 「あ」は2カラム幅: cursorX=2 は「あ」の直後の文字境界
     await tester.pumpWidget(
       buildCaretSubject('あb\nxx\nzz', cursorX: 2, cursorY: 0),
@@ -345,7 +355,10 @@ void main() {
     final painter = TextPainter(
       text: TextSpan(
         text: 'あ',
-        style: TerminalFontStyles.getTextStyle('JetBrains Mono', fontSize: 14.0),
+        style: TerminalFontStyles.getTextStyle(
+          'JetBrains Mono',
+          fontSize: 14.0,
+        ),
       ),
       textDirection: TextDirection.ltr,
       textScaler: TextScaler.noScaling,

--- a/test/services/tmux/poll_pane_realworld_test.dart
+++ b/test/services/tmux/poll_pane_realworld_test.dart
@@ -1,0 +1,122 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_muxpod/services/command/command_request.dart';
+import 'package:flutter_muxpod/services/command/command_result.dart';
+import 'package:flutter_muxpod/services/tmux/tmux_command_executor.dart';
+import 'package:flutter_muxpod/services/tmux/tmux_facade.dart';
+
+/// pollPane 出力パースの回帰テスト（Issue #70 データ層の根本対応）。
+///
+/// 従来の「最後の改行で逆から切る」パースは、capture-pane 出力の最終行が空行の
+/// ときにその改行が「カーソル行との区切り」として消費され、最終空行がドロップ
+/// していた（キャレットが1行上にズレる原因）。マーカー区切りでは空行が保持される。
+class _FakeExecutor implements TmuxCommandExecutor {
+  _FakeExecutor(this.output);
+
+  final String output;
+
+  @override
+  Future<CommandResult> execute(CommandRequest request) async =>
+      CommandResult(
+        mergedOutput: output,
+        outputSeparation: CommandOutputSeparation.merged,
+        actualTransport: CommandTransport.persistent,
+      );
+
+  @override
+  bool get isConnected => true;
+
+  @override
+  String? get tmuxPath => '/usr/bin/tmux';
+
+  @override
+  Future<void> sendKeysCommand(String command) async {}
+
+  @override
+  Future<void> setWindowRestoreTrap(List<String> windowTargets) async {}
+
+  @override
+  Future<void> restoreWindowsNoWait(List<String> targets) async {}
+
+  @override
+  void write(String data) {}
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  /// PersistentShell 通過後（先頭/末尾の改行1つずつ除去後）のバイト列を模倣し、
+  /// マーカー区切りの pollPane 出力を構築する。
+  String framed(String capture, String cursorLine, String modeLine) {
+    final sep = tmuxPollSeparator('deadbeef12345678');
+    return '$sep\n$capture$sep$cursorLine\n$sep$modeLine\n$sep';
+  }
+
+  group('pollPane (marker-separated output)', () {
+    test('preserves trailing empty line of capture (Issue #70)', () async {
+      // Claude Code 等の TUI: UI行 + 下部の空行（最終行が空行）＋履歴
+      final rows = [
+        ...List.generate(41, (i) => 'hist-$i'),
+        ...List.generate(20, (i) => 'ui-row-$i'),
+        ...List.generate(19, (i) => ''),
+      ];
+      final capture = '${rows.join('\n')}\n';
+      final snap = await TmuxFacade().pollPane(
+        _FakeExecutor(framed(capture, '2,17,44,39', '')),
+        target: '%0',
+      );
+
+      expect(snap.cursorX, 2);
+      expect(snap.cursorY, 17);
+      expect(snap.paneWidth, 44);
+      expect(snap.paneHeight, 39);
+      expect(snap.paneMode, '');
+      // 41(履歴) + 39(ペイン行) = 80 行。末尾の空行が失われてはならない。
+      final lines = snap.content.rawText.split('\n');
+      expect(lines.length, 80);
+      // アプリのキャレット行計算: 80 - 39 + 17 = 58 (0-based) = ui-row-17
+      expect(lines[80 - 39 + 17], 'ui-row-17');
+    });
+
+    test('preserves capture first line when empty', () async {
+      final capture = '\nB\n\n';
+      final snap = await TmuxFacade().pollPane(
+        _FakeExecutor(framed(capture, '0,1,10,3', '')),
+        target: '%0',
+      );
+      expect(snap.content.rawText.split('\n'), ['', 'B', '']);
+    });
+
+    test('parses copy-mode pane mode', () async {
+      final capture = 'a\nb\n';
+      final snap = await TmuxFacade().pollPane(
+        _FakeExecutor(framed(capture, '3,0,10,2', 'copy-mode')),
+        target: '%0',
+      );
+      expect(snap.paneMode, 'copy-mode');
+      expect(snap.content.rawText.split('\n'), ['a', 'b']);
+    });
+
+    test('cursor line with trailing content is split exactly', () async {
+      final capture = 'x\n';
+      final snap = await TmuxFacade().pollPane(
+        _FakeExecutor(framed(capture, '10,0,80,1', '')),
+        target: '%0',
+      );
+      expect(snap.cursorX, 10);
+      expect(snap.content.rawText, 'x');
+    });
+  });
+
+  group('pollPane (legacy unframed output fallback)', () {
+    test('parses legacy fixtures without markers', () async {
+      final snap = await TmuxFacade().pollPane(
+        _FakeExecutor('hello\n7,8,90,30\n'),
+        target: '%0',
+      );
+      expect(snap.content.rawText, 'hello');
+      expect(snap.cursorX, 7);
+      expect(snap.cursorY, 8);
+      expect(snap.paneHeight, 30);
+    });
+  });
+}

--- a/test/services/tmux/poll_pane_realworld_test.dart
+++ b/test/services/tmux/poll_pane_realworld_test.dart
@@ -15,12 +15,11 @@ class _FakeExecutor implements TmuxCommandExecutor {
   final String output;
 
   @override
-  Future<CommandResult> execute(CommandRequest request) async =>
-      CommandResult(
-        mergedOutput: output,
-        outputSeparation: CommandOutputSeparation.merged,
-        actualTransport: CommandTransport.persistent,
-      );
+  Future<CommandResult> execute(CommandRequest request) async => CommandResult(
+    mergedOutput: output,
+    outputSeparation: CommandOutputSeparation.merged,
+    actualTransport: CommandTransport.persistent,
+  );
 
   @override
   bool get isConnected => true;


### PR DESCRIPTION
## Summary
- Fixes #70: the terminal caret was rendered one row above the actual cursor position (and could drift horizontally)
- Root cause 1 (data layer): pollPane parsed its output by cutting on trailing newlines backwards, which silently dropped the last empty line of capture-pane output and shifted the caret up by one row
- Root cause 2 (rendering layer): the caret was composited over the line with Stack+Positioned instead of being placed at the exact position inside the text layout, so it could not track the real glyph boundaries (e.g. full-width characters, fallback fonts)

## Changes
- `lib/services/tmux/tmux_facade.dart`: `pollPane` now embeds a per-call random-ID separator marker (`\x01###POLL_<hex>###\x01`) between the capture-pane / cursor-position / pane-mode outputs and splits sections by marker matching. Empty lines in capture output are preserved (the trailing empty row is no longer dropped). Legacy non-marker output falls back to the previous newline-based parsing
- `lib/screens/terminal/widgets/ansi_text_view.dart`: the caret is no longer composited with Stack+Positioned. It is now a zero-width inline `WidgetSpan` inserted at the exact character boundary computed from the cursor column, drawn via `OverflowBox` so it overlays the next cell without shifting any text
- `lib/services/terminal/ansi_parser.dart`: extracted `_segmentToTextSpan` from `lineToTextSpan` and added `lineToTextSpanWithCaret`, which splits segments at the caret offset and pads with NBSP cells when the cursor sits beyond the end of the line text
- `test/services/tmux/poll_pane_realworld_test.dart` (new): regression tests for marker-separated pollPane output — trailing empty line preservation, empty first line, copy-mode parsing, exact cursor-line split, and the legacy fallback path
- `test/screens/terminal/ansi_text_view_test.dart`: tests for inline caret rendering (inside `RichText`, no `Positioned`), exact row/column placement, caret size (2px × fontSize), blink cycle, empty-line position, beyond-line-end padding, and full-width character boundary

## Test plan
- [x] `flutter test test/services/tmux/poll_pane_realworld_test.dart test/screens/terminal/ansi_text_view_test.dart` — all 19 tests pass
- [ ] Manual: connect to a tmux session running a TUI (e.g. Claude Code) whose last pane row is empty and verify the caret sits on the exact cursor row/column
- [ ] Manual: verify the caret tracks full-width characters (CJK) and stays on the correct row when scrolling through history