### PR TITLE
Custom key buttons: user-defined buttons and a freely arranged key bar

### DIFF
--- a/lib/providers/custom_keys_provider.dart
+++ b/lib/providers/custom_keys_provider.dart
@@ -8,17 +8,12 @@ import '../services/custom_keys/custom_key_button.dart';
 
 /// State of the custom key buttons and their row layouts.
 class CustomKeysState {
-  const CustomKeysState({
-    required this.buttons,
-    required this.row0,
-    required this.row1,
-    required this.row2,
-  });
+  const CustomKeysState({required this.buttons, required this.rows});
 
   final List<CustomKeyButton> buttons;
-  final List<String> row0;
-  final List<String> row1;
-  final List<String> row2;
+
+  /// Token rows, top to bottom. Length 0..[CustomKeyRows.maxRows].
+  final List<List<String>> rows;
 
   CustomKeyButton? buttonById(String id) {
     for (final b in buttons) {
@@ -27,22 +22,18 @@ class CustomKeysState {
     return null;
   }
 
-  /// Buttons not referenced by row0, row1 or row2.
+  /// Buttons no row references.
   List<CustomKeyButton> unplacedButtons() {
-    final placed = <String>{
-      for (final token in [...row0, ...row1, ...row2])
-        if (CustomKeyRows.isCustomToken(token)) token,
-    };
+    final placed = _placedTokens();
     return buttons
         .where((b) => !placed.contains('ck:${b.id.substring(3)}'))
         .toList();
   }
 
-  /// Tokens not present in row0, row1 or row2, in canonical order:
-  /// [CustomKeyRows.allLayoutTokens] first, then custom `ck:` tokens in
-  /// [buttons] order.
+  /// Tokens no row holds, in canonical order: [CustomKeyRows.allLayoutTokens]
+  /// first, then custom `ck:` tokens in [buttons] order.
   List<String> unusedTokens() {
-    final placed = <String>{...row0, ...row1, ...row2};
+    final placed = _placedTokens();
     final unused = <String>[
       for (final token in CustomKeyRows.allLayoutTokens)
         if (!placed.contains(token)) token,
@@ -53,61 +44,39 @@ class CustomKeysState {
     }
     return unused;
   }
+
+  Set<String> _placedTokens() => {for (final row in rows) ...row};
 }
 
 /// Manages custom key buttons and their row layouts, persisting to shared_preferences.
 class CustomKeysNotifier extends Notifier<CustomKeysState> {
   static const String buttonsKey = 'custom_key_buttons_v1';
-  static const String row0Key = 'custom_key_row0_v1';
-  static const String row1Key = 'custom_key_row1_v1';
-  static const String row2Key = 'custom_key_row2_v1';
+
+  /// 行レイアウト全体（`List<List<String>>` の JSON）。
+  static const String rowsKey = 'custom_key_rows_v1';
+
+  /// 旧形式（行が3本固定だった時代）のキー。移行時にのみ読み、移行後は削除する。
+  static const String legacyRow0Key = 'custom_key_row0_v1';
+  static const String legacyRow1Key = 'custom_key_row1_v1';
+  static const String legacyRow2Key = 'custom_key_row2_v1';
 
   static const String shelfMigrationKey = 'custom_keys_shelf_v1';
 
   @override
   CustomKeysState build() {
     _load();
-    return const CustomKeysState(
-      buttons: [],
-      row0: CustomKeyRows.standardRow0,
-      row1: CustomKeyRows.standardRow1,
-      row2: CustomKeyRows.standardRow2,
-    );
+    return const CustomKeysState(buttons: [], rows: CustomKeyRows.defaultRows);
   }
 
   Future<void> _load() async {
     final prefs = await SharedPreferences.getInstance();
     if (!ref.mounted) return;
     final buttons = _loadButtons(prefs);
-    var row0 = _loadRow(prefs, row0Key, CustomKeyRows.standardRow0);
-    var row1 = _loadRow(prefs, row1Key, CustomKeyRows.standardRow1);
-    var row2 = _loadRow(prefs, row2Key, CustomKeyRows.standardRow2);
-    // 専用のカスタム行が導入される前のレイアウトを一度だけ移行する:
-    // row1/row2 に混在していたカスタムトークンを row0 へ集約する。
-    if (prefs.getString(row0Key) == null) {
-      row0 = [
-        ...row1.where(CustomKeyRows.isCustomToken),
-        ...row2.where(CustomKeyRows.isCustomToken),
-      ];
-      row1 = row1.where((t) => !CustomKeyRows.isCustomToken(t)).toList();
-      row2 = row2.where((t) => !CustomKeyRows.isCustomToken(t)).toList();
-    }
-    // 一度だけ: row2 が既定と異なる（ユーザーが並べ替えた）うえに直接入力の
-    // 数字キーを持たない場合のみ、描画時の自動付与に代えて num1..num4 を明示
-    // 的に追記する。既定の row2 は旧来の直接入力レイアウトで数字を描くため、
-    // ここで触ると既定レイアウトが壊れる（キーの存在有無では判定できない:
-    // _persist() が毎回すべての行キーを書くため）。
-    if (!(prefs.getBool(shelfMigrationKey) ?? false) &&
-        !listEquals(row2, CustomKeyRows.standardRow2) &&
-        !row2.any(CustomKeyRows.directInputExtras.contains)) {
-      row2 = [...row2, ...CustomKeyRows.directInputExtras];
-    }
-    state = CustomKeysState(
-      buttons: buttons,
-      row0: row0,
-      row1: row1,
-      row2: row2,
-    );
+    final rows = prefs.getString(rowsKey) != null
+        ? _loadRows(prefs)
+        : await _migrateLegacyRows(prefs);
+    if (!ref.mounted) return;
+    state = CustomKeysState(buttons: buttons, rows: rows);
     await _persist();
   }
 
@@ -130,24 +99,85 @@ class CustomKeysNotifier extends Notifier<CustomKeysState> {
     }
   }
 
-  List<String> _loadRow(
+  /// 新形式の行レイアウトを読む。壊れていれば既定レイアウトに戻す。
+  List<List<String>> _loadRows(SharedPreferences prefs) {
+    final raw = prefs.getString(rowsKey);
+    if (raw == null) return _copyRows(CustomKeyRows.defaultRows);
+    try {
+      final decoded = jsonDecode(raw);
+      if (decoded is! List) return _copyRows(CustomKeyRows.defaultRows);
+      final rows = <List<String>>[];
+      for (final row in decoded) {
+        if (row is! List) return _copyRows(CustomKeyRows.defaultRows);
+        final tokens = <String>[];
+        for (final token in row) {
+          if (token is! String) return _copyRows(CustomKeyRows.defaultRows);
+          tokens.add(token);
+        }
+        rows.add(tokens);
+      }
+      if (rows.length > CustomKeyRows.maxRows) {
+        return rows.sublist(0, CustomKeyRows.maxRows);
+      }
+      return rows;
+    } catch (_) {
+      return _copyRows(CustomKeyRows.defaultRows);
+    }
+  }
+
+  /// 行が3本固定だった旧レイアウトを新形式へ一度だけ移行する。
+  ///
+  /// 旧来の 2 つの移行（カスタムトークンの行0への集約、並べ替え済み行2への
+  /// num1..num4 追記）をここで適用したうえで `[row0, row1, row2]` を返し、
+  /// 旧キーは削除する。
+  Future<List<List<String>>> _migrateLegacyRows(SharedPreferences prefs) async {
+    var row0 = _loadLegacyRow(prefs, legacyRow0Key, const <String>[]);
+    var row1 = _loadLegacyRow(prefs, legacyRow1Key, CustomKeyRows.standardRow1);
+    var row2 = _loadLegacyRow(prefs, legacyRow2Key, CustomKeyRows.standardRow2);
+    // 専用のカスタム行が導入される前のレイアウト: row1/row2 に混在していた
+    // カスタムトークンを row0 へ集約する。
+    if (prefs.getString(legacyRow0Key) == null) {
+      row0 = [
+        ...row1.where(CustomKeyRows.isCustomToken),
+        ...row2.where(CustomKeyRows.isCustomToken),
+      ];
+      row1 = row1.where((t) => !CustomKeyRows.isCustomToken(t)).toList();
+      row2 = row2.where((t) => !CustomKeyRows.isCustomToken(t)).toList();
+    }
+    // row2 が既定と異なる（ユーザーが並べ替えた）うえに直接入力の数字キーを
+    // 持たない場合のみ、描画時の自動付与に代えて num1..num4 を明示的に追記
+    // する。既定の row2 は旧来の直接入力レイアウトで数字を描くため、ここで
+    // 触ると既定レイアウトが壊れる（キーの存在有無では判定できない: 旧版の
+    // 保存処理が毎回すべての行キーを書いていたため）。
+    if (!(prefs.getBool(shelfMigrationKey) ?? false) &&
+        !listEquals(row2, CustomKeyRows.standardRow2) &&
+        !row2.any(CustomKeyRows.directInputExtras.contains)) {
+      row2 = [...row2, ...CustomKeyRows.directInputExtras];
+    }
+    await prefs.remove(legacyRow0Key);
+    await prefs.remove(legacyRow1Key);
+    await prefs.remove(legacyRow2Key);
+    return [row0, row1, row2];
+  }
+
+  List<String> _loadLegacyRow(
     SharedPreferences prefs,
     String key,
     List<String> fallback,
   ) {
     final raw = prefs.getString(key);
-    if (raw == null) return fallback;
+    if (raw == null) return List.of(fallback);
     try {
       final decoded = jsonDecode(raw);
-      if (decoded is! List) return fallback;
+      if (decoded is! List) return List.of(fallback);
       final row = <String>[];
       for (final item in decoded) {
-        if (item is! String) return fallback;
+        if (item is! String) return List.of(fallback);
         row.add(item);
       }
       return row;
     } catch (_) {
-      return fallback;
+      return List.of(fallback);
     }
   }
 
@@ -155,14 +185,10 @@ class CustomKeysNotifier extends Notifier<CustomKeysState> {
     final buttonsJson = jsonEncode(
       state.buttons.map((b) => b.toJson()).toList(),
     );
-    final row0Json = jsonEncode(state.row0);
-    final row1Json = jsonEncode(state.row1);
-    final row2Json = jsonEncode(state.row2);
+    final rowsJson = jsonEncode(state.rows);
     final prefs = await SharedPreferences.getInstance();
     await prefs.setString(buttonsKey, buttonsJson);
-    await prefs.setString(row0Key, row0Json);
-    await prefs.setString(row1Key, row1Json);
-    await prefs.setString(row2Key, row2Json);
+    await prefs.setString(rowsKey, rowsJson);
     await prefs.setBool(shelfMigrationKey, true);
   }
 
@@ -172,12 +198,7 @@ class CustomKeysNotifier extends Notifier<CustomKeysState> {
       label: label.trim(),
       steps: List.of(steps),
     );
-    state = CustomKeysState(
-      buttons: [...state.buttons, b],
-      row0: state.row0,
-      row1: state.row1,
-      row2: state.row2,
-    );
+    state = CustomKeysState(buttons: [...state.buttons, b], rows: state.rows);
     _persist();
     return b;
   }
@@ -198,12 +219,7 @@ class CustomKeysNotifier extends Notifier<CustomKeysState> {
               : b,
         )
         .toList();
-    state = CustomKeysState(
-      buttons: buttons,
-      row0: state.row0,
-      row1: state.row1,
-      row2: state.row2,
-    );
+    state = CustomKeysState(buttons: buttons, rows: state.rows);
     _persist();
   }
 
@@ -211,63 +227,65 @@ class CustomKeysNotifier extends Notifier<CustomKeysState> {
     final token = 'ck:${id.substring(3)}';
     state = CustomKeysState(
       buttons: state.buttons.where((b) => b.id != id).toList(),
-      row0: state.row0.where((t) => t != token).toList(),
-      row1: state.row1.where((t) => t != token).toList(),
-      row2: state.row2.where((t) => t != token).toList(),
+      rows: [
+        for (final row in state.rows) row.where((t) => t != token).toList(),
+      ],
     );
     _persist();
   }
 
   void setRowTokens(int row, List<String> tokens) {
-    final customIds = state.buttons
-        .map((b) => 'ck:${b.id.substring(3)}')
-        .toSet();
+    if (row < 0 || row >= state.rows.length) return;
+    final customIds = _customTokens();
     final seen = <String>{};
     final clean = tokens
         .where((t) => CustomKeyRows.isKnownToken(t, customIds) && seen.add(t))
         .toList();
+    final rows = _copyRows(state.rows);
+    rows[row] = clean;
+    state = CustomKeysState(buttons: state.buttons, rows: rows);
+    _persist();
+  }
+
+  /// 空の行を最下段に追加する。[CustomKeyRows.maxRows] に達していれば何もしない。
+  void addRow() {
+    if (state.rows.length >= CustomKeyRows.maxRows) return;
     state = CustomKeysState(
       buttons: state.buttons,
-      row0: row == 0 ? clean : state.row0,
-      row1: row == 1 ? clean : state.row1,
-      row2: row == 2 ? clean : state.row2,
+      rows: [..._copyRows(state.rows), <String>[]],
     );
     _persist();
   }
 
-  /// Moves [token] to [toRow] (0,1,2) at slot [toIndex], or to the shelf when
-  /// [toRow] == [CustomKeyRows.shelfRow].
+  /// 行を削除する。載っていたトークンは未使用（Unused）へ戻るだけで失われない。
+  void removeRow(int row) {
+    if (row < 0 || row >= state.rows.length) return;
+    final rows = _copyRows(state.rows)..removeAt(row);
+    state = CustomKeysState(buttons: state.buttons, rows: rows);
+    _persist();
+  }
+
+  /// Moves [token] to [toRow] at slot [toIndex], or to the shelf when [toRow]
+  /// is [CustomKeyRows.shelfRow].
   ///
   /// The token is first stripped from every row. When [toRow] is a real row the
   /// slot index is interpreted against that row's pre-move token list, so a
   /// same-row move from a lower index lands at [toIndex] - 1. Unknown tokens
   /// (not standard and not an existing custom button) are a no-op.
   void placeToken(String token, {required int toRow, required int toIndex}) {
-    final customIds = state.buttons
-        .map((b) => 'ck:${b.id.substring(3)}')
-        .toSet();
-    if (!CustomKeyRows.isKnownToken(token, customIds)) return;
+    if (!CustomKeyRows.isKnownToken(token, _customTokens())) return;
 
-    final row0 = state.row0.where((t) => t != token).toList();
-    final row1 = state.row1.where((t) => t != token).toList();
-    final row2 = state.row2.where((t) => t != token).toList();
+    final rows = [
+      for (final row in state.rows) row.where((t) => t != token).toList(),
+    ];
 
-    if (toRow == 0 || toRow == 1 || toRow == 2) {
-      final preMove = switch (toRow) {
-        0 => state.row0,
-        1 => state.row1,
-        _ => state.row2,
-      };
-      final target = switch (toRow) {
-        0 => row0,
-        1 => row1,
-        _ => row2,
-      };
-      final oldIndex = preMove.indexOf(token);
+    if (toRow >= 0 && toRow < rows.length) {
+      final oldIndex = state.rows[toRow].indexOf(token);
       var index = toIndex;
       if (oldIndex >= 0 && oldIndex < toIndex) {
         index = toIndex - 1;
       }
+      final target = rows[toRow];
       final insertAt = index < 0
           ? 0
           : index > target.length
@@ -276,14 +294,16 @@ class CustomKeysNotifier extends Notifier<CustomKeysState> {
       target.insert(insertAt, token);
     }
 
-    state = CustomKeysState(
-      buttons: state.buttons,
-      row0: row0,
-      row1: row1,
-      row2: row2,
-    );
+    state = CustomKeysState(buttons: state.buttons, rows: rows);
     _persist();
   }
+
+  Set<String> _customTokens() =>
+      state.buttons.map((b) => 'ck:${b.id.substring(3)}').toSet();
+
+  static List<List<String>> _copyRows(List<List<String>> rows) => [
+    for (final row in rows) List.of(row),
+  ];
 }
 
 final customKeysProvider =

--- a/lib/providers/custom_keys_provider.dart
+++ b/lib/providers/custom_keys_provider.dart
@@ -1,0 +1,292 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../services/custom_keys/custom_key_button.dart';
+
+/// State of the custom key buttons and their row layouts.
+class CustomKeysState {
+  const CustomKeysState({
+    required this.buttons,
+    required this.row0,
+    required this.row1,
+    required this.row2,
+  });
+
+  final List<CustomKeyButton> buttons;
+  final List<String> row0;
+  final List<String> row1;
+  final List<String> row2;
+
+  CustomKeyButton? buttonById(String id) {
+    for (final b in buttons) {
+      if (b.id == id) return b;
+    }
+    return null;
+  }
+
+  /// Buttons not referenced by row0, row1 or row2.
+  List<CustomKeyButton> unplacedButtons() {
+    final placed = <String>{
+      for (final token in [...row0, ...row1, ...row2])
+        if (CustomKeyRows.isCustomToken(token)) token,
+    };
+    return buttons
+        .where((b) => !placed.contains('ck:${b.id.substring(3)}'))
+        .toList();
+  }
+
+  /// Tokens not present in row0, row1 or row2, in canonical order:
+  /// [CustomKeyRows.allLayoutTokens] first, then custom `ck:` tokens in
+  /// [buttons] order.
+  List<String> unusedTokens() {
+    final placed = <String>{...row0, ...row1, ...row2};
+    final unused = <String>[
+      for (final token in CustomKeyRows.allLayoutTokens)
+        if (!placed.contains(token)) token,
+    ];
+    for (final b in buttons) {
+      final token = 'ck:${b.id.substring(3)}';
+      if (!placed.contains(token)) unused.add(token);
+    }
+    return unused;
+  }
+}
+
+/// Manages custom key buttons and their row layouts, persisting to shared_preferences.
+class CustomKeysNotifier extends Notifier<CustomKeysState> {
+  static const String buttonsKey = 'custom_key_buttons_v1';
+  static const String row0Key = 'custom_key_row0_v1';
+  static const String row1Key = 'custom_key_row1_v1';
+  static const String row2Key = 'custom_key_row2_v1';
+
+  static const String shelfMigrationKey = 'custom_keys_shelf_v1';
+
+  @override
+  CustomKeysState build() {
+    _load();
+    return const CustomKeysState(
+      buttons: [],
+      row0: CustomKeyRows.standardRow0,
+      row1: CustomKeyRows.standardRow1,
+      row2: CustomKeyRows.standardRow2,
+    );
+  }
+
+  Future<void> _load() async {
+    final prefs = await SharedPreferences.getInstance();
+    if (!ref.mounted) return;
+    final buttons = _loadButtons(prefs);
+    var row0 = _loadRow(prefs, row0Key, CustomKeyRows.standardRow0);
+    var row1 = _loadRow(prefs, row1Key, CustomKeyRows.standardRow1);
+    var row2 = _loadRow(prefs, row2Key, CustomKeyRows.standardRow2);
+    // 専用のカスタム行が導入される前のレイアウトを一度だけ移行する:
+    // row1/row2 に混在していたカスタムトークンを row0 へ集約する。
+    if (prefs.getString(row0Key) == null) {
+      row0 = [
+        ...row1.where(CustomKeyRows.isCustomToken),
+        ...row2.where(CustomKeyRows.isCustomToken),
+      ];
+      row1 = row1.where((t) => !CustomKeyRows.isCustomToken(t)).toList();
+      row2 = row2.where((t) => !CustomKeyRows.isCustomToken(t)).toList();
+    }
+    // 一度だけ: row2 が既定と異なる（ユーザーが並べ替えた）うえに直接入力の
+    // 数字キーを持たない場合のみ、描画時の自動付与に代えて num1..num4 を明示
+    // 的に追記する。既定の row2 は旧来の直接入力レイアウトで数字を描くため、
+    // ここで触ると既定レイアウトが壊れる（キーの存在有無では判定できない:
+    // _persist() が毎回すべての行キーを書くため）。
+    if (!(prefs.getBool(shelfMigrationKey) ?? false) &&
+        !listEquals(row2, CustomKeyRows.standardRow2) &&
+        !row2.any(CustomKeyRows.directInputExtras.contains)) {
+      row2 = [...row2, ...CustomKeyRows.directInputExtras];
+    }
+    state = CustomKeysState(
+      buttons: buttons,
+      row0: row0,
+      row1: row1,
+      row2: row2,
+    );
+    await _persist();
+  }
+
+  List<CustomKeyButton> _loadButtons(SharedPreferences prefs) {
+    final raw = prefs.getString(buttonsKey);
+    if (raw == null) return [];
+    try {
+      final decoded = jsonDecode(raw);
+      if (decoded is! List) return [];
+      final buttons = <CustomKeyButton>[];
+      for (final item in decoded) {
+        if (item is! Map<String, dynamic>) continue;
+        final button = CustomKeyButton.fromJson(item);
+        if (button == null) continue;
+        buttons.add(button);
+      }
+      return buttons;
+    } catch (_) {
+      return [];
+    }
+  }
+
+  List<String> _loadRow(
+    SharedPreferences prefs,
+    String key,
+    List<String> fallback,
+  ) {
+    final raw = prefs.getString(key);
+    if (raw == null) return fallback;
+    try {
+      final decoded = jsonDecode(raw);
+      if (decoded is! List) return fallback;
+      final row = <String>[];
+      for (final item in decoded) {
+        if (item is! String) return fallback;
+        row.add(item);
+      }
+      return row;
+    } catch (_) {
+      return fallback;
+    }
+  }
+
+  Future<void> _persist() async {
+    final buttonsJson = jsonEncode(
+      state.buttons.map((b) => b.toJson()).toList(),
+    );
+    final row0Json = jsonEncode(state.row0);
+    final row1Json = jsonEncode(state.row1);
+    final row2Json = jsonEncode(state.row2);
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(buttonsKey, buttonsJson);
+    await prefs.setString(row0Key, row0Json);
+    await prefs.setString(row1Key, row1Json);
+    await prefs.setString(row2Key, row2Json);
+    await prefs.setBool(shelfMigrationKey, true);
+  }
+
+  CustomKeyButton addButton(String label, List<CustomKeyStep> steps) {
+    final b = CustomKeyButton(
+      id: CustomKeyButton.newId(),
+      label: label.trim(),
+      steps: List.of(steps),
+    );
+    state = CustomKeysState(
+      buttons: [...state.buttons, b],
+      row0: state.row0,
+      row1: state.row1,
+      row2: state.row2,
+    );
+    _persist();
+    return b;
+  }
+
+  void updateButton(
+    String id, {
+    required String label,
+    required List<CustomKeyStep> steps,
+  }) {
+    final buttons = state.buttons
+        .map(
+          (b) => b.id == id
+              ? CustomKeyButton(
+                  id: b.id,
+                  label: label.trim(),
+                  steps: List.of(steps),
+                )
+              : b,
+        )
+        .toList();
+    state = CustomKeysState(
+      buttons: buttons,
+      row0: state.row0,
+      row1: state.row1,
+      row2: state.row2,
+    );
+    _persist();
+  }
+
+  void deleteButton(String id) {
+    final token = 'ck:${id.substring(3)}';
+    state = CustomKeysState(
+      buttons: state.buttons.where((b) => b.id != id).toList(),
+      row0: state.row0.where((t) => t != token).toList(),
+      row1: state.row1.where((t) => t != token).toList(),
+      row2: state.row2.where((t) => t != token).toList(),
+    );
+    _persist();
+  }
+
+  void setRowTokens(int row, List<String> tokens) {
+    final customIds = state.buttons
+        .map((b) => 'ck:${b.id.substring(3)}')
+        .toSet();
+    final seen = <String>{};
+    final clean = tokens
+        .where((t) => CustomKeyRows.isKnownToken(t, customIds) && seen.add(t))
+        .toList();
+    state = CustomKeysState(
+      buttons: state.buttons,
+      row0: row == 0 ? clean : state.row0,
+      row1: row == 1 ? clean : state.row1,
+      row2: row == 2 ? clean : state.row2,
+    );
+    _persist();
+  }
+
+  /// Moves [token] to [toRow] (0,1,2) at slot [toIndex], or to the shelf when
+  /// [toRow] == [CustomKeyRows.shelfRow].
+  ///
+  /// The token is first stripped from every row. When [toRow] is a real row the
+  /// slot index is interpreted against that row's pre-move token list, so a
+  /// same-row move from a lower index lands at [toIndex] - 1. Unknown tokens
+  /// (not standard and not an existing custom button) are a no-op.
+  void placeToken(String token, {required int toRow, required int toIndex}) {
+    final customIds = state.buttons
+        .map((b) => 'ck:${b.id.substring(3)}')
+        .toSet();
+    if (!CustomKeyRows.isKnownToken(token, customIds)) return;
+
+    final row0 = state.row0.where((t) => t != token).toList();
+    final row1 = state.row1.where((t) => t != token).toList();
+    final row2 = state.row2.where((t) => t != token).toList();
+
+    if (toRow == 0 || toRow == 1 || toRow == 2) {
+      final preMove = switch (toRow) {
+        0 => state.row0,
+        1 => state.row1,
+        _ => state.row2,
+      };
+      final target = switch (toRow) {
+        0 => row0,
+        1 => row1,
+        _ => row2,
+      };
+      final oldIndex = preMove.indexOf(token);
+      var index = toIndex;
+      if (oldIndex >= 0 && oldIndex < toIndex) {
+        index = toIndex - 1;
+      }
+      final insertAt = index < 0
+          ? 0
+          : index > target.length
+          ? target.length
+          : index;
+      target.insert(insertAt, token);
+    }
+
+    state = CustomKeysState(
+      buttons: state.buttons,
+      row0: row0,
+      row1: row1,
+      row2: row2,
+    );
+    _persist();
+  }
+}
+
+final customKeysProvider =
+    NotifierProvider<CustomKeysNotifier, CustomKeysState>(
+      CustomKeysNotifier.new,
+    );

--- a/lib/screens/custom_keys/custom_keys_screen.dart
+++ b/lib/screens/custom_keys/custom_keys_screen.dart
@@ -47,12 +47,29 @@ class CustomKeysScreen extends ConsumerWidget {
               onTap: () => _editButton(context, ref, button),
             ),
           const Divider(),
-          const _SectionHeader('Layout — Custom Row'),
-          _buildRowStrip(context, ref, state, 0, state.row0),
-          const _SectionHeader('Layout — Row 1'),
-          _buildRowStrip(context, ref, state, 1, state.row1),
-          const _SectionHeader('Layout — Row 2'),
-          _buildRowStrip(context, ref, state, 2, state.row2),
+          for (var row = 0; row < state.rows.length; row++) ...[
+            _RowHeader(
+              title: 'Layout — Row ${row + 1}',
+              onDelete: () =>
+                  ref.read(customKeysProvider.notifier).removeRow(row),
+              deleteKey: Key('row-$row-delete'),
+            ),
+            _buildRowStrip(context, ref, state, row, state.rows[row]),
+          ],
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 8),
+            child: Align(
+              alignment: Alignment.centerLeft,
+              child: TextButton.icon(
+                key: const Key('add-row'),
+                onPressed: state.rows.length >= CustomKeyRows.maxRows
+                    ? null
+                    : () => ref.read(customKeysProvider.notifier).addRow(),
+                icon: const Icon(Icons.playlist_add),
+                label: const Text('+ Add row'),
+              ),
+            ),
+          ),
           const _SectionHeader('Unused'),
           Padding(
             padding: const EdgeInsets.fromLTRB(16, 0, 16, 4),
@@ -383,6 +400,38 @@ class _SectionHeader extends StatelessWidget {
           color: isDark ? DesignColors.textMuted : DesignColors.textMutedLight,
         ),
       ),
+    );
+  }
+}
+
+/// Section header for one layout row: the label plus a delete affordance.
+class _RowHeader extends StatelessWidget {
+  const _RowHeader({
+    required this.title,
+    required this.onDelete,
+    required this.deleteKey,
+  });
+
+  final String title;
+  final VoidCallback onDelete;
+  final Key deleteKey;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Expanded(child: _SectionHeader(title)),
+        Padding(
+          padding: const EdgeInsets.only(right: 8),
+          child: IconButton(
+            key: deleteKey,
+            icon: const Icon(Icons.delete_outline),
+            iconSize: 20,
+            tooltip: 'Delete row',
+            onPressed: onDelete,
+          ),
+        ),
+      ],
     );
   }
 }

--- a/lib/screens/custom_keys/custom_keys_screen.dart
+++ b/lib/screens/custom_keys/custom_keys_screen.dart
@@ -50,8 +50,10 @@ class CustomKeysScreen extends ConsumerWidget {
           for (var row = 0; row < state.rows.length; row++) ...[
             _RowHeader(
               title: 'Layout — Row ${row + 1}',
+              onAdd: () => _addButton(context, ref, row: row, toIndex: null),
               onDelete: () =>
                   ref.read(customKeysProvider.notifier).removeRow(row),
+              addKey: Key('row-$row-add'),
               deleteKey: Key('row-$row-delete'),
             ),
             _buildRowStrip(context, ref, state, row, state.rows[row]),
@@ -148,7 +150,24 @@ class CustomKeysScreen extends ConsumerWidget {
           child: Wrap(
             runSpacing: 8,
             crossAxisAlignment: WrapCrossAlignment.center,
-            children: children,
+            children: [
+              ...children,
+              // An empty row renders nothing in the bar; say so, otherwise the
+              // row looks broken rather than unused.
+              if (tokens.isEmpty)
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 8),
+                  child: Text(
+                    'Empty — hidden in the bar',
+                    style: TextStyle(
+                      fontSize: 12,
+                      color: Theme.of(context).brightness == Brightness.dark
+                          ? DesignColors.textMuted
+                          : DesignColors.textMutedLight,
+                    ),
+                  ),
+                ),
+            ],
           ),
         );
       },
@@ -311,7 +330,16 @@ class CustomKeysScreen extends ConsumerWidget {
     );
   }
 
-  Future<void> _addButton(BuildContext context, WidgetRef ref) async {
+  /// Creates a button and places it in [row].
+  ///
+  /// [toIndex] null appends, 0 prepends. When [row] is out of range (the layout
+  /// has no rows yet) a row is created first, so the button is never invisible.
+  Future<void> _addButton(
+    BuildContext context,
+    WidgetRef ref, {
+    int row = 0,
+    int? toIndex = 0,
+  }) async {
     final result = await _openEditor(
       context,
       initialLabel: '',
@@ -320,14 +348,15 @@ class CustomKeysScreen extends ConsumerWidget {
       ],
     );
     if (result == null) return;
-    final button = ref
-        .read(customKeysProvider.notifier)
-        .addButton(result.$1, result.$2);
-    // New buttons land first on the dedicated custom row (row 0): it is the
-    // topmost row and the leading slot needs no scrolling to reach.
-    ref
-        .read(customKeysProvider.notifier)
-        .placeToken('ck:${button.id.substring(3)}', toRow: 0, toIndex: 0);
+    final notifier = ref.read(customKeysProvider.notifier);
+    if (ref.read(customKeysProvider).rows.isEmpty) notifier.addRow();
+    final target = row < ref.read(customKeysProvider).rows.length ? row : 0;
+    final button = notifier.addButton(result.$1, result.$2);
+    notifier.placeToken(
+      'ck:${button.id.substring(3)}',
+      toRow: target,
+      toIndex: toIndex ?? ref.read(customKeysProvider).rows[target].length,
+    );
   }
 
   Future<void> _editButton(
@@ -408,12 +437,16 @@ class _SectionHeader extends StatelessWidget {
 class _RowHeader extends StatelessWidget {
   const _RowHeader({
     required this.title,
+    required this.onAdd,
     required this.onDelete,
+    required this.addKey,
     required this.deleteKey,
   });
 
   final String title;
+  final VoidCallback onAdd;
   final VoidCallback onDelete;
+  final Key addKey;
   final Key deleteKey;
 
   @override
@@ -421,6 +454,13 @@ class _RowHeader extends StatelessWidget {
     return Row(
       children: [
         Expanded(child: _SectionHeader(title)),
+        IconButton(
+          key: addKey,
+          icon: const Icon(Icons.add),
+          iconSize: 20,
+          tooltip: 'New button in this row',
+          onPressed: onAdd,
+        ),
         Padding(
           padding: const EdgeInsets.only(right: 8),
           child: IconButton(

--- a/lib/screens/custom_keys/custom_keys_screen.dart
+++ b/lib/screens/custom_keys/custom_keys_screen.dart
@@ -1,0 +1,400 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../providers/custom_keys_provider.dart';
+import '../../services/custom_keys/custom_key_button.dart';
+import '../../theme/design_colors.dart';
+import '../../widgets/dialogs/custom_key_button_editor_dialog.dart';
+
+/// Full editor for custom key buttons: the button library plus the row
+/// layout strips for the special keys bar.
+class CustomKeysScreen extends ConsumerWidget {
+  const CustomKeysScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(customKeysProvider);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Custom Buttons')),
+      body: ListView(
+        children: [
+          const _SectionHeader('Buttons'),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 8),
+            child: Align(
+              alignment: Alignment.centerLeft,
+              child: TextButton.icon(
+                onPressed: () => _addButton(context, ref),
+                icon: const Icon(Icons.add),
+                label: const Text('+ Add button'),
+              ),
+            ),
+          ),
+          for (final button in state.buttons)
+            ListTile(
+              leading: const _AmberDot(),
+              title: Text(button.label),
+              subtitle: Text(_stepSummary(button.steps)),
+              trailing: IconButton(
+                key: Key('delete-${button.id}'),
+                icon: const Icon(Icons.delete_outline),
+                tooltip: 'Delete button',
+                onPressed: () => ref
+                    .read(customKeysProvider.notifier)
+                    .deleteButton(button.id),
+              ),
+              onTap: () => _editButton(context, ref, button),
+            ),
+          const Divider(),
+          const _SectionHeader('Layout — Custom Row'),
+          _buildRowStrip(context, ref, state, 0, state.row0),
+          const _SectionHeader('Layout — Row 1'),
+          _buildRowStrip(context, ref, state, 1, state.row1),
+          const _SectionHeader('Layout — Row 2'),
+          _buildRowStrip(context, ref, state, 2, state.row2),
+          const _SectionHeader('Unused'),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 0, 16, 4),
+            child: Text(
+              'Drag buttons here to hide them from the bar.',
+              style: TextStyle(
+                fontSize: 12,
+                color: Theme.of(context).brightness == Brightness.dark
+                    ? DesignColors.textMuted
+                    : DesignColors.textMutedLight,
+              ),
+            ),
+          ),
+          _buildShelfStrip(context, ref, state, state.unusedTokens()),
+          const SizedBox(height: 24),
+        ],
+      ),
+    );
+  }
+
+  /// A horizontal strip of draggable chips with drop slots interleaved so a
+  /// chip can be dropped at any index (the trailing slot appends). The whole
+  /// strip is also a drop target that appends, so a sloppy drop is not lost.
+  Widget _buildRowStrip(
+    BuildContext context,
+    WidgetRef ref,
+    CustomKeysState state,
+    int row,
+    List<String> tokens,
+  ) {
+    final children = <Widget>[];
+    for (var i = 0; i <= tokens.length; i++) {
+      if (i > 0) {
+        final token = tokens[i - 1];
+        final button = CustomKeyRows.isCustomToken(token)
+            ? _buttonForToken(state, token)
+            : null;
+        if (!CustomKeyRows.isCustomToken(token) || button != null) {
+          children.add(
+            _draggableChip(
+              context,
+              ref,
+              key: Key('chip-$row-$token'),
+              token: token,
+              button: button,
+            ),
+          );
+        }
+      }
+      children.add(_dropSlot(context, ref, row, i));
+    }
+
+    return DragTarget<String>(
+      onWillAcceptWithDetails: (_) => true,
+      onAcceptWithDetails: (details) => ref
+          .read(customKeysProvider.notifier)
+          .placeToken(details.data, toRow: row, toIndex: tokens.length),
+      builder: (context, candidates, rejected) {
+        final active = candidates.isNotEmpty;
+        final colorScheme = Theme.of(context).colorScheme;
+        return Container(
+          key: Key('layout-row-$row'),
+          margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+          padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 8),
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(12),
+            color: active ? colorScheme.primary.withValues(alpha: 0.06) : null,
+            border: Border.all(
+              color: active
+                  ? colorScheme.primary.withValues(alpha: 0.5)
+                  : Colors.transparent,
+            ),
+          ),
+          // Wrap, never a horizontal scroller: during a drag the strip cannot
+          // be scrolled, so every chip and drop slot has to stay on screen.
+          child: Wrap(
+            runSpacing: 8,
+            crossAxisAlignment: WrapCrossAlignment.center,
+            children: children,
+          ),
+        );
+      },
+    );
+  }
+
+  /// The "Unused" shelf: a single drop target covering the whole strip. Any
+  /// chip dropped here is removed from every row and hidden from the bar.
+  Widget _buildShelfStrip(
+    BuildContext context,
+    WidgetRef ref,
+    CustomKeysState state,
+    List<String> tokens,
+  ) {
+    final chips = <Widget>[];
+    for (final token in tokens) {
+      final button = CustomKeyRows.isCustomToken(token)
+          ? _buttonForToken(state, token)
+          : null;
+      if (CustomKeyRows.isCustomToken(token) && button == null) continue;
+      chips.add(
+        _draggableChip(
+          context,
+          ref,
+          key: Key('chip-shelf-$token'),
+          token: token,
+          button: button,
+        ),
+      );
+    }
+
+    return DragTarget<String>(
+      key: const Key('slot-shelf'),
+      onWillAcceptWithDetails: (_) => true,
+      onAcceptWithDetails: (details) => ref
+          .read(customKeysProvider.notifier)
+          .placeToken(details.data, toRow: CustomKeyRows.shelfRow, toIndex: 0),
+      builder: (context, candidates, rejected) {
+        final active = candidates.isNotEmpty;
+        final colorScheme = Theme.of(context).colorScheme;
+        return Container(
+          key: const Key('layout-shelf'),
+          margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+          padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 8),
+          constraints: const BoxConstraints(minHeight: 56),
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(12),
+            color: active
+                ? colorScheme.primary.withValues(alpha: 0.06)
+                : colorScheme.surface.withValues(alpha: 0.4),
+            border: Border.all(
+              color: active
+                  ? colorScheme.primary.withValues(alpha: 0.5)
+                  : colorScheme.outline.withValues(alpha: 0.3),
+            ),
+          ),
+          child: chips.isEmpty
+              ? Center(
+                  child: Text(
+                    'No unused buttons',
+                    style: TextStyle(
+                      fontSize: 12,
+                      color: Theme.of(context).brightness == Brightness.dark
+                          ? DesignColors.textMuted
+                          : DesignColors.textMutedLight,
+                    ),
+                  ),
+                )
+              : Wrap(spacing: 8, runSpacing: 8, children: chips),
+        );
+      },
+    );
+  }
+
+  /// A chip that starts a drag on long-press. A plain tap still reaches the
+  /// chip underneath, so custom chips keep their editor-open tap behaviour.
+  Widget _draggableChip(
+    BuildContext context,
+    WidgetRef ref, {
+    required Key key,
+    required String token,
+    required CustomKeyButton? button,
+  }) {
+    Widget visual({required bool elevated}) {
+      final chip = button == null
+          ? _standardChip(context, token)
+          : _customChip(context, ref, button);
+      if (!elevated) return chip;
+      return Material(
+        color: Colors.transparent,
+        elevation: 4,
+        borderRadius: BorderRadius.circular(24),
+        clipBehavior: Clip.antiAlias,
+        child: chip,
+      );
+    }
+
+    return LongPressDraggable<String>(
+      key: key,
+      data: token,
+      feedback: visual(elevated: true),
+      childWhenDragging: Opacity(opacity: 0.4, child: visual(elevated: false)),
+      child: visual(elevated: false),
+    );
+  }
+
+  Widget _standardChip(BuildContext context, String token) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    return Chip(
+      label: Text(CustomKeyRows.tokenLabel(token) ?? token),
+      visualDensity: VisualDensity.compact,
+      labelStyle: TextStyle(
+        color: isDark ? DesignColors.textMuted : DesignColors.textMutedLight,
+      ),
+    );
+  }
+
+  Widget _customChip(
+    BuildContext context,
+    WidgetRef ref,
+    CustomKeyButton button,
+  ) {
+    return ActionChip(
+      avatar: const Icon(Icons.tune, size: 16, color: DesignColors.secondary),
+      label: Text(button.label),
+      labelStyle: const TextStyle(color: DesignColors.secondary),
+      side: const BorderSide(color: DesignColors.secondary),
+      visualDensity: VisualDensity.compact,
+      onPressed: () => _editButton(context, ref, button),
+    );
+  }
+
+  Widget _dropSlot(BuildContext context, WidgetRef ref, int row, int index) {
+    return DragTarget<String>(
+      key: Key('slot-$row-$index'),
+      onWillAcceptWithDetails: (_) => true,
+      onAcceptWithDetails: (details) => ref
+          .read(customKeysProvider.notifier)
+          .placeToken(details.data, toRow: row, toIndex: index),
+      builder: (context, candidates, rejected) {
+        final active = candidates.isNotEmpty;
+        final colorScheme = Theme.of(context).colorScheme;
+        return Container(
+          width: 12,
+          height: 40,
+          margin: const EdgeInsets.symmetric(horizontal: 2),
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(6),
+            color: active
+                ? colorScheme.primary.withValues(alpha: 0.25)
+                : Colors.transparent,
+            border: Border.all(
+              color: active
+                  ? colorScheme.primary.withValues(alpha: 0.5)
+                  : Colors.transparent,
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  Future<void> _addButton(BuildContext context, WidgetRef ref) async {
+    final result = await _openEditor(
+      context,
+      initialLabel: '',
+      initialSteps: const [
+        CustomKeyStep(type: CustomKeyStepType.text, value: ''),
+      ],
+    );
+    if (result == null) return;
+    final button = ref
+        .read(customKeysProvider.notifier)
+        .addButton(result.$1, result.$2);
+    // New buttons land first on the dedicated custom row (row 0): it is the
+    // topmost row and the leading slot needs no scrolling to reach.
+    ref
+        .read(customKeysProvider.notifier)
+        .placeToken('ck:${button.id.substring(3)}', toRow: 0, toIndex: 0);
+  }
+
+  Future<void> _editButton(
+    BuildContext context,
+    WidgetRef ref,
+    CustomKeyButton button,
+  ) async {
+    final result = await _openEditor(
+      context,
+      initialLabel: button.label,
+      initialSteps: button.steps,
+      onDelete: () =>
+          ref.read(customKeysProvider.notifier).deleteButton(button.id),
+    );
+    if (result == null) return;
+    ref
+        .read(customKeysProvider.notifier)
+        .updateButton(button.id, label: result.$1, steps: result.$2);
+  }
+
+  Future<(String, List<CustomKeyStep>)?> _openEditor(
+    BuildContext context, {
+    required String initialLabel,
+    required List<CustomKeyStep> initialSteps,
+    VoidCallback? onDelete,
+  }) {
+    return showDialog<(String, List<CustomKeyStep>)>(
+      context: context,
+      builder: (context) => CustomKeyButtonEditorDialog(
+        initialLabel: initialLabel,
+        initialSteps: initialSteps,
+        onDelete: onDelete,
+      ),
+    );
+  }
+
+  static CustomKeyButton? _buttonForToken(CustomKeysState state, String token) {
+    return state.buttonById('ck_${token.substring(3)}');
+  }
+
+  static String _stepSummary(List<CustomKeyStep> steps) {
+    return steps
+        .map(
+          (s) => switch (s.type) {
+            CustomKeyStepType.text => "'${s.value}'",
+            CustomKeyStepType.key => s.value,
+            CustomKeyStepType.pause => 'pause(${s.value}ms)',
+          },
+        )
+        .join(' + ');
+  }
+}
+
+class _SectionHeader extends StatelessWidget {
+  const _SectionHeader(this.title);
+
+  final String title;
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+      child: Text(
+        title,
+        style: TextStyle(
+          fontSize: 11,
+          fontWeight: FontWeight.w700,
+          letterSpacing: 1.5,
+          color: isDark ? DesignColors.textMuted : DesignColors.textMutedLight,
+        ),
+      ),
+    );
+  }
+}
+
+class _AmberDot extends StatelessWidget {
+  const _AmberDot();
+
+  @override
+  Widget build(BuildContext context) {
+    return const CircleAvatar(
+      backgroundColor: DesignColors.secondary,
+      radius: 5,
+    );
+  }
+}

--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -6,6 +6,7 @@ import 'package:google_fonts/google_fonts.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import '../../providers/settings_provider.dart';
+import '../../services/keychain/secure_storage.dart';
 import '../../l10n/app_localizations.dart';
 import '../../l10n/l10n_ext.dart';
 import '../../theme/design_colors.dart';
@@ -15,6 +16,7 @@ import '../../widgets/dialogs/min_font_size_dialog.dart';
 import '../../widgets/dialogs/theme_dialog.dart';
 import '../../services/version_info.dart';
 import 'licenses_screen.dart';
+import '../custom_keys/custom_keys_screen.dart';
 
 /// 設定画面
 class SettingsScreen extends ConsumerWidget {
@@ -223,6 +225,27 @@ class SettingsScreen extends ConsumerWidget {
                     },
                   ),
                 ],
+                const Divider(),
+                // TODO(i18n): localize once arb keys exist for these entries.
+                const _SectionHeader(title: 'Buttons'),
+                ListTile(
+                  leading: const Icon(Icons.apps),
+                  title: const Text('Custom Buttons'),
+                  subtitle: const Text(
+                    'Add buttons and action sequences to the key bar',
+                  ),
+                  onTap: () => Navigator.of(context).push(
+                    MaterialPageRoute(builder: (_) => const CustomKeysScreen()),
+                  ),
+                ),
+                const Divider(),
+                const _SectionHeader(title: 'Security'),
+                ListTile(
+                  leading: const Icon(Icons.key_off),
+                  title: const Text('Clear SSH Host Keys'),
+                  subtitle: const Text('Reset saved server fingerprints'),
+                  onTap: () => _confirmClearHostKeys(context),
+                ),
                 const Divider(),
                 _SectionHeader(title: l10n.settingsSectionBehavior),
                 SwitchListTile(
@@ -522,6 +545,52 @@ class SettingsScreen extends ConsumerWidget {
         ],
       ),
     );
+  }
+
+  /// SSHホスト鍵フィンガープリントを全て消去する（確認付き）。
+  ///
+  /// サーバーのホスト鍵が変わった / 保存状態が壊れた場合の復旧手段。
+  /// アプリデータ全体を消すより軽く、次回接続でホスト鍵を再受諾できる。
+  Future<void> _confirmClearHostKeys(BuildContext context) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: const Text('Clear SSH host keys?'),
+        content: const Text(
+          'This removes all saved server host-key fingerprints. The next '
+          'connection silently trusts and re-saves whatever host key each '
+          'server presents, so only do this on a network you trust.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(false),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(dialogContext).pop(true),
+            child: const Text('Clear'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true) return;
+
+    // 削除は mounted チェックより前に走らせる: 画面が閉じても、確認済みの
+    // 意図は実行する。mounted は SnackBar の表示だけを守る。
+    String message;
+    try {
+      final removed = await SecureStorageService()
+          .deleteAllHostKeyFingerprints();
+      message = removed == 0
+          ? 'No saved host keys to clear'
+          : 'Cleared $removed saved host key${removed == 1 ? '' : 's'}';
+    } catch (e) {
+      message = 'Could not clear host keys: ${e.runtimeType}';
+    }
+    if (!context.mounted) return;
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(SnackBar(content: Text(message)));
   }
 
   void _showTextInputDialog(

--- a/lib/screens/terminal/terminal_screen.dart
+++ b/lib/screens/terminal/terminal_screen.dart
@@ -72,6 +72,10 @@ import 'package:image_picker/image_picker.dart';
 import '../settings/settings_screen.dart';
 import 'widgets/ansi_text_view.dart';
 import 'widgets/terminal_zoom.dart';
+import '../../providers/custom_keys_provider.dart';
+import '../../services/custom_keys/custom_key_button.dart';
+import '../../widgets/dialogs/custom_key_button_editor_dialog.dart';
+import '../custom_keys/custom_keys_screen.dart';
 
 // inventory: TERM-ENUM-001
 /// スクロールモードのソース
@@ -3115,18 +3119,32 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
               if (!_canSendSpecialKey)
                 _ReadOnlyBanner(isDark: isDark)
               else
-                SpecialKeysBar(
-                  // inventory: TERM-INPUT-006
-                  onKeyPressed: _sendKeyWithOverlay,
-                  onSpecialKeyPressed: _sendSpecialKeyWithOverlay,
-                  // inventory: TERM-INPUT-009
-                  onInputTap: _showInputDialog,
-                  directInputEnabled: _directInputEnabled,
-                  onDirectInputToggle: () {
-                    ref.read(settingsProvider.notifier).toggleDirectInput();
+                // customKeysProvider はこの Consumer 内でだけ watch する:
+                // 親 build() を再実行させると BottomSheet が閉じてしまう
+                // （このクラス冒頭のコメントと BUG-3 の回帰テスト参照）。
+                Consumer(
+                  builder: (context, ref, _) {
+                    final customKeys = ref.watch(customKeysProvider);
+                    return SpecialKeysBar(
+                      // inventory: TERM-INPUT-006
+                      onKeyPressed: _sendKeyWithOverlay,
+                      onSpecialKeyPressed: _sendSpecialKeyWithOverlay,
+                      // inventory: TERM-INPUT-009
+                      onInputTap: _showInputDialog,
+                      directInputEnabled: _directInputEnabled,
+                      onDirectInputToggle: () {
+                        ref.read(settingsProvider.notifier).toggleDirectInput();
+                      },
+                      // inventory: TERM-FILE-002
+                      onImagePickRequested: _handleImageTransfer,
+                      customButtons: customKeys.buttons,
+                      row0Tokens: customKeys.row0,
+                      row1Tokens: customKeys.row1,
+                      row2Tokens: customKeys.row2,
+                      onCustomButtonEdit: _editCustomButton,
+                      onManageButtons: _openCustomKeysScreen,
+                    );
                   },
-                  // inventory: TERM-FILE-002
-                  onImagePickRequested: _handleImageTransfer,
                 ),
             ],
           ),
@@ -3143,6 +3161,31 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         ],
       ),
     );
+  }
+
+  /// カスタムキーボタンの編集ダイアログを開き、保存時にプロバイダへ反映する。
+  void _editCustomButton(CustomKeyButton button) async {
+    final result = await showDialog<(String, List<CustomKeyStep>)>(
+      context: context,
+      builder: (_) => CustomKeyButtonEditorDialog(
+        initialLabel: button.label,
+        initialSteps: button.steps,
+        onDelete: () =>
+            ref.read(customKeysProvider.notifier).deleteButton(button.id),
+      ),
+    );
+    if (result != null && mounted) {
+      ref
+          .read(customKeysProvider.notifier)
+          .updateButton(button.id, label: result.$1, steps: result.$2);
+    }
+  }
+
+  /// カスタムボタン管理画面を開く。
+  void _openCustomKeysScreen() {
+    Navigator.of(
+      context,
+    ).push(MaterialPageRoute(builder: (_) => const CustomKeysScreen()));
   }
 
   // --- キーオーバーレイ ラッパー ---

--- a/lib/screens/terminal/terminal_screen.dart
+++ b/lib/screens/terminal/terminal_screen.dart
@@ -3138,9 +3138,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
                       // inventory: TERM-FILE-002
                       onImagePickRequested: _handleImageTransfer,
                       customButtons: customKeys.buttons,
-                      row0Tokens: customKeys.row0,
-                      row1Tokens: customKeys.row1,
-                      row2Tokens: customKeys.row2,
+                      rows: customKeys.rows,
                       onCustomButtonEdit: _editCustomButton,
                       onManageButtons: _openCustomKeysScreen,
                     );

--- a/lib/services/custom_keys/custom_key_button.dart
+++ b/lib/services/custom_keys/custom_key_button.dart
@@ -80,11 +80,11 @@ class CustomKeyButton {
 class CustomKeyRows {
   CustomKeyRows._();
 
-  /// Верхний ряд только под пользовательские кнопки (по умолчанию пуст).
-  static const List<String> standardRow0 = <String>[];
-
   /// Bucket id for the "Unused" shelf.
   static const int shelfRow = -1;
+
+  /// 縦方向のスペースは有限なので、トークン行はこの本数までとする。
+  static const int maxRows = 6;
 
   static const List<String> standardRow1 = [
     'esc',
@@ -115,6 +115,13 @@ class CustomKeyRows {
     'num2',
     'num3',
     'num4',
+  ];
+
+  /// 既定レイアウト（上から下）: 空のカスタム行、修飾キー行、ナビゲーション行。
+  static const List<List<String>> defaultRows = [
+    <String>[],
+    standardRow1,
+    standardRow2,
   ];
 
   /// Every standard token that can be placed, in canonical shelf order.

--- a/lib/services/custom_keys/custom_key_button.dart
+++ b/lib/services/custom_keys/custom_key_button.dart
@@ -1,0 +1,167 @@
+import 'dart:math';
+
+/// Тип шага действия пользовательской кнопки.
+enum CustomKeyStepType { text, key, pause }
+
+/// Один шаг последовательности: печать текста, нажатие клавиши или пауза.
+class CustomKeyStep {
+  const CustomKeyStep({required this.type, required this.value});
+
+  final CustomKeyStepType type;
+
+  /// text: литеральная строка; key: tmux-имя клавиши (Enter, C-c, …);
+  /// pause: длительность в мс (строка, положительное целое).
+  final String value;
+
+  Map<String, dynamic> toJson() => {'type': type.name, 'value': value};
+
+  static CustomKeyStep? fromJson(Map<String, dynamic> json) {
+    final typeName = json['type'];
+    final value = json['value'];
+    if (typeName is! String || value is! String) return null;
+    final type = CustomKeyStepType.values.asNameMap()[typeName];
+    if (type == null) return null;
+    if (!isValid(type, value)) return null;
+    return CustomKeyStep(type: type, value: value);
+  }
+
+  static bool isValid(CustomKeyStepType type, String value) {
+    if (value.trim().isEmpty) return false;
+    if (type == CustomKeyStepType.pause) {
+      final ms = int.tryParse(value.trim());
+      return ms != null && ms > 0;
+    }
+    return true;
+  }
+}
+
+/// Пользовательская кнопка панели клавиш.
+class CustomKeyButton {
+  const CustomKeyButton({
+    required this.id,
+    required this.label,
+    required this.steps,
+  });
+
+  final String id;
+  final String label;
+  final List<CustomKeyStep> steps;
+
+  Map<String, dynamic> toJson() => {
+    'id': id,
+    'label': label,
+    'steps': steps.map((s) => s.toJson()).toList(),
+  };
+
+  static CustomKeyButton? fromJson(Map<String, dynamic> json) {
+    final id = json['id'];
+    final label = json['label'];
+    final rawSteps = json['steps'];
+    if (id is! String || label is! String || rawSteps is! List) return null;
+    if (id.isEmpty || label.trim().isEmpty) return null;
+    final steps = <CustomKeyStep>[];
+    for (final raw in rawSteps) {
+      if (raw is! Map<String, dynamic>) return null;
+      final step = CustomKeyStep.fromJson(raw);
+      if (step == null) return null;
+      steps.add(step);
+    }
+    if (steps.isEmpty) return null;
+    return CustomKeyButton(id: id, label: label, steps: steps);
+  }
+
+  static String newId() {
+    final rand = Random().nextInt(0xffff).toRadixString(16).padLeft(4, '0');
+    return 'ck_${DateTime.now().millisecondsSinceEpoch}_$rand';
+  }
+}
+
+/// Стандартные токены раскладки рядов панели клавиш.
+class CustomKeyRows {
+  CustomKeyRows._();
+
+  /// Верхний ряд только под пользовательские кнопки (по умолчанию пуст).
+  static const List<String> standardRow0 = <String>[];
+
+  /// Bucket id for the "Unused" shelf.
+  static const int shelfRow = -1;
+
+  static const List<String> standardRow1 = [
+    'esc',
+    'tab',
+    'ctrl',
+    'alt',
+    'shift',
+    'enter',
+    'senter',
+    'slash',
+    'dash',
+  ];
+
+  static const List<String> standardRow2 = [
+    'pgup',
+    'pgdn',
+    'left',
+    'up',
+    'down',
+    'right',
+    'image',
+    'di_toggle',
+    'input',
+  ];
+
+  static const List<String> directInputExtras = [
+    'num1',
+    'num2',
+    'num3',
+    'num4',
+  ];
+
+  /// Every standard token that can be placed, in canonical shelf order.
+  static const List<String> allLayoutTokens = [
+    ...standardRow1,
+    ...standardRow2,
+    ...directInputExtras,
+  ];
+
+  static const Set<String> standardIds = {
+    ...standardRow1,
+    ...standardRow2,
+    ...directInputExtras,
+  };
+
+  static bool isStandardToken(String token) => standardIds.contains(token);
+
+  /// Display label for a standard token; returns null for unknown/custom tokens.
+  static String? tokenLabel(String token) => switch (token) {
+    'esc' => 'ESC',
+    'tab' => 'TAB',
+    'ctrl' => 'CTRL',
+    'alt' => 'ALT',
+    'shift' => 'SHIFT',
+    'enter' => 'ENTER',
+    'senter' => 'S-RET',
+    'slash' => '/',
+    'dash' => '-',
+    'pgup' => 'PgUp',
+    'pgdn' => 'PgDn',
+    'left' => 'Left',
+    'up' => 'Up',
+    'down' => 'Down',
+    'right' => 'Right',
+    'image' => 'Image',
+    'di_toggle' => 'Direct Input',
+    'input' => 'Input',
+    'num1' => '1',
+    'num2' => '2',
+    'num3' => '3',
+    'num4' => '4',
+    _ => null,
+  };
+
+  static bool isCustomToken(String token) => token.startsWith('ck:');
+
+  static bool isKnownToken(String token, Set<String> customIds) =>
+      isStandardToken(token) ||
+      (isCustomToken(token) && customIds.contains(token));
+}

--- a/lib/services/keychain/secure_storage.dart
+++ b/lib/services/keychain/secure_storage.dart
@@ -154,7 +154,13 @@ class SecureStorageService {
     if (_testValues != null) {
       return Map.of(_testValues!);
     }
-    return await _storage.readAll();
+    // resetOnError の既定は true で、Android の readAll() は 1 件でも復号
+    // 不能なエントリがあると secure storage 全体を消してから再試行する
+    // （パスワード・秘密鍵・接続設定まで飛ぶ）。列挙でその挙動は許容でき
+    // ないため、ここだけ明示的に無効化して例外として受け取る。
+    return await _storage.readAll(
+      aOptions: const AndroidOptions(resetOnError: false),
+    );
   }
 
   // ===== ホスト鍵検証 =====
@@ -166,7 +172,9 @@ class SecureStorageService {
     String type,
     String fingerprint,
   ) async {
-    await _writeValue(_hostKeyKey(host, port, type), fingerprint);
+    final key = _hostKeyKey(host, port, type);
+    await _writeValue(key, fingerprint);
+    await _rememberHostKey(key);
   }
 
   /// ホスト鍵フィンガープリントを取得
@@ -184,10 +192,71 @@ class SecureStorageService {
     int port,
     String type,
   ) async {
-    await _deleteValue(_hostKeyKey(host, port, type));
+    final key = _hostKeyKey(host, port, type);
+    await _deleteValue(key);
+    await _forgetHostKey(key);
   }
 
+  /// 保存済みのホスト鍵フィンガープリントを全て削除し、削除件数を返す。
+  ///
+  /// サーバーのホスト鍵が変わった / 保存状態が壊れた場合に、アプリデータ
+  /// 全体を消さず、次回接続でホスト鍵を再受諾できるようにする。
+  ///
+  /// 索引に載っているキーは個別削除する。個別削除は復号を伴わないので、
+  /// fingerprint の保存値が壊れていても成功する（この機能の本来の用途）。
+  /// 索引を持たない旧バージョンが書いた分は列挙で拾うが、列挙は復号を伴う
+  /// ため失敗し得る。失敗しても索引側の削除は続行する。
+  Future<int> deleteAllHostKeyFingerprints() async {
+    final keys = <String>{};
+    try {
+      keys.addAll(await _hostKeyIndex());
+    } on PlatformException catch (e) {
+      debugPrint('hostkey index unreadable: ${e.code}');
+    }
+    try {
+      keys.addAll(await getKeysWithPrefix(_hostKeyPrefix));
+    } on PlatformException catch (e) {
+      debugPrint('hostkey enumeration failed: ${e.code}');
+    }
+    keys.remove(_hostKeyIndexKey);
+    for (final key in keys) {
+      await _deleteValue(key);
+    }
+    await _deleteValue(_hostKeyIndexKey);
+    return keys.length;
+  }
+
+  // ===== ホスト鍵の索引 =====
+  //
+  // 「どのキーを書いたか」だけを 1 エントリにまとめて保持する。fingerprint
+  // 本体とは別エントリなので、本体が復号不能になっても索引から鍵名を取り出
+  // して個別削除できる。索引キー自身も hostkey_ プレフィックスに属するため、
+  // 全消去時に一緒に消える。
+
+  Future<Set<String>> _hostKeyIndex() async {
+    final raw = await _readValue(_hostKeyIndexKey);
+    if (raw == null || raw.isEmpty) return <String>{};
+    return raw.split('\n').where((k) => k.isNotEmpty).toSet();
+  }
+
+  Future<void> _rememberHostKey(String key) async {
+    final index = await _hostKeyIndex();
+    if (!index.add(key)) return;
+    await _writeValue(_hostKeyIndexKey, index.join('\n'));
+  }
+
+  Future<void> _forgetHostKey(String key) async {
+    final index = await _hostKeyIndex();
+    if (!index.remove(key)) return;
+    await _writeValue(_hostKeyIndexKey, index.join('\n'));
+  }
+
+  static const String _hostKeyPrefix = 'hostkey_';
+
+  /// 書き込んだホスト鍵キーの索引（鍵名のみ、値は含まない）。
+  static const String _hostKeyIndexKey = '${_hostKeyPrefix}index';
+
   String _hostKeyKey(String host, int port, String type) {
-    return 'hostkey_${host}_${port}_$type';
+    return '$_hostKeyPrefix${host}_${port}_$type';
   }
 }

--- a/lib/widgets/custom_key_button_widget.dart
+++ b/lib/widgets/custom_key_button_widget.dart
@@ -1,0 +1,103 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+import '../services/custom_keys/custom_key_button.dart';
+import '../theme/design_colors.dart';
+
+/// カスタムキーボタン：ラベルを表示し、タップでステップ列を順次実行する。
+///
+/// 標準の特殊キーボタン（シアン）と区別するため、枠線・文字をアンバー
+/// （`DesignColors.secondary`）で描画する。
+class CustomKeyButtonWidget extends StatefulWidget {
+  const CustomKeyButtonWidget({
+    super.key,
+    required this.button, // CustomKeyButton
+    required this.onKeyPressed, // void Function(String)
+    required this.onSpecialKeyPressed, // void Function(String)
+    required this.onEdit, // void Function(CustomKeyButton)
+    this.hapticFeedback = true,
+    this.height = 32,
+  });
+
+  final CustomKeyButton button;
+  final void Function(String) onKeyPressed;
+  final void Function(String) onSpecialKeyPressed;
+  final void Function(CustomKeyButton) onEdit;
+  final bool hapticFeedback;
+  final double height;
+
+  @override
+  State<CustomKeyButtonWidget> createState() => _CustomKeyButtonWidgetState();
+}
+
+class _CustomKeyButtonWidgetState extends State<CustomKeyButtonWidget> {
+  bool _executing = false;
+
+  Future<void> _execute() async {
+    if (_executing) return;
+    _executing = true;
+    try {
+      for (final step in widget.button.steps) {
+        switch (step.type) {
+          case CustomKeyStepType.text:
+            widget.onKeyPressed(step.value);
+          case CustomKeyStepType.key:
+            widget.onSpecialKeyPressed(step.value);
+          case CustomKeyStepType.pause:
+            final ms = int.tryParse(step.value.trim());
+            if (ms != null && ms > 0) {
+              await Future<void>.delayed(Duration(milliseconds: ms));
+            }
+        }
+      }
+    } finally {
+      _executing = false;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    return GestureDetector(
+      onTapDown: (_) {
+        if (widget.hapticFeedback) {
+          HapticFeedback.lightImpact();
+        }
+      },
+      onTap: _execute,
+      onLongPress: () => widget.onEdit(widget.button),
+      child: Container(
+        height: widget.height,
+        decoration: BoxDecoration(
+          color: isDark
+              ? DesignColors.keyBackground
+              : DesignColors.keyBackgroundLight,
+          borderRadius: BorderRadius.circular(4),
+          border: const Border(
+            bottom: BorderSide(color: DesignColors.secondary, width: 2),
+          ),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withValues(alpha: isDark ? 0.3 : 0.15),
+              blurRadius: 2,
+              offset: const Offset(0, 1),
+            ),
+          ],
+        ),
+        child: Center(
+          child: Text(
+            widget.button.label,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: GoogleFonts.jetBrainsMono(
+              fontSize: 10,
+              fontWeight: FontWeight.w700,
+              color: DesignColors.secondary,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/dialogs/custom_key_button_editor_dialog.dart
+++ b/lib/widgets/dialogs/custom_key_button_editor_dialog.dart
@@ -1,0 +1,360 @@
+import 'package:flutter/material.dart';
+
+import '../../services/custom_keys/custom_key_button.dart';
+
+/// Editor dialog for a single custom key button.
+///
+/// Shown via `showDialog<(String, List<CustomKeyStep>)>`; pops
+/// `(label.trim(), steps)` on Save, `null` on Cancel.
+class CustomKeyButtonEditorDialog extends StatefulWidget {
+  const CustomKeyButtonEditorDialog({
+    super.key,
+    required this.initialLabel,
+    required this.initialSteps,
+    this.onDelete,
+  });
+
+  final String initialLabel;
+  final List<CustomKeyStep> initialSteps;
+  final VoidCallback? onDelete;
+
+  @override
+  State<CustomKeyButtonEditorDialog> createState() =>
+      _CustomKeyButtonEditorDialogState();
+}
+
+class _CustomKeyButtonEditorDialogState
+    extends State<CustomKeyButtonEditorDialog> {
+  late final TextEditingController _labelController;
+  late final List<CustomKeyStep> _steps;
+  late final List<TextEditingController> _valueControllers;
+  String? _errorText;
+
+  @override
+  void initState() {
+    super.initState();
+    _labelController = TextEditingController(text: widget.initialLabel);
+    _steps = List.of(widget.initialSteps);
+    _valueControllers = widget.initialSteps
+        .map((s) => TextEditingController(text: s.value))
+        .toList();
+  }
+
+  @override
+  void dispose() {
+    _labelController.dispose();
+    for (final controller in _valueControllers) {
+      controller.dispose();
+    }
+    super.dispose();
+  }
+
+  static String _typeLabel(CustomKeyStepType type) {
+    switch (type) {
+      case CustomKeyStepType.text:
+        return 'Text';
+      case CustomKeyStepType.key:
+        return 'Key';
+      case CustomKeyStepType.pause:
+        return 'Pause';
+    }
+  }
+
+  static String _hintFor(CustomKeyStepType type) {
+    switch (type) {
+      case CustomKeyStepType.text:
+        return 'Text to type';
+      case CustomKeyStepType.key:
+        return 'tmux key (Enter, C-c, …)';
+      case CustomKeyStepType.pause:
+        return 'Milliseconds';
+    }
+  }
+
+  void _addStep() {
+    setState(() {
+      _steps.add(const CustomKeyStep(type: CustomKeyStepType.text, value: ''));
+      _valueControllers.add(TextEditingController());
+    });
+  }
+
+  void _deleteStep(int index) {
+    setState(() {
+      _steps.removeAt(index);
+      _valueControllers.removeAt(index).dispose();
+    });
+  }
+
+  void _moveStep(int index, int delta) {
+    final target = index + delta;
+    setState(() {
+      final step = _steps.removeAt(index);
+      _steps.insert(target, step);
+      final controller = _valueControllers.removeAt(index);
+      _valueControllers.insert(target, controller);
+    });
+  }
+
+  void _changeType(int index, CustomKeyStepType? type) {
+    if (type == null) return;
+    setState(() {
+      _steps[index] = CustomKeyStep(type: type, value: _steps[index].value);
+    });
+  }
+
+  String? _validate() {
+    if (_labelController.text.trim().isEmpty) return 'Label is required';
+    if (_steps.isEmpty) return 'At least one step';
+    for (var i = 0; i < _steps.length; i++) {
+      final type = _steps[i].type;
+      final value = _valueControllers[i].text;
+      if ((type == CustomKeyStepType.text || type == CustomKeyStepType.key) &&
+          value.trim().isEmpty) {
+        return 'Step value is required';
+      }
+      if (type == CustomKeyStepType.pause &&
+          !CustomKeyStep.isValid(type, value)) {
+        return 'Invalid pause value';
+      }
+    }
+    return null;
+  }
+
+  void _save() {
+    final error = _validate();
+    if (error != null) {
+      setState(() => _errorText = error);
+      return;
+    }
+    final steps = <CustomKeyStep>[
+      for (var i = 0; i < _steps.length; i++)
+        CustomKeyStep(type: _steps[i].type, value: _valueControllers[i].text),
+    ];
+    Navigator.pop(context, (_labelController.text.trim(), steps));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('Button'),
+      content: SizedBox(
+        width: 320,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            TextField(
+              key: const Key('label-field'),
+              controller: _labelController,
+              autofocus: true,
+              style: TextStyle(color: Theme.of(context).colorScheme.onSurface),
+              cursorColor: Theme.of(context).colorScheme.onSurface,
+              decoration: const InputDecoration(labelText: 'Label'),
+            ),
+            const SizedBox(height: 12),
+            const Text('Steps'),
+            const SizedBox(height: 4),
+            ConstrainedBox(
+              constraints: const BoxConstraints(maxHeight: 240),
+              child: SingleChildScrollView(
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    for (var i = 0; i < _steps.length; i++) _buildStepRow(i),
+                  ],
+                ),
+              ),
+            ),
+            TextButton(onPressed: _addStep, child: const Text('+ Add step')),
+            if (_errorText != null)
+              Text(
+                _errorText!,
+                style: TextStyle(color: Theme.of(context).colorScheme.error),
+              ),
+          ],
+        ),
+      ),
+      // One explicit row instead of three loose actions: AlertDialog's
+      // OverflowBar stacks them vertically as soon as they do not fit. Sizing
+      // is intrinsic (a Flexible cell splits the width evenly and ellipsises
+      // "Delete" into "Dele"), and the whole group scales down as a unit when
+      // the dialog is too narrow - so the labels are always shown whole and
+      // the row never wraps.
+      actionsPadding: const EdgeInsets.fromLTRB(12, 0, 12, 12),
+      actions: [
+        MediaQuery.withClampedTextScaling(
+          maxScaleFactor: 1.2,
+          child: FittedBox(
+            fit: BoxFit.scaleDown,
+            alignment: Alignment.centerRight,
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                if (widget.onDelete != null) ...[
+                  TextButton(
+                    key: const Key('dialog-delete'),
+                    onPressed: _confirmDelete,
+                    style: _compactAction(
+                      foreground: Theme.of(context).colorScheme.error,
+                    ),
+                    child: const Text('Delete', maxLines: 1, softWrap: false),
+                  ),
+                  const SizedBox(width: 16),
+                ],
+                TextButton(
+                  onPressed: () => Navigator.pop(context),
+                  style: _compactAction(),
+                  child: const Text('Cancel', maxLines: 1, softWrap: false),
+                ),
+                const SizedBox(width: 4),
+                FilledButton(
+                  onPressed: _save,
+                  style: _compactAction(),
+                  child: const Text('Save', maxLines: 1, softWrap: false),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  /// Action button style trimmed to its label: the default 64px minimum width
+  /// and 12-24px side padding are what pushes three buttons out of a narrow
+  /// dialog. The 40px height keeps the tap target usable.
+  static ButtonStyle _compactAction({Color? foreground}) {
+    return ButtonStyle(
+      foregroundColor: foreground == null
+          ? null
+          : WidgetStatePropertyAll<Color>(foreground),
+      padding: const WidgetStatePropertyAll<EdgeInsetsGeometry>(
+        EdgeInsets.symmetric(horizontal: 10),
+      ),
+      minimumSize: const WidgetStatePropertyAll<Size>(Size(0, 40)),
+      tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+    );
+  }
+
+  Future<void> _confirmDelete() async {
+    final navigator = Navigator.of(context);
+    final confirm = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Delete button?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(context, true),
+            style: TextButton.styleFrom(
+              foregroundColor: Theme.of(context).colorScheme.error,
+            ),
+            child: const Text('Delete'),
+          ),
+        ],
+      ),
+    );
+    if (confirm == true) {
+      navigator.pop();
+      widget.onDelete?.call();
+    }
+  }
+
+  Widget _buildStepRow(int index) {
+    final isFirst = index == 0;
+    final isLast = index == _steps.length - 1;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        // Align the type/actions row with the value field's 16px content
+        // inset (inputDecorationTheme.contentPadding): the trailing icon
+        // glyph sits 8px inside its 36px tap target, hence right: 8.
+        Padding(
+          padding: const EdgeInsets.only(left: 16, right: 8),
+          child: Row(
+            children: [
+              // Shrinkable type selector. The row's fixed parts (140px selector
+              // + three 40px actions + 24px padding = 284px) exceed the dialog
+              // content box on narrow screens - a 411dp phone at a large
+              // display-size setting gives ~230px - and a Row does not clip, so
+              // the actions used to paint outside the dialog card. The Expanded
+              // cell clamps the selector instead.
+              Expanded(
+                child: Align(
+                  alignment: Alignment.centerLeft,
+                  child: SizedBox(
+                    width: 140,
+                    child: DropdownButton<CustomKeyStepType>(
+                      key: Key('step-type-$index'),
+                      value: _steps[index].type,
+                      isDense: true,
+                      isExpanded: true,
+                      underline: const SizedBox.shrink(),
+                      items: [
+                        for (final type in CustomKeyStepType.values)
+                          DropdownMenuItem<CustomKeyStepType>(
+                            value: type,
+                            child: Text(
+                              _typeLabel(type),
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                          ),
+                      ],
+                      onChanged: (value) => _changeType(index, value),
+                    ),
+                  ),
+                ),
+              ),
+              IconButton(
+                key: Key('step-up-$index'),
+                iconSize: 20,
+                visualDensity: VisualDensity.compact,
+                padding: EdgeInsets.zero,
+                constraints: const BoxConstraints(minWidth: 36, minHeight: 36),
+                tooltip: 'Move up',
+                icon: const Icon(Icons.arrow_upward),
+                onPressed: isFirst ? null : () => _moveStep(index, -1),
+              ),
+              IconButton(
+                key: Key('step-down-$index'),
+                iconSize: 20,
+                visualDensity: VisualDensity.compact,
+                padding: EdgeInsets.zero,
+                constraints: const BoxConstraints(minWidth: 36, minHeight: 36),
+                tooltip: 'Move down',
+                icon: const Icon(Icons.arrow_downward),
+                onPressed: isLast ? null : () => _moveStep(index, 1),
+              ),
+              IconButton(
+                key: Key('step-delete-$index'),
+                iconSize: 20,
+                visualDensity: VisualDensity.compact,
+                padding: EdgeInsets.zero,
+                constraints: const BoxConstraints(minWidth: 36, minHeight: 36),
+                tooltip: 'Delete step',
+                icon: const Icon(Icons.delete_outline),
+                onPressed: () => _deleteStep(index),
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(height: 4),
+        // Full-width value field: always wide enough to show typed text,
+        // regardless of the system font scale.
+        TextField(
+          key: Key('step-value-$index'),
+          controller: _valueControllers[index],
+          style: TextStyle(color: Theme.of(context).colorScheme.onSurface),
+          cursorColor: Theme.of(context).colorScheme.onSurface,
+          decoration: InputDecoration(
+            hintText: _hintFor(_steps[index].type),
+            isDense: true,
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/widgets/special_keys_bar.dart
+++ b/lib/widgets/special_keys_bar.dart
@@ -531,13 +531,14 @@ class _SpecialKeysBarState extends State<SpecialKeysBar> {
     final row1Tokens = _visibleTokens(widget.row1Tokens);
     final row2Tokens = _visibleTokens(widget.row2Tokens);
 
-    // The manage (pencil) button is pinned to the end of row 1 while that
-    // row renders; when row 1 renders nothing it moves to the first row that
-    // does render (row 0, else row 2) so the editor entry point never
-    // disappears while the bar is visible.
-    final bool row1HostsPencil = row1Tokens.isNotEmpty;
-    final bool row0HostsPencil = !row1HostsPencil && row0Tokens.isNotEmpty;
-    final bool row2HostsPencil = !row1HostsPencil && !row0HostsPencil;
+    // The manage (pencil) button is pinned to the end of row 0, the custom
+    // row: that is where the user's own buttons live. Row 0 is empty by
+    // default, so when it renders nothing the pencil falls back to the first
+    // row that does render (row 1, else row 2) and the editor entry point
+    // never disappears while the bar is visible.
+    final bool row0HostsPencil = row0Tokens.isNotEmpty;
+    final bool row1HostsPencil = !row0HostsPencil && row1Tokens.isNotEmpty;
+    final bool row2HostsPencil = !row0HostsPencil && !row1HostsPencil;
 
     return Container(
       decoration: BoxDecoration(
@@ -576,7 +577,7 @@ class _SpecialKeysBarState extends State<SpecialKeysBar> {
   /// それ以外は汎用の水平スクロール行で描画する。
   Widget _buildRow1(List<String> tokens, {required bool hostsPencil}) {
     if (listEquals(widget.row1Tokens, CustomKeyRows.standardRow1)) {
-      return _buildLegacyModifierKeysRow();
+      return _buildLegacyModifierKeysRow(withManageButton: hostsPencil);
     }
     return _buildGenericTokenRow(
       tokens: tokens,
@@ -601,8 +602,8 @@ class _SpecialKeysBarState extends State<SpecialKeysBar> {
     );
   }
 
-  /// 行1の従来レイアウト（ESC…dash + 鉛筆ボタン）。既定レイアウト専用。
-  Widget _buildLegacyModifierKeysRow() {
+  /// 行1の従来レイアウト（ESC…dash、必要なら鉛筆ボタン）。既定レイアウト専用。
+  Widget _buildLegacyModifierKeysRow({required bool withManageButton}) {
     final isDark = Theme.of(context).brightness == Brightness.dark;
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 4),
@@ -624,7 +625,7 @@ class _SpecialKeysBarState extends State<SpecialKeysBar> {
           _buildShiftEnterKeyButton(),
           _buildLiteralKeyButton('/', '/'),
           _buildLiteralKeyButton('-', '-'),
-          _buildManageButton(),
+          if (withManageButton) _buildManageButton(),
         ],
       ),
     );

--- a/lib/widgets/special_keys_bar.dart
+++ b/lib/widgets/special_keys_bar.dart
@@ -34,14 +34,8 @@ class SpecialKeysBar extends StatefulWidget {
   /// カスタムキーボタン（ユーザー定義ボタン）
   final List<CustomKeyButton> customButtons;
 
-  /// 行0（専用カスタムキー行）のトークン列
-  final List<String> row0Tokens;
-
-  /// 行1（修飾キー行）のトークン列
-  final List<String> row1Tokens;
-
-  /// 行2（ナビゲーション行）のトークン列
-  final List<String> row2Tokens;
+  /// バーの行レイアウト（上から下）。各行は保持するトークン列。
+  final List<List<String>> rows;
 
   /// カスタムボタン編集リクエスト（長押し）
   final void Function(CustomKeyButton)? onCustomButtonEdit;
@@ -53,15 +47,13 @@ class SpecialKeysBar extends StatefulWidget {
     super.key,
     required this.onKeyPressed,
     required this.onSpecialKeyPressed,
+    required this.rows,
     this.onInputTap,
     this.hapticFeedback = true,
     this.directInputEnabled = false,
     this.onDirectInputToggle,
     this.onImagePickRequested,
     this.customButtons = const [],
-    required this.row0Tokens,
-    this.row1Tokens = CustomKeyRows.standardRow1,
-    this.row2Tokens = CustomKeyRows.standardRow2,
     this.onCustomButtonEdit,
     this.onManageButtons,
   });
@@ -81,10 +73,9 @@ class _SpecialKeysBarState extends State<SpecialKeysBar> {
   /// 入力欄にテキストを残したまま追加分のみ送信するために保持する
   String _sentText = '';
 
-  /// 行0・行1・行2の水平スクロール制御（新規ボタン追加時に末尾へ自動スクロール）
-  final ScrollController _row0ScrollController = ScrollController();
-  final ScrollController _row1ScrollController = ScrollController();
-  final ScrollController _row2ScrollController = ScrollController();
+  /// 行ごとの水平スクロール制御（新規ボタン追加時にその位置へ自動スクロール）。
+  /// 行数は可変なので、行数の変化に合わせて作成・破棄する。
+  final List<ScrollController> _rowScrollControllers = [];
 
   /// 現在IME変換中かどうか
   bool _isComposing = false;
@@ -110,6 +101,7 @@ class _SpecialKeysBarState extends State<SpecialKeysBar> {
   @override
   void initState() {
     super.initState();
+    _syncRowControllers(widget.rows.length);
     if (widget.directInputEnabled) {
       _directInputController.value = TextEditingValue(
         text: _sentinel,
@@ -130,24 +122,28 @@ class _SpecialKeysBarState extends State<SpecialKeysBar> {
       _isResettingController = false;
       _sentText = '';
     }
-    // 新規ボタンが追加されたら、その位置（先頭/末尾）まで自動スクロールする
-    if (widget.row0Tokens.length > oldWidget.row0Tokens.length) {
-      _scheduleScrollToNewToken(
-        _row0ScrollController,
-        atStart: _grewAtStart(oldWidget.row0Tokens, widget.row0Tokens),
-      );
+    _syncRowControllers(widget.rows.length);
+    // 新規トークンが追加された行を、その位置（先頭/末尾）まで自動スクロールする
+    final shared = widget.rows.length < oldWidget.rows.length
+        ? widget.rows.length
+        : oldWidget.rows.length;
+    for (var row = 0; row < shared; row++) {
+      if (widget.rows[row].length > oldWidget.rows[row].length) {
+        _scheduleScrollToNewToken(
+          _rowScrollControllers[row],
+          atStart: _grewAtStart(oldWidget.rows[row], widget.rows[row]),
+        );
+      }
     }
-    if (widget.row1Tokens.length > oldWidget.row1Tokens.length) {
-      _scheduleScrollToNewToken(
-        _row1ScrollController,
-        atStart: _grewAtStart(oldWidget.row1Tokens, widget.row1Tokens),
-      );
+  }
+
+  /// スクロール制御の本数を行数に合わせる（余った分は破棄する）。
+  void _syncRowControllers(int rowCount) {
+    while (_rowScrollControllers.length < rowCount) {
+      _rowScrollControllers.add(ScrollController());
     }
-    if (widget.row2Tokens.length > oldWidget.row2Tokens.length) {
-      _scheduleScrollToNewToken(
-        _row2ScrollController,
-        atStart: _grewAtStart(oldWidget.row2Tokens, widget.row2Tokens),
-      );
+    while (_rowScrollControllers.length > rowCount) {
+      _rowScrollControllers.removeLast().dispose();
     }
   }
 
@@ -180,9 +176,9 @@ class _SpecialKeysBarState extends State<SpecialKeysBar> {
     _directInputController.removeListener(_onDirectInputChanged);
     _directInputController.dispose();
     _directInputFocusNode.dispose();
-    _row0ScrollController.dispose();
-    _row1ScrollController.dispose();
-    _row2ScrollController.dispose();
+    for (final controller in _rowScrollControllers) {
+      controller.dispose();
+    }
     super.dispose();
   }
 
@@ -527,18 +523,13 @@ class _SpecialKeysBarState extends State<SpecialKeysBar> {
     final colorScheme = Theme.of(context).colorScheme;
 
     // Rows render exactly the tokens they hold, subject to mode skips.
-    final row0Tokens = _visibleTokens(widget.row0Tokens);
-    final row1Tokens = _visibleTokens(widget.row1Tokens);
-    final row2Tokens = _visibleTokens(widget.row2Tokens);
+    final visibleRows = [for (final row in widget.rows) _visibleTokens(row)];
 
-    // The manage (pencil) button is pinned to the end of row 0, the custom
-    // row: that is where the user's own buttons live. Row 0 is empty by
-    // default, so when it renders nothing the pencil falls back to the first
-    // row that does render (row 1, else row 2) and the editor entry point
-    // never disappears while the bar is visible.
-    final bool row0HostsPencil = row0Tokens.isNotEmpty;
-    final bool row1HostsPencil = !row0HostsPencil && row1Tokens.isNotEmpty;
-    final bool row2HostsPencil = !row0HostsPencil && !row1HostsPencil;
+    // The manage (pencil) button is pinned to the end of the first row that
+    // renders anything — the top row is the custom row, so it lands next to
+    // the user's own buttons. When no row renders (every row empty, or no rows
+    // at all) a pencil-only strip keeps the editor reachable.
+    final pencilHost = visibleRows.indexWhere((row) => row.isNotEmpty);
 
     return Container(
       decoration: BoxDecoration(
@@ -552,9 +543,9 @@ class _SpecialKeysBarState extends State<SpecialKeysBar> {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            _buildRow0(row0Tokens, hostsPencil: row0HostsPencil),
-            _buildRow1(row1Tokens, hostsPencil: row1HostsPencil),
-            _buildRow2(row2Tokens, hostsPencil: row2HostsPencil),
+            for (var row = 0; row < visibleRows.length; row++)
+              _buildRow(row, visibleRows[row], hostsPencil: row == pencilHost),
+            if (pencilHost < 0) _buildPencilOnlyRow(),
             if (widget.directInputEnabled) _buildDirectInputRow(),
             const SizedBox(height: 4),
           ],
@@ -563,44 +554,31 @@ class _SpecialKeysBarState extends State<SpecialKeysBar> {
     );
   }
 
-  /// 行0（専用カスタムキー行）：保持するトークンを順に描画する。
-  Widget _buildRow0(List<String> tokens, {required bool hostsPencil}) {
-    return _buildGenericTokenRow(
-      tokens: tokens,
-      height: 32,
-      scrollController: _row0ScrollController,
-      showManageButton: hostsPencil,
-    );
-  }
-
-  /// 行1（修飾キー行）。既定レイアウトは従来の固定描画を維持し、
-  /// それ以外は汎用の水平スクロール行で描画する。
-  Widget _buildRow1(List<String> tokens, {required bool hostsPencil}) {
-    if (listEquals(widget.row1Tokens, CustomKeyRows.standardRow1)) {
+  /// 1行を描画する。既定と完全一致する行だけ従来の固定描画を使い、それ以外は
+  /// 汎用の水平スクロール行で描く（判定は行の内容だけで、行番号には依らない）。
+  Widget _buildRow(int row, List<String> tokens, {required bool hostsPencil}) {
+    final stored = widget.rows[row];
+    if (listEquals(stored, CustomKeyRows.standardRow1)) {
       return _buildLegacyModifierKeysRow(withManageButton: hostsPencil);
     }
-    return _buildGenericTokenRow(
-      tokens: tokens,
-      height: 32,
-      scrollController: _row1ScrollController,
-      showManageButton: hostsPencil,
-    );
-  }
-
-  /// 行2（ナビゲーション行）。既定レイアウトは従来の固定描画を維持し、
-  /// それ以外（鉛筆ボタンの受け皿になる場合も含む）は汎用行で描画する。
-  Widget _buildRow2(List<String> tokens, {required bool hostsPencil}) {
-    if (listEquals(widget.row2Tokens, CustomKeyRows.standardRow2) &&
-        !hostsPencil) {
+    if (listEquals(stored, CustomKeyRows.standardRow2) && !hostsPencil) {
       return _buildLegacyArrowKeysRow();
     }
     return _buildGenericTokenRow(
       tokens: tokens,
-      height: 36,
-      scrollController: _row2ScrollController,
+      height: 32,
+      scrollController: _rowScrollControllers[row],
       showManageButton: hostsPencil,
     );
   }
+
+  /// トークンを描く行が1つも無いときの受け皿（鉛筆ボタンのみ）。
+  Widget _buildPencilOnlyRow() => _buildGenericTokenRow(
+    tokens: const <String>[],
+    height: 32,
+    scrollController: null,
+    showManageButton: true,
+  );
 
   /// 行1の従来レイアウト（ESC…dash、必要なら鉛筆ボタン）。既定レイアウト専用。
   Widget _buildLegacyModifierKeysRow({required bool withManageButton}) {
@@ -672,7 +650,7 @@ class _SpecialKeysBarState extends State<SpecialKeysBar> {
   Widget _buildGenericTokenRow({
     required List<String> tokens,
     required double height,
-    required ScrollController scrollController,
+    ScrollController? scrollController,
     required bool showManageButton,
   }) {
     if (tokens.isEmpty && !showManageButton) {

--- a/lib/widgets/special_keys_bar.dart
+++ b/lib/widgets/special_keys_bar.dart
@@ -1,8 +1,11 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:google_fonts/google_fonts.dart';
 
 import '../theme/design_colors.dart';
+import '../services/custom_keys/custom_key_button.dart';
+import 'custom_key_button_widget.dart';
 import '../l10n/l10n_ext.dart';
 
 /// 特殊キーバー（HTMLデザイン仕様準拠）
@@ -28,6 +31,24 @@ class SpecialKeysBar extends StatefulWidget {
   /// 画像転送ボタンが押された時のコールバック
   final VoidCallback? onImagePickRequested;
 
+  /// カスタムキーボタン（ユーザー定義ボタン）
+  final List<CustomKeyButton> customButtons;
+
+  /// 行0（専用カスタムキー行）のトークン列
+  final List<String> row0Tokens;
+
+  /// 行1（修飾キー行）のトークン列
+  final List<String> row1Tokens;
+
+  /// 行2（ナビゲーション行）のトークン列
+  final List<String> row2Tokens;
+
+  /// カスタムボタン編集リクエスト（長押し）
+  final void Function(CustomKeyButton)? onCustomButtonEdit;
+
+  /// ボタン管理画面を開くリクエスト（鉛筆ボタン）
+  final VoidCallback? onManageButtons;
+
   const SpecialKeysBar({
     super.key,
     required this.onKeyPressed,
@@ -37,6 +58,12 @@ class SpecialKeysBar extends StatefulWidget {
     this.directInputEnabled = false,
     this.onDirectInputToggle,
     this.onImagePickRequested,
+    this.customButtons = const [],
+    required this.row0Tokens,
+    this.row1Tokens = CustomKeyRows.standardRow1,
+    this.row2Tokens = CustomKeyRows.standardRow2,
+    this.onCustomButtonEdit,
+    this.onManageButtons,
   });
 
   @override
@@ -49,6 +76,15 @@ class _SpecialKeysBarState extends State<SpecialKeysBar> {
   bool _shiftPressed = false;
   final TextEditingController _directInputController = TextEditingController();
   final FocusNode _directInputFocusNode = FocusNode();
+
+  /// DirectInput: 端末へ送信済みの可視テキスト（デルタ送信用）
+  /// 入力欄にテキストを残したまま追加分のみ送信するために保持する
+  String _sentText = '';
+
+  /// 行0・行1・行2の水平スクロール制御（新規ボタン追加時に末尾へ自動スクロール）
+  final ScrollController _row0ScrollController = ScrollController();
+  final ScrollController _row1ScrollController = ScrollController();
+  final ScrollController _row2ScrollController = ScrollController();
 
   /// 現在IME変換中かどうか
   bool _isComposing = false;
@@ -92,7 +128,51 @@ class _SpecialKeysBarState extends State<SpecialKeysBar> {
       _isResettingController = true;
       _directInputController.clear();
       _isResettingController = false;
+      _sentText = '';
     }
+    // 新規ボタンが追加されたら、その位置（先頭/末尾）まで自動スクロールする
+    if (widget.row0Tokens.length > oldWidget.row0Tokens.length) {
+      _scheduleScrollToNewToken(
+        _row0ScrollController,
+        atStart: _grewAtStart(oldWidget.row0Tokens, widget.row0Tokens),
+      );
+    }
+    if (widget.row1Tokens.length > oldWidget.row1Tokens.length) {
+      _scheduleScrollToNewToken(
+        _row1ScrollController,
+        atStart: _grewAtStart(oldWidget.row1Tokens, widget.row1Tokens),
+      );
+    }
+    if (widget.row2Tokens.length > oldWidget.row2Tokens.length) {
+      _scheduleScrollToNewToken(
+        _row2ScrollController,
+        atStart: _grewAtStart(oldWidget.row2Tokens, widget.row2Tokens),
+      );
+    }
+  }
+
+  /// 追加されたトークンが行の先頭かどうか（先頭挿入なら true）
+  static bool _grewAtStart(List<String> before, List<String> after) {
+    if (before.isEmpty) return false;
+    return after.first != before.first;
+  }
+
+  /// 行の水平スクロールを新規ボタンの位置まで移動する
+  void _scheduleScrollToNewToken(
+    ScrollController controller, {
+    required bool atStart,
+  }) {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted || !controller.hasClients) return;
+      final position = controller.position;
+      if (position.maxScrollExtent > 0) {
+        controller.animateTo(
+          atStart ? 0 : position.maxScrollExtent,
+          duration: const Duration(milliseconds: 200),
+          curve: Curves.easeOut,
+        );
+      }
+    });
   }
 
   @override
@@ -100,6 +180,9 @@ class _SpecialKeysBarState extends State<SpecialKeysBar> {
     _directInputController.removeListener(_onDirectInputChanged);
     _directInputController.dispose();
     _directInputFocusNode.dispose();
+    _row0ScrollController.dispose();
+    _row1ScrollController.dispose();
+    _row2ScrollController.dispose();
     super.dispose();
   }
 
@@ -152,7 +235,7 @@ class _SpecialKeysBarState extends State<SpecialKeysBar> {
       return;
     }
 
-    // Sentinelが削除された = Backspaceが押された（iOS/iPadOS対応）
+    // Sentinelが削除された = 全テキスト削除（iOS/iPadOS対応のBackspace検出）
     if (text.isEmpty) {
       _lastComposingText = null;
       _sendDirectBackspace();
@@ -163,31 +246,44 @@ class _SpecialKeysBarState extends State<SpecialKeysBar> {
     // Sentinelを除去して実際の入力テキストを取得
     final actualText = text.replaceAll(_sentinel, '');
 
-    // 実際のテキストがあれば送信
-    if (actualText.isNotEmpty) {
-      // 外付けキーボードの二重入力防止: _handleKeyEventで処理済みならスキップ
-      if (_isRecentKeyEventHandled()) {
-        _lastComposingText = null;
-        _resetToSentinel();
-        return;
-      }
-
-      // iOS重複検出: 確定テキストがcomposingテキストより長く、
-      // composingテキストで始まる場合、iOSの重複挿入とみなしcomposingテキストを使用
-      String textToSend = actualText;
-      if (_lastComposingText != null &&
-          actualText.length > _lastComposingText!.length &&
-          actualText.startsWith(_lastComposingText!)) {
-        textToSend = _lastComposingText!;
-      }
+    // 外付けキーボードの二重入力防止: _handleKeyEventで処理済みならスキップ
+    if (_isRecentKeyEventHandled()) {
       _lastComposingText = null;
+      // キーイベント側で送信済みなので、欄のテキストは残したまま送信済みとして記録
+      _sentText = actualText;
+      return;
+    }
 
+    // 変化なし（IMEノイズ）なら何もしない
+    if (actualText == _sentText) return;
+    _lastComposingText = null;
+
+    // デルタ送信: 送信済みテキストとの共通接頭辞を除いた差分のみを送信する。
+    // 入力欄にテキストを残して可視化しつつ、追加分は逐次送信、
+    // 削除分はBSpaceを送信する。
+    var common = 0;
+    final minLen = _sentText.length < actualText.length
+        ? _sentText.length
+        : actualText.length;
+    while (common < minLen && _sentText[common] == actualText[common]) {
+      common++;
+    }
+    final removed = _sentText.length - common;
+    final appended = actualText.substring(common);
+
+    if (removed > 0) {
+      for (var r = 0; r < removed; r++) {
+        _sendDirectBackspace();
+      }
+    }
+
+    if (appended.isNotEmpty) {
       // Send modifier+key when CTRL/ALT is active (non-composing path)
       // This handles IMEs that commit without composing (e.g. Gboard English)
       // tmux format: C-c (Ctrl+C), M-a (Alt+A), C-M-x (Ctrl+Alt+X)
       if ((_ctrlPressed || _altPressed) &&
-          textToSend.length == 1 &&
-          RegExp(r'^[A-Za-z]$').hasMatch(textToSend)) {
+          appended.length == 1 &&
+          RegExp(r'^[A-Za-z]$').hasMatch(appended)) {
         if (widget.hapticFeedback) {
           HapticFeedback.lightImpact();
         }
@@ -201,14 +297,24 @@ class _SpecialKeysBarState extends State<SpecialKeysBar> {
           setState(() => _altPressed = false);
         }
         final prefix = modifiers.join('-');
-        widget.onSpecialKeyPressed('$prefix-${textToSend.toLowerCase()}');
-      } else {
-        widget.onKeyPressed(textToSend);
+        widget.onSpecialKeyPressed('$prefix-${appended.toLowerCase()}');
+
+        // 修飾キーとして消費した文字を入力欄から除去し、可視テキストと整合させる
+        final kept = actualText.substring(0, common);
+        _isResettingController = true;
+        _directInputController.value = TextEditingValue(
+          text: _sentinel + kept,
+          selection: TextSelection.collapsed(offset: kept.length + 1),
+        );
+        _isResettingController = false;
+        _sentText = kept;
+        return;
       }
 
-      // 送信後にsentinelにリセット
-      _resetToSentinel();
+      widget.onKeyPressed(appended);
     }
+
+    _sentText = actualText;
   }
 
   /// DirectInput: ソフトウェアキーボードのEnter（送信）で呼ばれる
@@ -237,6 +343,7 @@ class _SpecialKeysBarState extends State<SpecialKeysBar> {
   /// iOSプラットフォームがIME確定時に送る遅延テキスト更新を吸収する。
   /// PostFrameCallbackでcontrollerが上書きされていれば再度sentinelにリセットする。
   void _resetToSentinel() {
+    _sentText = '';
     _isResettingController = true;
     _directInputController.value = TextEditingValue(
       text: _sentinel,
@@ -418,6 +525,20 @@ class _SpecialKeysBarState extends State<SpecialKeysBar> {
   Widget build(BuildContext context) {
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final colorScheme = Theme.of(context).colorScheme;
+
+    // Rows render exactly the tokens they hold, subject to mode skips.
+    final row0Tokens = _visibleTokens(widget.row0Tokens);
+    final row1Tokens = _visibleTokens(widget.row1Tokens);
+    final row2Tokens = _visibleTokens(widget.row2Tokens);
+
+    // The manage (pencil) button is pinned to the end of row 1 while that
+    // row renders; when row 1 renders nothing it moves to the first row that
+    // does render (row 0, else row 2) so the editor entry point never
+    // disappears while the bar is visible.
+    final bool row1HostsPencil = row1Tokens.isNotEmpty;
+    final bool row0HostsPencil = !row1HostsPencil && row0Tokens.isNotEmpty;
+    final bool row2HostsPencil = !row1HostsPencil && !row0HostsPencil;
+
     return Container(
       decoration: BoxDecoration(
         color: isDark
@@ -430,8 +551,9 @@ class _SpecialKeysBarState extends State<SpecialKeysBar> {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            _buildModifierKeysRow(),
-            _buildArrowKeysRow(),
+            _buildRow0(row0Tokens, hostsPencil: row0HostsPencil),
+            _buildRow1(row1Tokens, hostsPencil: row1HostsPencil),
+            _buildRow2(row2Tokens, hostsPencil: row2HostsPencil),
             if (widget.directInputEnabled) _buildDirectInputRow(),
             const SizedBox(height: 4),
           ],
@@ -440,8 +562,47 @@ class _SpecialKeysBarState extends State<SpecialKeysBar> {
     );
   }
 
-  /// 上部の修飾キー行（ESC, TAB, CTRL, ALT, SHIFT, ENTER, S-RET, /, -）
-  Widget _buildModifierKeysRow() {
+  /// 行0（専用カスタムキー行）：保持するトークンを順に描画する。
+  Widget _buildRow0(List<String> tokens, {required bool hostsPencil}) {
+    return _buildGenericTokenRow(
+      tokens: tokens,
+      height: 32,
+      scrollController: _row0ScrollController,
+      showManageButton: hostsPencil,
+    );
+  }
+
+  /// 行1（修飾キー行）。既定レイアウトは従来の固定描画を維持し、
+  /// それ以外は汎用の水平スクロール行で描画する。
+  Widget _buildRow1(List<String> tokens, {required bool hostsPencil}) {
+    if (listEquals(widget.row1Tokens, CustomKeyRows.standardRow1)) {
+      return _buildLegacyModifierKeysRow();
+    }
+    return _buildGenericTokenRow(
+      tokens: tokens,
+      height: 32,
+      scrollController: _row1ScrollController,
+      showManageButton: hostsPencil,
+    );
+  }
+
+  /// 行2（ナビゲーション行）。既定レイアウトは従来の固定描画を維持し、
+  /// それ以外（鉛筆ボタンの受け皿になる場合も含む）は汎用行で描画する。
+  Widget _buildRow2(List<String> tokens, {required bool hostsPencil}) {
+    if (listEquals(widget.row2Tokens, CustomKeyRows.standardRow2) &&
+        !hostsPencil) {
+      return _buildLegacyArrowKeysRow();
+    }
+    return _buildGenericTokenRow(
+      tokens: tokens,
+      height: 36,
+      scrollController: _row2ScrollController,
+      showManageButton: hostsPencil,
+    );
+  }
+
+  /// 行1の従来レイアウト（ESC…dash + 鉛筆ボタン）。既定レイアウト専用。
+  Widget _buildLegacyModifierKeysRow() {
     final isDark = Theme.of(context).brightness == Brightness.dark;
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 4),
@@ -463,117 +624,14 @@ class _SpecialKeysBarState extends State<SpecialKeysBar> {
           _buildShiftEnterKeyButton(),
           _buildLiteralKeyButton('/', '/'),
           _buildLiteralKeyButton('-', '-'),
+          _buildManageButton(),
         ],
       ),
     );
   }
 
-  /// Shift+Enterキーボタン（Claude CodeのAcceptEdits等用）
-  Widget _buildShiftEnterKeyButton() {
-    return Expanded(
-      child: GestureDetector(
-        onTapDown: (_) {
-          if (widget.hapticFeedback) {
-            HapticFeedback.lightImpact();
-          }
-        },
-        onTap: () => _sendSpecialKey('S-Enter'),
-        child: Container(
-          height: 32,
-          margin: const EdgeInsets.symmetric(horizontal: 2),
-          decoration: BoxDecoration(
-            color: DesignColors.secondary.withValues(alpha: 0.3),
-            borderRadius: BorderRadius.circular(4),
-            border: Border(
-              bottom: BorderSide(
-                color: DesignColors.secondary.withValues(alpha: 0.5),
-                width: 2,
-              ),
-            ),
-            boxShadow: [
-              BoxShadow(
-                color: Colors.black.withValues(alpha: 0.3),
-                blurRadius: 2,
-                offset: const Offset(0, 1),
-              ),
-            ],
-          ),
-          child: Center(
-            child: Text(
-              'S-RET',
-              style: GoogleFonts.jetBrainsMono(
-                fontSize: 8,
-                fontWeight: FontWeight.w700,
-                color: DesignColors.secondary,
-              ),
-            ),
-          ),
-        ),
-      ),
-    );
-  }
-
-  /// ENTERキーボタン（単体でEnterを送信）
-  Widget _buildEnterKeyButton() {
-    return Expanded(
-      child: GestureDetector(
-        onTapDown: (_) {
-          if (widget.hapticFeedback) {
-            HapticFeedback.lightImpact();
-          }
-        },
-        onTap: () => _sendSpecialKey('Enter'),
-        child: Container(
-          height: 32,
-          margin: const EdgeInsets.symmetric(horizontal: 2),
-          decoration: BoxDecoration(
-            color: DesignColors.primary.withValues(alpha: 0.3),
-            borderRadius: BorderRadius.circular(4),
-            border: Border(
-              bottom: BorderSide(
-                color: DesignColors.primary.withValues(alpha: 0.5),
-                width: 2,
-              ),
-            ),
-            boxShadow: [
-              BoxShadow(
-                color: Colors.black.withValues(alpha: 0.3),
-                blurRadius: 2,
-                offset: const Offset(0, 1),
-              ),
-            ],
-          ),
-          child: Center(
-            child: FittedBox(
-              fit: BoxFit.scaleDown,
-              child: Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Icon(
-                    Icons.keyboard_return,
-                    size: 12,
-                    color: DesignColors.primary,
-                  ),
-                  const SizedBox(width: 2),
-                  Text(
-                    'RET',
-                    style: GoogleFonts.jetBrainsMono(
-                      fontSize: 9,
-                      fontWeight: FontWeight.w700,
-                      color: DesignColors.primary,
-                    ),
-                  ),
-                ],
-              ),
-            ),
-          ),
-        ),
-      ),
-    );
-  }
-
-  /// 下部の矢印キー + Inputボタン行
-  Widget _buildArrowKeysRow() {
+  /// 行2の従来レイアウト（ナビゲーション + 数字/Input）。既定レイアウト専用。
+  Widget _buildLegacyArrowKeysRow() {
     if (widget.directInputEnabled) {
       return SingleChildScrollView(
         scrollDirection: Axis.horizontal,
@@ -604,6 +662,286 @@ class _SpecialKeysBarState extends State<SpecialKeysBar> {
           const SizedBox(width: 4),
           Expanded(child: _buildInputButton()),
         ],
+      ),
+    );
+  }
+
+  /// 汎用の水平スクロール行：保持トークンを順に描画し、必要なら
+  /// 鉛筆ボタンをスクロールの外に固定する。
+  Widget _buildGenericTokenRow({
+    required List<String> tokens,
+    required double height,
+    required ScrollController scrollController,
+    required bool showManageButton,
+  }) {
+    if (tokens.isEmpty && !showManageButton) {
+      return const SizedBox.shrink();
+    }
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 4),
+      color: isDark ? DesignColors.surfaceDark : DesignColors.surfaceLight,
+      child: Row(
+        children: [
+          if (tokens.isNotEmpty)
+            Expanded(
+              child: SingleChildScrollView(
+                controller: scrollController,
+                scrollDirection: Axis.horizontal,
+                child: Row(
+                  children: [
+                    for (final token in tokens) ...[
+                      _buildToken(token, height: height),
+                      const SizedBox(width: 2),
+                    ],
+                  ],
+                ),
+              ),
+            )
+          else
+            const Spacer(),
+          if (showManageButton) _buildManageButton(),
+        ],
+      ),
+    );
+  }
+
+  /// モード依存のスキップを適用した可視トークン列。
+  List<String> _visibleTokens(List<String> tokens) =>
+      tokens.where(_shouldRenderToken).toList();
+
+  /// 標準トークン・カスタムトークンを問わず単一トークンを描画する。
+  /// [height] はカスタムボタンの高さ（行0/行1=32、行2=36）。
+  Widget _buildToken(String token, {required double height}) {
+    switch (token) {
+      case 'esc':
+        return _buildSpecialKeyButton('ESC', 'Escape', width: 40);
+      case 'tab':
+        return _buildSpecialKeyButton('TAB', 'Tab', width: 40);
+      case 'ctrl':
+        return _buildModifierButton('CTRL', _ctrlPressed, () {
+          setState(() => _ctrlPressed = !_ctrlPressed);
+        }, width: 44);
+      case 'alt':
+        return _buildModifierButton('ALT', _altPressed, () {
+          setState(() => _altPressed = !_altPressed);
+        }, width: 44);
+      case 'shift':
+        return _buildModifierButton('SHIFT', _shiftPressed, () {
+          setState(() => _shiftPressed = !_shiftPressed);
+        }, width: 48);
+      case 'enter':
+        return _buildEnterKeyButton(width: 56);
+      case 'senter':
+        return _buildShiftEnterKeyButton(width: 56);
+      case 'slash':
+        return _buildLiteralKeyButton('/', '/', width: 32);
+      case 'dash':
+        return _buildLiteralKeyButton('-', '-', width: 32);
+      case 'pgup':
+        return _buildNavigationKeyButton('PgUp', 'PPage');
+      case 'pgdn':
+        return _buildNavigationKeyButton('PgDn', 'NPage');
+      case 'left':
+        return _buildArrowButton(Icons.arrow_left, 'Left');
+      case 'up':
+        return _buildArrowButton(Icons.arrow_drop_up, 'Up');
+      case 'down':
+        return _buildArrowButton(Icons.arrow_drop_down, 'Down');
+      case 'right':
+        return _buildArrowButton(Icons.arrow_right, 'Right');
+      case 'image':
+        return _buildImageTransferButton();
+      case 'di_toggle':
+        return _buildDirectInputToggle();
+      case 'input':
+        return SizedBox(width: 64, child: _buildInputButton());
+      case 'num1':
+        return _buildNumberKeyButton('1');
+      case 'num2':
+        return _buildNumberKeyButton('2');
+      case 'num3':
+        return _buildNumberKeyButton('3');
+      case 'num4':
+        return _buildNumberKeyButton('4');
+      default:
+        final button = _buttonForToken(token);
+        if (button == null) return const SizedBox.shrink();
+        return SizedBox(
+          width: _labelWidth(button.label),
+          child: _buildCustomKeyButton(button, height: height),
+        );
+    }
+  }
+
+  /// モード依存のトークンスキップ（input / num1..num4 / image）
+  bool _shouldRenderToken(String token) {
+    if (token == 'input') return !widget.directInputEnabled;
+    if (CustomKeyRows.directInputExtras.contains(token)) {
+      return widget.directInputEnabled;
+    }
+    if (token == 'image') return widget.onImagePickRequested != null;
+    return true;
+  }
+
+  /// カスタムボタンのトークン解決（`ck:<id-suffix>` → CustomKeyButton）
+  CustomKeyButton? _buttonForToken(String token) {
+    if (!CustomKeyRows.isCustomToken(token)) return null;
+    final id = 'ck_${token.substring(3)}';
+    for (final b in widget.customButtons) {
+      if (b.id == id) return b;
+    }
+    return null;
+  }
+
+  /// ラベル長に応じたカスタムボタン幅（44〜96px）
+  double _labelWidth(String label) =>
+      (label.length * 7.0 + 14.0).clamp(44.0, 96.0).toDouble();
+
+  /// カスタムボタン：タップ時にソフトウェア修飾子をリセットしてから送信
+  Widget _buildCustomKeyButton(CustomKeyButton button, {double height = 32}) {
+    return CustomKeyButtonWidget(
+      button: button,
+      height: height,
+      onKeyPressed: (key) {
+        _resetSoftwareModifiers();
+        widget.onKeyPressed(key);
+      },
+      onSpecialKeyPressed: (key) {
+        _resetSoftwareModifiers();
+        widget.onSpecialKeyPressed(key);
+      },
+      onEdit: (b) => widget.onCustomButtonEdit?.call(b),
+      hapticFeedback: widget.hapticFeedback,
+    );
+  }
+
+  /// Shift+Enterキーボタン（Claude CodeのAcceptEdits等用）
+  Widget _buildShiftEnterKeyButton({double? width}) {
+    final button = GestureDetector(
+      onTapDown: (_) {
+        if (widget.hapticFeedback) {
+          HapticFeedback.lightImpact();
+        }
+      },
+      onTap: () => _sendSpecialKey('S-Enter'),
+      child: Container(
+        height: 32,
+        margin: const EdgeInsets.symmetric(horizontal: 2),
+        decoration: BoxDecoration(
+          color: DesignColors.secondary.withValues(alpha: 0.3),
+          borderRadius: BorderRadius.circular(4),
+          border: Border(
+            bottom: BorderSide(
+              color: DesignColors.secondary.withValues(alpha: 0.5),
+              width: 2,
+            ),
+          ),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withValues(alpha: 0.3),
+              blurRadius: 2,
+              offset: const Offset(0, 1),
+            ),
+          ],
+        ),
+        child: Center(
+          child: Text(
+            'S-RET',
+            style: GoogleFonts.jetBrainsMono(
+              fontSize: 8,
+              fontWeight: FontWeight.w700,
+              color: DesignColors.secondary,
+            ),
+          ),
+        ),
+      ),
+    );
+    return width == null
+        ? Expanded(child: button)
+        : SizedBox(width: width, child: button);
+  }
+
+  /// ENTERキーボタン（単体でEnterを送信）
+  Widget _buildEnterKeyButton({double? width}) {
+    final button = GestureDetector(
+      onTapDown: (_) {
+        if (widget.hapticFeedback) {
+          HapticFeedback.lightImpact();
+        }
+      },
+      onTap: () => _sendSpecialKey('Enter'),
+      child: Container(
+        height: 32,
+        margin: const EdgeInsets.symmetric(horizontal: 2),
+        decoration: BoxDecoration(
+          color: DesignColors.primary.withValues(alpha: 0.3),
+          borderRadius: BorderRadius.circular(4),
+          border: Border(
+            bottom: BorderSide(
+              color: DesignColors.primary.withValues(alpha: 0.5),
+              width: 2,
+            ),
+          ),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withValues(alpha: 0.3),
+              blurRadius: 2,
+              offset: const Offset(0, 1),
+            ),
+          ],
+        ),
+        child: Center(
+          child: FittedBox(
+            fit: BoxFit.scaleDown,
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Icon(
+                  Icons.keyboard_return,
+                  size: 12,
+                  color: DesignColors.primary,
+                ),
+                const SizedBox(width: 2),
+                Text(
+                  'RET',
+                  style: GoogleFonts.jetBrainsMono(
+                    fontSize: 9,
+                    fontWeight: FontWeight.w700,
+                    color: DesignColors.primary,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+    return width == null
+        ? Expanded(child: button)
+        : SizedBox(width: width, child: button);
+  }
+
+  /// ボタン管理画面を開く鉛筆ボタン（32×32、行1末尾・スクロール外に固定）
+  Widget _buildManageButton() {
+    return GestureDetector(
+      onTap: () {
+        if (widget.hapticFeedback) {
+          HapticFeedback.selectionClick();
+        }
+        widget.onManageButtons?.call();
+      },
+      child: Container(
+        width: 32,
+        height: 32,
+        decoration: BoxDecoration(
+          color: DesignColors.keyBackground,
+          borderRadius: BorderRadius.circular(4),
+          border: Border.all(color: Colors.white.withValues(alpha: 0.05)),
+        ),
+        child: const Center(
+          child: Icon(Icons.edit_outlined, size: 18, color: Colors.white70),
+        ),
       ),
     );
   }
@@ -762,157 +1100,161 @@ class _SpecialKeysBarState extends State<SpecialKeysBar> {
   }
 
   /// 特殊キーボタン（tmux形式で送信）
-  Widget _buildSpecialKeyButton(String label, String tmuxKey) {
+  Widget _buildSpecialKeyButton(String label, String tmuxKey, {double? width}) {
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final colorScheme = Theme.of(context).colorScheme;
-    return Expanded(
-      child: GestureDetector(
-        onTapDown: (_) {
-          if (widget.hapticFeedback) {
-            HapticFeedback.lightImpact();
-          }
-        },
-        onTap: () => _sendSpecialKey(tmuxKey),
-        child: Container(
-          height: 32,
-          margin: const EdgeInsets.symmetric(horizontal: 2),
-          decoration: BoxDecoration(
-            color: isDark
-                ? DesignColors.keyBackground
-                : DesignColors.keyBackgroundLight,
-            borderRadius: BorderRadius.circular(4),
-            border: Border(
-              bottom: BorderSide(
-                color: isDark ? Colors.black : Colors.grey.shade400,
-                width: 2,
-              ),
+    final button = GestureDetector(
+      onTapDown: (_) {
+        if (widget.hapticFeedback) {
+          HapticFeedback.lightImpact();
+        }
+      },
+      onTap: () => _sendSpecialKey(tmuxKey),
+      child: Container(
+        height: 32,
+        margin: const EdgeInsets.symmetric(horizontal: 2),
+        decoration: BoxDecoration(
+          color: isDark
+              ? DesignColors.keyBackground
+              : DesignColors.keyBackgroundLight,
+          borderRadius: BorderRadius.circular(4),
+          border: Border(
+            bottom: BorderSide(
+              color: isDark ? Colors.black : Colors.grey.shade400,
+              width: 2,
             ),
-            boxShadow: [
-              BoxShadow(
-                color: Colors.black.withValues(alpha: isDark ? 0.3 : 0.15),
-                blurRadius: 2,
-                offset: const Offset(0, 1),
-              ),
-            ],
           ),
-          child: Center(
-            child: Text(
-              label,
-              style: GoogleFonts.jetBrainsMono(
-                fontSize: 10,
-                fontWeight: FontWeight.w700,
-                color: colorScheme.onSurface.withValues(alpha: 0.9),
-              ),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withValues(alpha: isDark ? 0.3 : 0.15),
+              blurRadius: 2,
+              offset: const Offset(0, 1),
+            ),
+          ],
+        ),
+        child: Center(
+          child: Text(
+            label,
+            style: GoogleFonts.jetBrainsMono(
+              fontSize: 10,
+              fontWeight: FontWeight.w700,
+              color: colorScheme.onSurface.withValues(alpha: 0.9),
             ),
           ),
         ),
       ),
     );
+    return width == null
+        ? Expanded(child: button)
+        : SizedBox(width: width, child: button);
   }
 
   /// リテラルキーボタン（そのまま文字として送信）
-  Widget _buildLiteralKeyButton(String label, String key) {
+  Widget _buildLiteralKeyButton(String label, String key, {double? width}) {
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final colorScheme = Theme.of(context).colorScheme;
-    return Expanded(
-      child: GestureDetector(
-        onTapDown: (_) {
-          if (widget.hapticFeedback) {
-            HapticFeedback.lightImpact();
-          }
-        },
-        onTap: () => _sendLiteralKey(key),
-        child: Container(
-          height: 32,
-          margin: const EdgeInsets.symmetric(horizontal: 2),
-          decoration: BoxDecoration(
-            color: isDark
-                ? DesignColors.keyBackground
-                : DesignColors.keyBackgroundLight,
-            borderRadius: BorderRadius.circular(4),
-            border: Border(
-              bottom: BorderSide(
-                color: isDark ? Colors.black : Colors.grey.shade400,
-                width: 2,
-              ),
+    final button = GestureDetector(
+      onTapDown: (_) {
+        if (widget.hapticFeedback) {
+          HapticFeedback.lightImpact();
+        }
+      },
+      onTap: () => _sendLiteralKey(key),
+      child: Container(
+        height: 32,
+        margin: const EdgeInsets.symmetric(horizontal: 2),
+        decoration: BoxDecoration(
+          color: isDark
+              ? DesignColors.keyBackground
+              : DesignColors.keyBackgroundLight,
+          borderRadius: BorderRadius.circular(4),
+          border: Border(
+            bottom: BorderSide(
+              color: isDark ? Colors.black : Colors.grey.shade400,
+              width: 2,
             ),
-            boxShadow: [
-              BoxShadow(
-                color: Colors.black.withValues(alpha: isDark ? 0.3 : 0.15),
-                blurRadius: 2,
-                offset: const Offset(0, 1),
-              ),
-            ],
           ),
-          child: Center(
-            child: Text(
-              label,
-              style: GoogleFonts.jetBrainsMono(
-                fontSize: 10,
-                fontWeight: FontWeight.w700,
-                color: colorScheme.onSurface.withValues(alpha: 0.9),
-              ),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withValues(alpha: isDark ? 0.3 : 0.15),
+              blurRadius: 2,
+              offset: const Offset(0, 1),
+            ),
+          ],
+        ),
+        child: Center(
+          child: Text(
+            label,
+            style: GoogleFonts.jetBrainsMono(
+              fontSize: 10,
+              fontWeight: FontWeight.w700,
+              color: colorScheme.onSurface.withValues(alpha: 0.9),
             ),
           ),
         ),
       ),
     );
+    return width == null
+        ? Expanded(child: button)
+        : SizedBox(width: width, child: button);
   }
 
   Widget _buildModifierButton(
     String label,
     bool isPressed,
-    VoidCallback onPressed,
-  ) {
+    VoidCallback onPressed, {
+    double? width,
+  }) {
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final colorScheme = Theme.of(context).colorScheme;
-    return Expanded(
-      child: GestureDetector(
-        onTapDown: (_) {
-          if (widget.hapticFeedback) {
-            HapticFeedback.lightImpact();
-          }
-        },
-        onTap: onPressed,
-        child: Container(
-          height: 32,
-          margin: const EdgeInsets.symmetric(horizontal: 2),
-          decoration: BoxDecoration(
-            color: isPressed
-                ? colorScheme.primary
-                : (isDark
-                      ? DesignColors.keyBackground
-                      : DesignColors.keyBackgroundLight),
-            borderRadius: BorderRadius.circular(4),
-            border: Border(
-              bottom: BorderSide(
-                color: isPressed
-                    ? colorScheme.primary
-                    : (isDark ? Colors.black : Colors.grey.shade400),
-                width: 2,
-              ),
+    final button = GestureDetector(
+      onTapDown: (_) {
+        if (widget.hapticFeedback) {
+          HapticFeedback.lightImpact();
+        }
+      },
+      onTap: onPressed,
+      child: Container(
+        height: 32,
+        margin: const EdgeInsets.symmetric(horizontal: 2),
+        decoration: BoxDecoration(
+          color: isPressed
+              ? colorScheme.primary
+              : (isDark
+                    ? DesignColors.keyBackground
+                    : DesignColors.keyBackgroundLight),
+          borderRadius: BorderRadius.circular(4),
+          border: Border(
+            bottom: BorderSide(
+              color: isPressed
+                  ? colorScheme.primary
+                  : (isDark ? Colors.black : Colors.grey.shade400),
+              width: 2,
             ),
-            boxShadow: [
-              BoxShadow(
-                color: Colors.black.withValues(alpha: isDark ? 0.3 : 0.15),
-                blurRadius: 2,
-                offset: const Offset(0, 1),
-              ),
-            ],
           ),
-          child: Center(
-            child: Text(
-              label,
-              style: GoogleFonts.jetBrainsMono(
-                fontSize: 10,
-                fontWeight: FontWeight.w700,
-                color: isPressed ? colorScheme.onPrimary : colorScheme.primary,
-              ),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withValues(alpha: isDark ? 0.3 : 0.15),
+              blurRadius: 2,
+              offset: const Offset(0, 1),
+            ),
+          ],
+        ),
+        child: Center(
+          child: Text(
+            label,
+            style: GoogleFonts.jetBrainsMono(
+              fontSize: 10,
+              fontWeight: FontWeight.w700,
+              color: isPressed ? colorScheme.onPrimary : colorScheme.primary,
             ),
           ),
         ),
       ),
     );
+    return width == null
+        ? Expanded(child: button)
+        : SizedBox(width: width, child: button);
   }
 
   Widget _buildArrowButton(IconData icon, String tmuxKey) {

--- a/specs/004-custom-key-buttons/data-model.md
+++ b/specs/004-custom-key-buttons/data-model.md
@@ -88,10 +88,17 @@ skipped at render time (`input` in direct mode; `num1..num4` in normal mode).
 ### Default rows
 
 ```dart
-row0 = <String>[]  // dedicated custom row, top of the bar
-row1 = ['esc','tab','ctrl','alt','shift','enter','senter','slash','dash']
-row2 = ['pgup','pgdn','left','up','down','right','image','di_toggle','input']
+CustomKeyRows.defaultRows = [
+  <String>[],                                                       // custom row, top
+  ['esc','tab','ctrl','alt','shift','enter','senter','slash','dash'],
+  ['pgup','pgdn','left','up','down','right','image','di_toggle','input'],
+];
+CustomKeyRows.maxRows = 6;  // the bar's vertical budget
 ```
+
+The row count is dynamic: rows can be added and removed, so nothing may key
+behaviour off a row index. The two legacy layouts are recognised by CONTENT
+(`listEquals` against the modifier / navigation defaults).
 
 `num1..num4` belong to no default row: they are unplaced (Unused) until the
 user drags them in, and they only render while direct input is on.
@@ -110,10 +117,9 @@ user drags them in, and they only render while direct input is on.
 | key | content |
 |---|---|
 | `custom_key_buttons_v1` | JSON array of button objects |
-| `custom_key_row0_v1` | JSON array of tokens (custom row) |
-| `custom_key_row1_v1` | JSON array of tokens |
-| `custom_key_row2_v1` | JSON array of tokens |
+| `custom_key_rows_v1` | JSON array of arrays: the whole layout, top to bottom |
 | `custom_keys_shelf_v1` | bool marker: the num-token migration already ran |
+| `custom_key_row0_v1`, `custom_key_row1_v1`, `custom_key_row2_v1` | legacy, read once on migration and then deleted |
 
 Absent key → default (empty buttons, default rows). Corrupt value: wholly
 unparseable / non-array → default; partially invalid array → drop only the
@@ -123,26 +129,30 @@ the rest).
 The Unused shelf has no key of its own — it is derived from the rows, so the
 stored layout can never disagree with what the shelf shows.
 
-`_persist()` writes every row key on every load. Therefore the presence of a
+Older builds persisted every row key on every load, so the presence of a legacy
 row key says nothing about whether the user ever customized that row; the
 num-token migration compares the row against its default (`listEquals`) instead.
 
-### One-time migrations (on load)
+A stored layout longer than `maxRows` is truncated on load, and a corrupt value
+falls back to `defaultRows`.
 
-1. No `custom_key_row0_v1`: custom tokens found in row 1 / row 2 are hoisted
+### One-time migration (on load, when `custom_key_rows_v1` is absent)
+
+1. Read the three legacy keys (missing or corrupt → that row's default).
+2. No `custom_key_row0_v1`: custom tokens found in row 1 / row 2 are hoisted
    into row 0 (layouts written before the dedicated custom row existed).
-2. `custom_keys_shelf_v1` unset, row 2 differs from its default, and row 2 has
+3. `custom_keys_shelf_v1` unset, row 2 differs from its default, and row 2 has
    no `num1..num4`: append them once. Older builds injected the numbers at
    render time; making them real tokens keeps them draggable.
+4. Write `[row0, row1, row2]` under `custom_key_rows_v1` and delete the three
+   legacy keys.
 
 ## State (provider)
 
 ```dart
 class CustomKeysState {
   final List<CustomKeyButton> buttons;
-  final List<String> row0;
-  final List<String> row1;
-  final List<String> row2;
+  final List<List<String>> rows;   // top to bottom, 0..CustomKeyRows.maxRows
   // helpers:
   CustomKeyButton? buttonById(String id);
   List<CustomKeyButton> unplacedButtons();  // library minus every row
@@ -156,7 +166,9 @@ Provider API (`CustomKeysNotifier extends Notifier<CustomKeysState>`):
 CustomKeyButton addButton(String label, List<CustomKeyStep> steps);
 void updateButton(String id, {required String label, required List<CustomKeyStep> steps});
 void deleteButton(String id);            // removes ck: tokens from every row
-void setRowTokens(int row, List<String> tokens); // row: 0|1|2; validated before save
+void setRowTokens(int row, List<String> tokens); // row index; validated before save
+void addRow();            // appends an empty bottom row; no-op at maxRows
+void removeRow(int row);  // drops the row; its tokens return to the shelf
 void placeToken(String token, {required int toRow, required int toIndex});
 // toRow == CustomKeyRows.shelfRow parks the token outside the bar; the index is
 // read against the target row *before* the move, so a same-row drag to a higher

--- a/specs/004-custom-key-buttons/data-model.md
+++ b/specs/004-custom-key-buttons/data-model.md
@@ -1,0 +1,164 @@
+# 004 Custom Key Buttons — Data Model
+
+## CustomKeyStepType
+
+```dart
+enum CustomKeyStepType { text, key, pause }
+```
+
+## CustomKeyStep
+
+Immutable. One step of a button action.
+
+```dart
+class CustomKeyStep {
+  final CustomKeyStepType type;
+  final String value; // text: literal string; key: tmux key name; pause: ms as string
+}
+```
+
+Serialized (JSON object):
+
+```json
+{ "type": "text" | "key" | "pause", "value": "…" }
+```
+
+Semantics per type:
+
+| type | value | example | send path |
+|---|---|---|---|
+| `text` | literal string, sent as typed text | `"/models"` | `onKeyPressed(value)` |
+| `key` | tmux key name (same vocabulary as the bar's special keys) | `"Enter"`, `"Escape"`, `"C-c"`, `"S-Enter"`, `"BSpace"` | `onSpecialKeyPressed(value)` |
+| `pause` | positive integer, milliseconds | `"300"` | `await Future.delayed(Duration(milliseconds: int.parse(value)))` |
+
+Validation: `text`/`key` → non-empty trimmed value; `pause` → positive integer.
+
+## CustomKeyButton
+
+```dart
+class CustomKeyButton {
+  final String id;          // 'ck_' + epochMilliseconds + '_' + 4-hex rand, generated at creation
+  final String label;       // displayed on the button; non-empty after trim
+  final List<CustomKeyStep> steps; // non-empty
+}
+```
+
+Serialized (JSON object):
+
+```json
+{
+  "id": "ck_1755820000000_a1b2",
+  "label": "/models",
+  "steps": [
+    { "type": "text", "value": "/models" },
+    { "type": "key",  "value": "Enter" }
+  ]
+}
+```
+
+## Row layout tokens
+
+A row is `List<String>` of tokens. Standard tokens are the stable ids below;
+custom tokens carry the `ck:` prefix (e.g. `"ck:1755820000000_a1b2"`), so the
+two namespaces cannot collide.
+
+### Standard key id table
+
+Row 1 (modifier row), in canonical order:
+
+```
+esc  tab  ctrl  alt  shift  enter  senter  slash  dash
+```
+
+Row 2 (navigation row), in canonical order:
+
+```
+pgup  pgdn  left  up  down  right  image  di_toggle  input
+```
+
+Direct-input-mode extras (render only when `directInputEnabled`):
+
+```
+num1  num2  num3  num4
+```
+
+Mode-dependent standard tokens that cannot render in the current mode are
+skipped at render time (`input` in direct mode; `num1..num4` in normal mode).
+
+### Default rows
+
+```dart
+row0 = <String>[]  // dedicated custom row, top of the bar
+row1 = ['esc','tab','ctrl','alt','shift','enter','senter','slash','dash']
+row2 = ['pgup','pgdn','left','up','down','right','image','di_toggle','input']
+```
+
+`num1..num4` belong to no default row: they are unplaced (Unused) until the
+user drags them in, and they only render while direct input is on.
+
+### Token validation
+
+- Token is valid iff it is a standard id (in the table above) or starts with
+  `ck:` and its suffix matches an existing button id.
+- Unknown tokens (deleted button, corrupt data) are skipped at render and
+  removed on next save.
+- Any token may sit in any row at any index. Nothing is pinned: a standard token
+  can be reordered, moved to another row, or parked on the Unused shelf.
+
+## Persistence (shared_preferences)
+
+| key | content |
+|---|---|
+| `custom_key_buttons_v1` | JSON array of button objects |
+| `custom_key_row0_v1` | JSON array of tokens (custom row) |
+| `custom_key_row1_v1` | JSON array of tokens |
+| `custom_key_row2_v1` | JSON array of tokens |
+| `custom_keys_shelf_v1` | bool marker: the num-token migration already ran |
+
+Absent key → default (empty buttons, default rows). Corrupt value: wholly
+unparseable / non-array → default; partially invalid array → drop only the
+invalid entries, keep the valid ones (a single corrupt button must not wipe
+the rest).
+
+The Unused shelf has no key of its own — it is derived from the rows, so the
+stored layout can never disagree with what the shelf shows.
+
+`_persist()` writes every row key on every load. Therefore the presence of a
+row key says nothing about whether the user ever customized that row; the
+num-token migration compares the row against its default (`listEquals`) instead.
+
+### One-time migrations (on load)
+
+1. No `custom_key_row0_v1`: custom tokens found in row 1 / row 2 are hoisted
+   into row 0 (layouts written before the dedicated custom row existed).
+2. `custom_keys_shelf_v1` unset, row 2 differs from its default, and row 2 has
+   no `num1..num4`: append them once. Older builds injected the numbers at
+   render time; making them real tokens keeps them draggable.
+
+## State (provider)
+
+```dart
+class CustomKeysState {
+  final List<CustomKeyButton> buttons;
+  final List<String> row0;
+  final List<String> row1;
+  final List<String> row2;
+  // helpers:
+  CustomKeyButton? buttonById(String id);
+  List<CustomKeyButton> unplacedButtons();  // library minus every row
+  List<String> unusedTokens();              // standard + custom, canonical order
+}
+```
+
+Provider API (`CustomKeysNotifier extends Notifier<CustomKeysState>`):
+
+```dart
+CustomKeyButton addButton(String label, List<CustomKeyStep> steps);
+void updateButton(String id, {required String label, required List<CustomKeyStep> steps});
+void deleteButton(String id);            // removes ck: tokens from every row
+void setRowTokens(int row, List<String> tokens); // row: 0|1|2; validated before save
+void placeToken(String token, {required int toRow, required int toIndex});
+// toRow == CustomKeyRows.shelfRow parks the token outside the bar; the index is
+// read against the target row *before* the move, so a same-row drag to a higher
+// slot lands at toIndex - 1.
+```

--- a/specs/004-custom-key-buttons/spec.md
+++ b/specs/004-custom-key-buttons/spec.md
@@ -20,9 +20,10 @@ steps: literal text, special key (tmux key name), or pause.
 
 ## Decisions (from design Q&A)
 
-1. **Placement**: three rows are laid out by the user. Row 0 is a dedicated
-   custom row at the top, empty by default; row 1 is the modifier row and row 2
-   the navigation row, both starting from their historical defaults. Any token
+1. **Placement**: the bar is an ordered list of rows the user builds. The
+   default layout is three rows — an empty custom row on top, then the modifier
+   row and the navigation row at their historical contents. Rows can be added
+   ("+ Add row", up to `CustomKeyRows.maxRows` = 6) and deleted. Any token
    (standard or custom) may be placed in any row at any index, and tokens the
    user does not want are parked on an "Unused" shelf that is derived from the
    rows, not stored.
@@ -125,11 +126,11 @@ TerminalScreen ──> SpecialKeysBar ──> CustomKeyButtonWidget (render+exec
   `DesignColors.secondary` (amber) border/text — distinct from the cyan
   `primary` used by ENTER. Labels render on one line with `TextOverflow.ellipsis`.
 - **Pencil button**: fixed icon button (`Icons.edit_outlined`) pinned outside
-  the scroller at the end of row 0, next to the user's own buttons. Row 0 is
-  empty by default, and an empty row renders nothing, so the pencil then falls
-  back to row 1 (its historical place) and, if that is empty too, to row 2 —
-  the entry point never disappears while the bar is visible, and it is never
-  rendered twice. Tap → `onManageButtons()` (opens the full editor).
+  the scroller at the end of the FIRST row that renders anything — the top row
+  is the custom row, so it sits next to the user's own buttons. When no row
+  renders (every row empty, or no rows at all) the bar draws a pencil-only
+  strip, so the entry point never disappears and is never rendered twice.
+  Tap → `onManageButtons()` (opens the full editor).
 - **Auto-scroll**: when a row grows, it scrolls to reveal the new token — to the
   start when the token was prepended, to the end when appended.
 
@@ -155,8 +156,11 @@ TerminalScreen ──> SpecialKeysBar ──> CustomKeyButtonWidget (render+exec
     `"/models" + Enter`), tap → edit dialog, delete via trailing button,
     header "+ Add button" → add dialog, and the new button is placed at the head
     of the custom row so it is visible immediately.
-  - Sections "Layout — Custom Row" / "Layout — Row 1" / "Layout — Row 2" and
-    "Unused": each is a strip of chips. Every chip (standard or custom) is
+  - Sections "Layout — Row N" (1-based from the top, one per row) and "Unused":
+    each is a strip of chips. Each row header carries a delete button, and a
+    "+ Add row" tile after the last strip appends an empty row (disabled at
+    `CustomKeyRows.maxRows`). Deleting a row does not delete its buttons: its
+    tokens simply return to the shelf. Every chip (standard or custom) is
     long-press draggable; per-index drop slots between chips place the token at
     that exact index, and dropping on a strip's free area appends. Dragging a
     chip onto "Unused" removes it from the bar. Strips wrap onto multiple lines

--- a/specs/004-custom-key-buttons/spec.md
+++ b/specs/004-custom-key-buttons/spec.md
@@ -125,9 +125,11 @@ TerminalScreen ──> SpecialKeysBar ──> CustomKeyButtonWidget (render+exec
   `DesignColors.secondary` (amber) border/text — distinct from the cyan
   `primary` used by ENTER. Labels render on one line with `TextOverflow.ellipsis`.
 - **Pencil button**: fixed icon button (`Icons.edit_outlined`) pinned outside
-  the scroller at the end of row 1; if row 1 is empty it moves to the first
-  non-empty row, so the entry point never disappears while the bar is visible.
-  Tap → `onManageButtons()` (opens the full editor).
+  the scroller at the end of row 0, next to the user's own buttons. Row 0 is
+  empty by default, and an empty row renders nothing, so the pencil then falls
+  back to row 1 (its historical place) and, if that is empty too, to row 2 —
+  the entry point never disappears while the bar is visible, and it is never
+  rendered twice. Tap → `onManageButtons()` (opens the full editor).
 - **Auto-scroll**: when a row grows, it scrolls to reveal the new token — to the
   start when the token was prepended, to the end when appended.
 

--- a/specs/004-custom-key-buttons/spec.md
+++ b/specs/004-custom-key-buttons/spec.md
@@ -1,0 +1,225 @@
+# 004 Custom Key Buttons — Spec
+
+Status: approved (design Q&A) / implementation pending
+Date: 2026-08-21
+Branch: feat/custom-key-buttons
+
+## Problem
+
+The special keys bar (`lib/widgets/special_keys_bar.dart`) is hard-coded: rows of
+fixed buttons (ESC/TAB/CTRL/ALT/SHIFT/ENTER/S-RET, `/`, `-`, navigation keys, the
+Cmd input button). Users cannot add their own buttons or multi-step actions
+(e.g. type `/models` then press Enter).
+
+## Goal
+
+Let the user define custom buttons and lay out the special keys bar freely: any
+button — custom or standard — can sit in any row at any position, or be parked
+out of the bar entirely. Each custom button executes an ordered sequence of
+steps: literal text, special key (tmux key name), or pause.
+
+## Decisions (from design Q&A)
+
+1. **Placement**: three rows are laid out by the user. Row 0 is a dedicated
+   custom row at the top, empty by default; row 1 is the modifier row and row 2
+   the navigation row, both starting from their historical defaults. Any token
+   (standard or custom) may be placed in any row at any index, and tokens the
+   user does not want are parked on an "Unused" shelf that is derived from the
+   rows, not stored.
+2. **Action model**: a button is an ordered list of steps — `text` / `key` /
+   `pause`. Example: `[text: "/models", key: "Enter"]`.
+3. **Editing UX**: full editor reachable from the Settings screen (new section)
+   AND from the terminal via a pencil button on the bar; layout is edited by
+   long-press drag-and-drop of chips between the row strips and the shelf;
+   tapping a custom chip opens the editor dialog for that button.
+4. **Persistence**: global (shared_preferences), like other settings.
+5. **Architecture**: token-list rows (approach A) — each row is an ordered list
+   of tokens: stable standard-key ids + custom-button ids.
+6. **Overflow**: a row that exactly equals its historical default renders on the
+   legacy path (`Row` of `Expanded`, byte-identical to before); any other row
+   renders through one generic token renderer inside a horizontal
+   `SingleChildScrollView` with fixed-width buttons, so free insertion can never
+   squeeze the row. An empty row renders nothing, which is how a user hides a
+   whole row.
+
+## Non-goals (YAGNI)
+
+- No per-connection button sets (global only).
+- No macros beyond the step types (no loops, no shell commands on device).
+- No reordering of the button *library* list (position is defined by row
+  tokens, not list order).
+- No editing of standard buttons (labels/keys of standard buttons stay fixed).
+- No direct-input row layout editing: `input` / `num1..num4` / `di_toggle` are
+  ordinary tokens, but which of them render is still decided by direct-input
+  mode.
+
+## Architecture
+
+```
+Settings screen ──> CustomKeysScreen (full editor)
+                        │ add/edit/delete + drag-and-drop layout
+                        ▼
+CustomKeysNotifier (Riverpod, shared_preferences)
+                        │  buttons + row0/row1/row2 tokens
+                        ▼
+TerminalScreen ──> SpecialKeysBar ──> CustomKeyButtonWidget (render+execute)
+                        │                 │ tap → steps via onKeyPressed /
+                        │                 │       onSpecialKeyPressed
+                        └── pencil ───────┘ long-press → editor dialog
+```
+
+### Components
+
+| Component | File | Responsibility |
+|---|---|---|
+| Model | `lib/services/custom_keys/custom_key_button.dart` | step types, button model, JSON (de)serialization, standard-key id table, default row layouts, token validation |
+| Provider | `lib/providers/custom_keys_provider.dart` | `CustomKeysState` (buttons + row0/row1/row2), CRUD, `placeToken` / `setRowTokens`, derived `unusedTokens()`, persistence in shared_preferences, two one-time layout migrations |
+| Bar widget | `lib/widgets/special_keys_bar.dart` (modify) | new params (`customButtons`, `row0Tokens`, `row1Tokens`, `row2Tokens`, `onCustomButtonEdit`, `onManageButtons`); one generic token renderer for every row, legacy fast path only for an exactly-default row; empty rows vanish; pencil pinned to row 1 (or the first non-empty row) |
+| Button widget | `lib/widgets/custom_key_button_widget.dart` | renders one custom button (amber accent), tap → sequential step execution, long-press → edit callback, re-entry guard |
+| Editor dialog | `lib/widgets/dialogs/custom_key_button_editor_dialog.dart` | add/edit a button: label + ordered step list (type dropdown, value field, move up/down, delete, add step), optional Delete with confirmation |
+| Editor screen | `lib/screens/custom_keys/custom_keys_screen.dart` | full editor: buttons library (add/edit/delete) + drag-and-drop strips for the custom row, row 1, row 2 and the Unused shelf |
+| Settings entry | `lib/screens/settings/settings_screen.dart` (modify) | new section tile → CustomKeysScreen |
+| Terminal wiring | `lib/screens/terminal/terminal_screen.dart` (modify) | watch the provider inside the bar's `Consumer`, pass data + edit callbacks to the bar |
+
+## Data model (summary — see data-model.md)
+
+- `CustomKeyStep { type: text|key|pause, value: String }` — `value` is the
+  literal text, the tmux key name (Enter, Escape, C-c, BSpace, S-Enter, …), or
+  the pause duration in milliseconds (as string, e.g. "300").
+- `CustomKeyButton { id, label, steps: List<CustomKeyStep> }` — `id` is a
+  stable unique string generated at creation (`ck_<epochMs>_<rand>`).
+- Row layout: `List<String>` of tokens. Standard tokens are stable ids:
+  - Row 0 (custom row): empty by default.
+  - Row 1: `esc tab ctrl alt shift enter senter slash dash`
+  - Row 2: `pgup pgdn left up down right image di_toggle input`
+    (`input` renders only in normal mode; `num1..num4` render only in
+    direct-input mode — mode-dependent standard tokens that are not renderable
+    in the current mode are skipped, in every row).
+  - Custom tokens are prefixed `ck:` (e.g. `ck:1234_ab`), unambiguous against
+    standard ids.
+- Unplaced tokens are derived (`CustomKeysState.unusedTokens()`), never stored:
+  every standard token plus every custom button that no row references, in
+  canonical order.
+- Persistence keys: `custom_key_buttons_v1` (JSON array of buttons),
+  `custom_key_row0_v1`, `custom_key_row1_v1`, `custom_key_row2_v1` (JSON arrays
+  of tokens) and the marker `custom_keys_shelf_v1`. Absent keys → defaults.
+- Two one-time migrations on load: (a) no `custom_key_row0_v1` → custom tokens
+  found in row 1/row 2 move into row 0; (b) a row 2 that differs from the
+  default and lacks `num1..num4` gets them appended once. Note that `_persist()`
+  writes every row key on every load, so "key present" must never be read as
+  "the user customized this row".
+
+## Behavior details
+
+### Rendering
+
+- **Default row** (exactly equal to that row's default token list): unchanged
+  `Row` of `Expanded` buttons — byte-identical to the pre-feature layout.
+- **Any other row**: `SingleChildScrollView(horizontal)` containing a `Row` of
+  fixed-width buttons produced by one generic token renderer, so a standard
+  token renders the same in every row. Standard widths: ESC/TAB ≈ 40,
+  CTRL/ALT ≈ 44, SHIFT ≈ 48, ENTER/S-RET ≈ 56, `/`/`-` ≈ 32, nav 36×36;
+  custom buttons get label-based width (min 44, max 96, ellipsis).
+- **Empty row**: renders nothing — this is how the user hides a row.
+- **Custom button styling**: same base as `_buildSpecialKeyButton` but with
+  `DesignColors.secondary` (amber) border/text — distinct from the cyan
+  `primary` used by ENTER. Labels render on one line with `TextOverflow.ellipsis`.
+- **Pencil button**: fixed icon button (`Icons.edit_outlined`) pinned outside
+  the scroller at the end of row 1; if row 1 is empty it moves to the first
+  non-empty row, so the entry point never disappears while the bar is visible.
+  Tap → `onManageButtons()` (opens the full editor).
+- **Auto-scroll**: when a row grows, it scrolls to reveal the new token — to the
+  start when the token was prepended, to the end when appended.
+
+### Execution
+
+- Tap on a custom button → haptic (if enabled) → reset software modifier
+  toggles (CTRL/ALT/SHIFT) → execute steps in order:
+  - `text`: `onKeyPressed(value)`
+  - `key`: `onSpecialKeyPressed(value)`
+  - `pause`: `await Future.delayed(Duration(milliseconds: int.parse(value)))`
+- Step sends are enqueued in order through the existing callbacks; the backend
+  (PaneWriter/SSH queue) is FIFO, so ordering is preserved. Pauses delay the
+  enqueue of the following step.
+- Re-entry guard: an in-flight execution is tracked; taps during execution are
+  ignored (a long pause sequence cannot be double-triggered).
+- No key overlay per step (bulk actions would be noisy).
+- Modifier toggles are NOT applied to custom steps and are reset on tap.
+
+### Editor
+
+- **Full editor (CustomKeysScreen)**:
+  - Section "Buttons": list of custom buttons (label + step summary, e.g.
+    `"/models" + Enter`), tap → edit dialog, delete via trailing button,
+    header "+ Add button" → add dialog, and the new button is placed at the head
+    of the custom row so it is visible immediately.
+  - Sections "Layout — Custom Row" / "Layout — Row 1" / "Layout — Row 2" and
+    "Unused": each is a strip of chips. Every chip (standard or custom) is
+    long-press draggable; per-index drop slots between chips place the token at
+    that exact index, and dropping on a strip's free area appends. Dragging a
+    chip onto "Unused" removes it from the bar. Strips wrap onto multiple lines
+    (never a horizontal scroller) because scrolling is impossible mid-drag and
+    an off-screen slot would be unreachable. Tapping a custom chip opens its
+    editor dialog.
+  - Validation: label non-empty; at least one step; text/key step values
+    non-empty (trimmed); pause value is a positive integer. Invalid → inline
+    error, no save. Empty text/key steps are rejected because a persisted
+    empty step would make the button unparseable on next load (defense in
+    depth: the loader below also drops such entries).
+  - Delete of a button also removes its tokens from every row.
+- **Quick edit (long-press)**: the same `CustomKeyButtonEditorDialog`,
+  pre-filled, launched from the terminal screen with the button's data.
+
+### Settings entry
+
+New section header `Buttons` with a single `ListTile` ("Custom Buttons",
+subtitle "Add buttons and action sequences to the key bar") → pushes
+`CustomKeysScreen`. Placed after the existing Key Overlay section.
+
+## Error handling
+
+- Corrupt persisted JSON: a wholly unparseable buttons value (or a non-array)
+  falls back to an empty list; a partially invalid array drops only the
+  invalid entries and keeps the valid ones (drop-bad-keep-good — one corrupt
+  button must not wipe the rest). Corrupt row values fall back to the default
+  row. Never crashes startup.
+- Unknown tokens in a row (button deleted, or id collision): skipped at render.
+- Pause parse failure at execution: step skipped, sequence continues (defensive
+  against hand-edited data; validation trims the value, execution trims too).
+- Read-only terminal (`_ReadOnlyBanner` shown): bar hidden entirely; pencil and
+  custom buttons not reachable (existing behavior).
+
+## Testing
+
+- **Unit — model** (`test/services/custom_keys/custom_key_button_test.dart`):
+  JSON round-trip for all step types; corrupt JSON → default; token prefix
+  validation; standard-id table completeness.
+- **Unit — provider** (`test/providers/custom_keys_provider_test.dart`):
+  defaults when keys absent; add/update/delete persist; delete removes row
+  tokens from every row; `setRowTokens` drops unknown/duplicate tokens;
+  `placeToken` index arithmetic (head, same-row shift, shelf, unknown token);
+  `unusedTokens()` canonical order; both migrations, including that a persisted
+  default row 2 is left alone; SharedPreferences mock.
+- **Widget — bar** (`test/widgets/special_keys_bar_test.dart`, extend): default
+  layout unchanged (existing tests keep passing); a standard token renders in
+  the custom row and a custom token renders in row 2; a reordered row honours
+  its order; an empty row vanishes and the pencil moves to the first non-empty
+  row; numbers are not auto-appended; a row scrolls to a newly prepended or
+  appended token; long-press fires the edit callback; tap executes steps in
+  order exactly once; modifier reset on custom tap.
+- **Widget — editor dialog**: label/step validation; step add/reorder/delete;
+  Delete with confirmation (confirm and cancel); layout survives a 2× text
+  scale and a 308dp-wide dialog (actions on one row, labels not clipped).
+- **Widget — editor screen**: buttons CRUD; drag between rows, within a row, to
+  and from the Unused shelf; delete removes the token; persistence through the
+  provider.
+- **Gate**: `flutter analyze` clean; full `flutter test` green apart from the
+  suite's known pre-existing failures.
+
+## Verification
+
+- `flutter analyze` — no issues.
+- Full `flutter test` suite (existing + new).
+- Manual smoke on a device: add a button `/models` + `Enter`, drag it and a
+  standard key between rows and onto the Unused shelf, verify the bar matches
+  the editor, that both send on tap, and that the layout survives a restart.

--- a/specs/004-custom-key-buttons/spec.md
+++ b/specs/004-custom-key-buttons/spec.md
@@ -155,12 +155,15 @@ TerminalScreen ──> SpecialKeysBar ──> CustomKeyButtonWidget (render+exec
   - Section "Buttons": list of custom buttons (label + step summary, e.g.
     `"/models" + Enter`), tap → edit dialog, delete via trailing button,
     header "+ Add button" → add dialog, and the new button is placed at the head
-    of the custom row so it is visible immediately.
+    of the topmost row so it is visible immediately. To fill another row, use
+    that row's own "+" (or drag the chip there).
   - Sections "Layout — Row N" (1-based from the top, one per row) and "Unused":
-    each is a strip of chips. Each row header carries a delete button, and a
-    "+ Add row" tile after the last strip appends an empty row (disabled at
-    `CustomKeyRows.maxRows`). Deleting a row does not delete its buttons: its
-    tokens simply return to the shelf. Every chip (standard or custom) is
+    each is a strip of chips. Each row header carries "+" (create a button at
+    the END of THAT row) and a delete button; a "+ Add row" tile after the last
+    strip appends an empty row (disabled at `CustomKeyRows.maxRows`). Deleting a
+    row does not delete its buttons: its tokens simply return to the shelf.
+    A row holding no tokens shows "Empty — hidden in the bar", because an empty
+    row renders nothing in the bar and would otherwise look broken. Every chip (standard or custom) is
     long-press draggable; per-index drop slots between chips place the token at
     that exact index, and dropping on a strip's free area appends. Dragging a
     chip onto "Unused" removes it from the bar. Strips wrap onto multiple lines

--- a/test/providers/custom_keys_provider_test.dart
+++ b/test/providers/custom_keys_provider_test.dart
@@ -17,8 +17,8 @@ void main() {
     await Future<void>.delayed(Duration.zero);
     final s = container.read(customKeysProvider);
     expect(s.buttons, isEmpty);
-    expect(s.row1, CustomKeyRows.standardRow1);
-    expect(s.row2, CustomKeyRows.standardRow2);
+    expect(s.rows[1], CustomKeyRows.standardRow1);
+    expect(s.rows[2], CustomKeyRows.standardRow2);
   });
 
   test('add/update/delete persist', () async {
@@ -65,7 +65,7 @@ void main() {
 
     notifier.deleteButton(b.id);
     final s = container.read(customKeysProvider);
-    expect(s.row1, CustomKeyRows.standardRow1);
+    expect(s.rows[1], CustomKeyRows.standardRow1);
   });
 
   test('setRowTokens drops unknown and duplicate tokens', () async {
@@ -79,20 +79,20 @@ void main() {
     ]);
     final ck = 'ck:${b.id.substring(3)}';
     notifier.setRowTokens(2, ['bogus', 'pgup', ck, ck, 'left']);
-    expect(container.read(customKeysProvider).row2, ['pgup', ck, 'left']);
+    expect(container.read(customKeysProvider).rows[2], ['pgup', ck, 'left']);
   });
 
   test('corrupt stored JSON falls back to defaults', () async {
     SharedPreferences.setMockInitialValues({
       CustomKeysNotifier.buttonsKey: 'not json',
-      CustomKeysNotifier.row1Key: 'also not json',
+      CustomKeysNotifier.legacyRow1Key: 'also not json',
     });
     final container = ProviderContainer();
     addTearDown(container.dispose);
     await Future<void>.delayed(Duration.zero);
     final s = container.read(customKeysProvider);
     expect(s.buttons, isEmpty);
-    expect(s.row1, CustomKeyRows.standardRow1);
+    expect(s.rows[1], CustomKeyRows.standardRow1);
   });
 
   test('load skips invalid button entries and keeps valid ones', () async {
@@ -128,7 +128,7 @@ void main() {
     addTearDown(container.dispose);
     container.read(customKeysProvider); // trigger build + async _load
     await Future<void>.delayed(Duration.zero);
-    expect(container.read(customKeysProvider).row0, isEmpty);
+    expect(container.read(customKeysProvider).rows[0], isEmpty);
   });
 
   test('legacy layout migrates custom tokens into the custom row', () async {
@@ -149,8 +149,8 @@ void main() {
           ],
         },
       ]),
-      CustomKeysNotifier.row1Key: jsonEncode(['esc', 'ck:1_a', 'tab']),
-      CustomKeysNotifier.row2Key: jsonEncode(['left', 'ck:2_b']),
+      CustomKeysNotifier.legacyRow1Key: jsonEncode(['esc', 'ck:1_a', 'tab']),
+      CustomKeysNotifier.legacyRow2Key: jsonEncode(['left', 'ck:2_b']),
     });
     final container = ProviderContainer();
     addTearDown(container.dispose);
@@ -158,9 +158,9 @@ void main() {
     await Future<void>.delayed(Duration.zero);
 
     final state = container.read(customKeysProvider);
-    expect(state.row0, ['ck:1_a', 'ck:2_b']);
-    expect(state.row1, ['esc', 'tab']);
-    expect(state.row2, ['left', ...CustomKeyRows.directInputExtras]);
+    expect(state.rows[0], ['ck:1_a', 'ck:2_b']);
+    expect(state.rows[1], ['esc', 'tab']);
+    expect(state.rows[2], ['left', ...CustomKeyRows.directInputExtras]);
   });
 
   test('an existing custom row is left alone on load', () async {
@@ -174,8 +174,8 @@ void main() {
           ],
         },
       ]),
-      CustomKeysNotifier.row0Key: jsonEncode(<String>[]),
-      CustomKeysNotifier.row1Key: jsonEncode(['esc', 'ck:1_a']),
+      CustomKeysNotifier.legacyRow0Key: jsonEncode(<String>[]),
+      CustomKeysNotifier.legacyRow1Key: jsonEncode(['esc', 'ck:1_a']),
     });
     final container = ProviderContainer();
     addTearDown(container.dispose);
@@ -183,8 +183,8 @@ void main() {
     await Future<void>.delayed(Duration.zero);
 
     final state = container.read(customKeysProvider);
-    expect(state.row0, isEmpty);
-    expect(state.row1, ['esc', 'ck:1_a']);
+    expect(state.rows[0], isEmpty);
+    expect(state.rows[1], ['esc', 'ck:1_a']);
   });
 
   test('setRowTokens row0 persists and survives recreation', () async {
@@ -200,21 +200,21 @@ void main() {
     final ck = 'ck:${b.id.substring(3)}';
 
     notifier.setRowTokens(0, [ck]);
-    expect(container.read(customKeysProvider).row0, [ck]);
+    expect(container.read(customKeysProvider).rows[0], [ck]);
 
     // Persistence is async; give _persist a chance to flush.
     await Future<void>.delayed(Duration.zero);
     final prefs = await SharedPreferences.getInstance();
-    expect(jsonDecode(prefs.getString(CustomKeysNotifier.row0Key)!), [ck]);
+    expect(jsonDecode(prefs.getString(CustomKeysNotifier.rowsKey)!)[0], [ck]);
 
     final container2 = ProviderContainer();
     addTearDown(container2.dispose);
     container2.read(customKeysProvider); // trigger build + async _load
     await Future<void>.delayed(Duration.zero);
     final s = container2.read(customKeysProvider);
-    expect(s.row0, [ck]);
-    expect(s.row1, CustomKeyRows.standardRow1);
-    expect(s.row2, CustomKeyRows.standardRow2);
+    expect(s.rows[0], [ck]);
+    expect(s.rows[1], CustomKeyRows.standardRow1);
+    expect(s.rows[2], CustomKeyRows.standardRow2);
   });
 
   test('button only in row0 is not reported unplaced', () async {
@@ -245,7 +245,7 @@ void main() {
     notifier.setRowTokens(0, ['ck:${b.id.substring(3)}']);
 
     notifier.deleteButton(b.id);
-    expect(container.read(customKeysProvider).row0, isEmpty);
+    expect(container.read(customKeysProvider).rows[0], isEmpty);
   });
 
   test('unknown tokens in stored row0 JSON are dropped', () async {
@@ -262,12 +262,12 @@ void main() {
 
     notifier.setRowTokens(0, ['bogus', ck, ck]);
 
-    expect(container.read(customKeysProvider).row0, [ck]);
+    expect(container.read(customKeysProvider).rows[0], [ck]);
 
-    // The sanitised row is what gets persisted under row0Key.
+    // The sanitised row is what gets persisted inside the rows key.
     await Future<void>.delayed(Duration.zero);
     final prefs = await SharedPreferences.getInstance();
-    expect(jsonDecode(prefs.getString(CustomKeysNotifier.row0Key)!), [ck]);
+    expect(jsonDecode(prefs.getString(CustomKeysNotifier.rowsKey)!)[0], [ck]);
   });
 
   test(
@@ -322,9 +322,9 @@ void main() {
     notifier.placeToken('esc', toRow: 0, toIndex: 0);
 
     final s = container.read(customKeysProvider);
-    expect(s.row0, ['esc']);
-    expect(s.row1.contains('esc'), isFalse);
-    expect(s.row1.first, 'tab');
+    expect(s.rows[0], ['esc']);
+    expect(s.rows[1].contains('esc'), isFalse);
+    expect(s.rows[1].first, 'tab');
   });
 
   test(
@@ -340,7 +340,7 @@ void main() {
       // row1 default: [esc, tab, ctrl, alt, shift, enter, senter, slash, dash]
       notifier.placeToken('esc', toRow: 1, toIndex: 2);
 
-      expect(container.read(customKeysProvider).row1, [
+      expect(container.read(customKeysProvider).rows[1], [
         'tab',
         'esc',
         'ctrl',
@@ -367,7 +367,7 @@ void main() {
       notifier.placeToken('esc', toRow: CustomKeyRows.shelfRow, toIndex: 0);
 
       final s = container.read(customKeysProvider);
-      expect(s.row1.contains('esc'), isFalse);
+      expect(s.rows[1].contains('esc'), isFalse);
       expect(s.unusedTokens(), contains('esc'));
     },
   );
@@ -385,9 +385,9 @@ void main() {
     notifier.placeToken('ck:missing', toRow: 1, toIndex: 0);
 
     final s = container.read(customKeysProvider);
-    expect(s.row0, before.row0);
-    expect(s.row1, before.row1);
-    expect(s.row2, before.row2);
+    expect(s.rows[0], before.rows[0]);
+    expect(s.rows[1], before.rows[1]);
+    expect(s.rows[2], before.rows[2]);
   });
 
   test('placeToken state survives provider recreation', () async {
@@ -405,20 +405,20 @@ void main() {
     container2.read(customKeysProvider);
     await Future<void>.delayed(Duration.zero);
     final s = container2.read(customKeysProvider);
-    expect(s.row0, ['esc']);
-    expect(s.row1.contains('esc'), isFalse);
+    expect(s.rows[0], ['esc']);
+    expect(s.rows[1].contains('esc'), isFalse);
   });
 
   test('customized row2 without num tokens gains num1..num4 once', () async {
     SharedPreferences.setMockInitialValues({
-      CustomKeysNotifier.row2Key: jsonEncode(['left']),
+      CustomKeysNotifier.legacyRow2Key: jsonEncode(['left']),
     });
     final container = ProviderContainer();
     addTearDown(container.dispose);
     container.read(customKeysProvider);
     await Future<void>.delayed(Duration.zero);
 
-    expect(container.read(customKeysProvider).row2, [
+    expect(container.read(customKeysProvider).rows[2], [
       'left',
       ...CustomKeyRows.directInputExtras,
     ]);
@@ -427,7 +427,7 @@ void main() {
     addTearDown(container2.dispose);
     container2.read(customKeysProvider);
     await Future<void>.delayed(Duration.zero);
-    expect(container2.read(customKeysProvider).row2, [
+    expect(container2.read(customKeysProvider).rows[2], [
       'left',
       ...CustomKeyRows.directInputExtras,
     ]);
@@ -440,7 +440,10 @@ void main() {
     container.read(customKeysProvider);
     await Future<void>.delayed(Duration.zero);
 
-    expect(container.read(customKeysProvider).row2, CustomKeyRows.standardRow2);
+    expect(
+      container.read(customKeysProvider).rows[2],
+      CustomKeyRows.standardRow2,
+    );
   });
 
   // _persist() writes every row key on every load, so "key present" never means
@@ -448,17 +451,174 @@ void main() {
   // the bar loses its legacy layout for everyone who never edited a row.
   test('persisted default row2 is not touched by the num migration', () async {
     SharedPreferences.setMockInitialValues({
-      CustomKeysNotifier.row2Key: jsonEncode(CustomKeyRows.standardRow2),
+      CustomKeysNotifier.legacyRow2Key: jsonEncode(CustomKeyRows.standardRow2),
     });
     final container = ProviderContainer();
     addTearDown(container.dispose);
     container.read(customKeysProvider);
     await Future<void>.delayed(Duration.zero);
 
-    expect(container.read(customKeysProvider).row2, CustomKeyRows.standardRow2);
+    expect(
+      container.read(customKeysProvider).rows[2],
+      CustomKeyRows.standardRow2,
+    );
     expect(
       container.read(customKeysProvider).unusedTokens(),
       CustomKeyRows.directInputExtras,
     );
+  });
+
+  // addRow appends an empty row at the bottom and persists it.
+  test('addRow appends an empty bottom row and persists', () async {
+    SharedPreferences.setMockInitialValues({});
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    container.read(customKeysProvider);
+    await Future<void>.delayed(Duration.zero);
+
+    container.read(customKeysProvider.notifier).addRow();
+    expect(container.read(customKeysProvider).rows.length, 4);
+    expect(container.read(customKeysProvider).rows.last, isEmpty);
+
+    await Future<void>.delayed(Duration.zero);
+    final prefs = await SharedPreferences.getInstance();
+    expect(
+      (jsonDecode(prefs.getString(CustomKeysNotifier.rowsKey)!) as List).length,
+      4,
+    );
+  });
+
+  // The bar has finite height: addRow stops at CustomKeyRows.maxRows.
+  test('addRow is a no-op at maxRows', () async {
+    SharedPreferences.setMockInitialValues({});
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    container.read(customKeysProvider);
+    await Future<void>.delayed(Duration.zero);
+    final notifier = container.read(customKeysProvider.notifier);
+
+    for (var i = 0; i < CustomKeyRows.maxRows + 2; i++) {
+      notifier.addRow();
+    }
+    expect(
+      container.read(customKeysProvider).rows.length,
+      CustomKeyRows.maxRows,
+    );
+  });
+
+  // removeRow must not destroy buttons: its tokens fall back to the shelf.
+  test('removeRow drops the row and its tokens become unused', () async {
+    SharedPreferences.setMockInitialValues({});
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    container.read(customKeysProvider);
+    await Future<void>.delayed(Duration.zero);
+    final notifier = container.read(customKeysProvider.notifier);
+    final b = notifier.addButton('X', [
+      CustomKeyStep(type: CustomKeyStepType.text, value: 'x'),
+    ]);
+    final ck = 'ck:${b.id.substring(3)}';
+    notifier.setRowTokens(0, [ck, 'esc']);
+
+    notifier.removeRow(0);
+
+    final s = container.read(customKeysProvider);
+    expect(s.rows.length, 2);
+    expect(s.rows.first, CustomKeyRows.standardRow1);
+    expect(s.buttons.single.id, b.id);
+    expect(s.unusedTokens(), contains(ck));
+  });
+
+  // Deleting every row is allowed; the bar falls back to a pencil-only strip.
+  test('removeRow can empty the layout entirely', () async {
+    SharedPreferences.setMockInitialValues({});
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    container.read(customKeysProvider);
+    await Future<void>.delayed(Duration.zero);
+    final notifier = container.read(customKeysProvider.notifier);
+
+    notifier.removeRow(2);
+    notifier.removeRow(1);
+    notifier.removeRow(0);
+
+    expect(container.read(customKeysProvider).rows, isEmpty);
+    expect(
+      container.read(customKeysProvider).unusedTokens(),
+      CustomKeyRows.allLayoutTokens,
+    );
+  });
+
+  // A token can be dropped into a row that did not exist a moment ago.
+  test('placeToken lands in a freshly added row', () async {
+    SharedPreferences.setMockInitialValues({});
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    container.read(customKeysProvider);
+    await Future<void>.delayed(Duration.zero);
+    final notifier = container.read(customKeysProvider.notifier);
+
+    notifier.addRow();
+    notifier.placeToken('esc', toRow: 3, toIndex: 0);
+
+    final s = container.read(customKeysProvider);
+    expect(s.rows[3], ['esc']);
+    expect(s.rows[1].contains('esc'), isFalse);
+  });
+
+  // Hand-edited or future data must not grow the bar past the cap.
+  test('stored rows beyond maxRows are truncated on load', () async {
+    SharedPreferences.setMockInitialValues({
+      CustomKeysNotifier.rowsKey: jsonEncode([
+        for (var i = 0; i < CustomKeyRows.maxRows + 2; i++) <String>['esc'],
+      ]),
+    });
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    container.read(customKeysProvider);
+    await Future<void>.delayed(Duration.zero);
+
+    expect(
+      container.read(customKeysProvider).rows.length,
+      CustomKeyRows.maxRows,
+    );
+  });
+
+  // The three legacy row keys collapse into the new single key exactly once.
+  test('legacy row keys migrate into the rows key and are removed', () async {
+    SharedPreferences.setMockInitialValues({
+      CustomKeysNotifier.legacyRow0Key: jsonEncode(<String>[]),
+      CustomKeysNotifier.legacyRow1Key: jsonEncode(['esc', 'tab']),
+      CustomKeysNotifier.legacyRow2Key: jsonEncode(CustomKeyRows.standardRow2),
+    });
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    container.read(customKeysProvider);
+    await Future<void>.delayed(Duration.zero);
+
+    expect(container.read(customKeysProvider).rows, [
+      <String>[],
+      ['esc', 'tab'],
+      CustomKeyRows.standardRow2,
+    ]);
+
+    final prefs = await SharedPreferences.getInstance();
+    expect(prefs.getString(CustomKeysNotifier.rowsKey), isNotNull);
+    expect(prefs.getString(CustomKeysNotifier.legacyRow0Key), isNull);
+    expect(prefs.getString(CustomKeysNotifier.legacyRow1Key), isNull);
+    expect(prefs.getString(CustomKeysNotifier.legacyRow2Key), isNull);
+  });
+
+  // A corrupt layout must not brick the bar.
+  test('corrupt rows value falls back to the default layout', () async {
+    SharedPreferences.setMockInitialValues({
+      CustomKeysNotifier.rowsKey: 'not json at all',
+    });
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    container.read(customKeysProvider);
+    await Future<void>.delayed(Duration.zero);
+
+    expect(container.read(customKeysProvider).rows, CustomKeyRows.defaultRows);
   });
 }

--- a/test/providers/custom_keys_provider_test.dart
+++ b/test/providers/custom_keys_provider_test.dart
@@ -1,0 +1,464 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:flutter_muxpod/providers/custom_keys_provider.dart';
+import 'package:flutter_muxpod/services/custom_keys/custom_key_button.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('defaults when keys absent', () async {
+    SharedPreferences.setMockInitialValues({});
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    // wait for the async load
+    await Future<void>.delayed(Duration.zero);
+    final s = container.read(customKeysProvider);
+    expect(s.buttons, isEmpty);
+    expect(s.row1, CustomKeyRows.standardRow1);
+    expect(s.row2, CustomKeyRows.standardRow2);
+  });
+
+  test('add/update/delete persist', () async {
+    SharedPreferences.setMockInitialValues({});
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    await Future<void>.delayed(Duration.zero);
+    final notifier = container.read(customKeysProvider.notifier);
+
+    final b = notifier.addButton('/models', [
+      CustomKeyStep(type: CustomKeyStepType.text, value: '/models'),
+      CustomKeyStep(type: CustomKeyStepType.key, value: 'Enter'),
+    ]);
+    expect(b.steps.length, 2);
+    expect(container.read(customKeysProvider).buttons.single.id, b.id);
+
+    notifier.updateButton(
+      b.id,
+      label: '/models v2',
+      steps: [CustomKeyStep(type: CustomKeyStepType.text, value: '/x')],
+    );
+    expect(
+      container.read(customKeysProvider).buttons.single.label,
+      '/models v2',
+    );
+
+    notifier.deleteButton(b.id);
+    expect(container.read(customKeysProvider).buttons, isEmpty);
+  });
+
+  test('deleteButton removes row tokens', () async {
+    SharedPreferences.setMockInitialValues({});
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    await Future<void>.delayed(Duration.zero);
+    final notifier = container.read(customKeysProvider.notifier);
+    final b = notifier.addButton('X', [
+      CustomKeyStep(type: CustomKeyStepType.text, value: 'x'),
+    ]);
+    notifier.setRowTokens(1, [
+      ...CustomKeyRows.standardRow1,
+      'ck:${b.id.substring(3)}',
+    ]);
+
+    notifier.deleteButton(b.id);
+    final s = container.read(customKeysProvider);
+    expect(s.row1, CustomKeyRows.standardRow1);
+  });
+
+  test('setRowTokens drops unknown and duplicate tokens', () async {
+    SharedPreferences.setMockInitialValues({});
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    await Future<void>.delayed(Duration.zero);
+    final notifier = container.read(customKeysProvider.notifier);
+    final b = notifier.addButton('X', [
+      CustomKeyStep(type: CustomKeyStepType.text, value: 'x'),
+    ]);
+    final ck = 'ck:${b.id.substring(3)}';
+    notifier.setRowTokens(2, ['bogus', 'pgup', ck, ck, 'left']);
+    expect(container.read(customKeysProvider).row2, ['pgup', ck, 'left']);
+  });
+
+  test('corrupt stored JSON falls back to defaults', () async {
+    SharedPreferences.setMockInitialValues({
+      CustomKeysNotifier.buttonsKey: 'not json',
+      CustomKeysNotifier.row1Key: 'also not json',
+    });
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    await Future<void>.delayed(Duration.zero);
+    final s = container.read(customKeysProvider);
+    expect(s.buttons, isEmpty);
+    expect(s.row1, CustomKeyRows.standardRow1);
+  });
+
+  test('load skips invalid button entries and keeps valid ones', () async {
+    final valid = {
+      'id': 'ck_1',
+      'label': 'Good',
+      'steps': [
+        {'type': 'text', 'value': 'a'},
+      ],
+    };
+    final invalid = {
+      'id': 'ck_2',
+      'label': 'Bad',
+      'steps': [
+        {'type': 'text', 'value': '   '},
+      ],
+    };
+    SharedPreferences.setMockInitialValues({
+      CustomKeysNotifier.buttonsKey: jsonEncode([valid, invalid]),
+    });
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    container.read(customKeysProvider); // trigger build + async _load
+    await Future<void>.delayed(Duration.zero);
+    final s = container.read(customKeysProvider);
+    expect(s.buttons.length, 1);
+    expect(s.buttons.single.id, 'ck_1');
+  });
+
+  test('row0 defaults to empty', () async {
+    SharedPreferences.setMockInitialValues({});
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    container.read(customKeysProvider); // trigger build + async _load
+    await Future<void>.delayed(Duration.zero);
+    expect(container.read(customKeysProvider).row0, isEmpty);
+  });
+
+  test('legacy layout migrates custom tokens into the custom row', () async {
+    SharedPreferences.setMockInitialValues({
+      CustomKeysNotifier.buttonsKey: jsonEncode([
+        {
+          'id': 'ck_1_a',
+          'label': 'A',
+          'steps': [
+            {'type': 'text', 'value': 'a'},
+          ],
+        },
+        {
+          'id': 'ck_2_b',
+          'label': 'B',
+          'steps': [
+            {'type': 'text', 'value': 'b'},
+          ],
+        },
+      ]),
+      CustomKeysNotifier.row1Key: jsonEncode(['esc', 'ck:1_a', 'tab']),
+      CustomKeysNotifier.row2Key: jsonEncode(['left', 'ck:2_b']),
+    });
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    container.read(customKeysProvider); // trigger build + async _load
+    await Future<void>.delayed(Duration.zero);
+
+    final state = container.read(customKeysProvider);
+    expect(state.row0, ['ck:1_a', 'ck:2_b']);
+    expect(state.row1, ['esc', 'tab']);
+    expect(state.row2, ['left', ...CustomKeyRows.directInputExtras]);
+  });
+
+  test('an existing custom row is left alone on load', () async {
+    SharedPreferences.setMockInitialValues({
+      CustomKeysNotifier.buttonsKey: jsonEncode([
+        {
+          'id': 'ck_1_a',
+          'label': 'A',
+          'steps': [
+            {'type': 'text', 'value': 'a'},
+          ],
+        },
+      ]),
+      CustomKeysNotifier.row0Key: jsonEncode(<String>[]),
+      CustomKeysNotifier.row1Key: jsonEncode(['esc', 'ck:1_a']),
+    });
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    container.read(customKeysProvider); // trigger build + async _load
+    await Future<void>.delayed(Duration.zero);
+
+    final state = container.read(customKeysProvider);
+    expect(state.row0, isEmpty);
+    expect(state.row1, ['esc', 'ck:1_a']);
+  });
+
+  test('setRowTokens row0 persists and survives recreation', () async {
+    SharedPreferences.setMockInitialValues({});
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    container.read(customKeysProvider); // trigger build + async _load
+    await Future<void>.delayed(Duration.zero);
+    final notifier = container.read(customKeysProvider.notifier);
+    final b = notifier.addButton('X', [
+      CustomKeyStep(type: CustomKeyStepType.text, value: 'x'),
+    ]);
+    final ck = 'ck:${b.id.substring(3)}';
+
+    notifier.setRowTokens(0, [ck]);
+    expect(container.read(customKeysProvider).row0, [ck]);
+
+    // Persistence is async; give _persist a chance to flush.
+    await Future<void>.delayed(Duration.zero);
+    final prefs = await SharedPreferences.getInstance();
+    expect(jsonDecode(prefs.getString(CustomKeysNotifier.row0Key)!), [ck]);
+
+    final container2 = ProviderContainer();
+    addTearDown(container2.dispose);
+    container2.read(customKeysProvider); // trigger build + async _load
+    await Future<void>.delayed(Duration.zero);
+    final s = container2.read(customKeysProvider);
+    expect(s.row0, [ck]);
+    expect(s.row1, CustomKeyRows.standardRow1);
+    expect(s.row2, CustomKeyRows.standardRow2);
+  });
+
+  test('button only in row0 is not reported unplaced', () async {
+    SharedPreferences.setMockInitialValues({});
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    container.read(customKeysProvider); // trigger build + async _load
+    await Future<void>.delayed(Duration.zero);
+    final notifier = container.read(customKeysProvider.notifier);
+    final b = notifier.addButton('X', [
+      CustomKeyStep(type: CustomKeyStepType.text, value: 'x'),
+    ]);
+    notifier.setRowTokens(0, ['ck:${b.id.substring(3)}']);
+
+    expect(container.read(customKeysProvider).unplacedButtons(), isEmpty);
+  });
+
+  test('deleteButton removes token from row0', () async {
+    SharedPreferences.setMockInitialValues({});
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    container.read(customKeysProvider); // trigger build + async _load
+    await Future<void>.delayed(Duration.zero);
+    final notifier = container.read(customKeysProvider.notifier);
+    final b = notifier.addButton('X', [
+      CustomKeyStep(type: CustomKeyStepType.text, value: 'x'),
+    ]);
+    notifier.setRowTokens(0, ['ck:${b.id.substring(3)}']);
+
+    notifier.deleteButton(b.id);
+    expect(container.read(customKeysProvider).row0, isEmpty);
+  });
+
+  test('unknown tokens in stored row0 JSON are dropped', () async {
+    SharedPreferences.setMockInitialValues({});
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    container.read(customKeysProvider); // trigger build + async _load
+    await Future<void>.delayed(Duration.zero);
+    final notifier = container.read(customKeysProvider.notifier);
+    final b = notifier.addButton('X', [
+      CustomKeyStep(type: CustomKeyStepType.text, value: 'x'),
+    ]);
+    final ck = 'ck:${b.id.substring(3)}';
+
+    notifier.setRowTokens(0, ['bogus', ck, ck]);
+
+    expect(container.read(customKeysProvider).row0, [ck]);
+
+    // The sanitised row is what gets persisted under row0Key.
+    await Future<void>.delayed(Duration.zero);
+    final prefs = await SharedPreferences.getInstance();
+    expect(jsonDecode(prefs.getString(CustomKeysNotifier.row0Key)!), [ck]);
+  });
+
+  test(
+    'unusedTokens contains only num tokens in canonical order by default',
+    () async {
+      SharedPreferences.setMockInitialValues({});
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      container.read(customKeysProvider);
+      await Future<void>.delayed(Duration.zero);
+
+      final s = container.read(customKeysProvider);
+      expect(s.unusedTokens(), CustomKeyRows.directInputExtras);
+      expect(
+        s.unusedTokens(),
+        CustomKeyRows.allLayoutTokens
+            .where(CustomKeyRows.directInputExtras.contains)
+            .toList(),
+      );
+    },
+  );
+
+  test(
+    'unplaced custom button appears in unusedTokens after standard tokens',
+    () async {
+      SharedPreferences.setMockInitialValues({});
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      container.read(customKeysProvider);
+      await Future<void>.delayed(Duration.zero);
+      final notifier = container.read(customKeysProvider.notifier);
+      final b = notifier.addButton('X', [
+        CustomKeyStep(type: CustomKeyStepType.text, value: 'x'),
+      ]);
+      final ck = 'ck:${b.id.substring(3)}';
+
+      expect(container.read(customKeysProvider).unusedTokens(), [
+        ...CustomKeyRows.directInputExtras,
+        ck,
+      ]);
+    },
+  );
+
+  test('placeToken moves a standard token to row0 head', () async {
+    SharedPreferences.setMockInitialValues({});
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    container.read(customKeysProvider);
+    await Future<void>.delayed(Duration.zero);
+    final notifier = container.read(customKeysProvider.notifier);
+
+    notifier.placeToken('esc', toRow: 0, toIndex: 0);
+
+    final s = container.read(customKeysProvider);
+    expect(s.row0, ['esc']);
+    expect(s.row1.contains('esc'), isFalse);
+    expect(s.row1.first, 'tab');
+  });
+
+  test(
+    'placeToken same-row move to higher index adjusts for removal',
+    () async {
+      SharedPreferences.setMockInitialValues({});
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      container.read(customKeysProvider);
+      await Future<void>.delayed(Duration.zero);
+      final notifier = container.read(customKeysProvider.notifier);
+
+      // row1 default: [esc, tab, ctrl, alt, shift, enter, senter, slash, dash]
+      notifier.placeToken('esc', toRow: 1, toIndex: 2);
+
+      expect(container.read(customKeysProvider).row1, [
+        'tab',
+        'esc',
+        'ctrl',
+        'alt',
+        'shift',
+        'enter',
+        'senter',
+        'slash',
+        'dash',
+      ]);
+    },
+  );
+
+  test(
+    'placeToken to shelf removes token from rows into unusedTokens',
+    () async {
+      SharedPreferences.setMockInitialValues({});
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      container.read(customKeysProvider);
+      await Future<void>.delayed(Duration.zero);
+      final notifier = container.read(customKeysProvider.notifier);
+
+      notifier.placeToken('esc', toRow: CustomKeyRows.shelfRow, toIndex: 0);
+
+      final s = container.read(customKeysProvider);
+      expect(s.row1.contains('esc'), isFalse);
+      expect(s.unusedTokens(), contains('esc'));
+    },
+  );
+
+  test('placeToken with unknown token is a no-op', () async {
+    SharedPreferences.setMockInitialValues({});
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    container.read(customKeysProvider);
+    await Future<void>.delayed(Duration.zero);
+    final notifier = container.read(customKeysProvider.notifier);
+    final before = container.read(customKeysProvider);
+
+    notifier.placeToken('bogus', toRow: 0, toIndex: 0);
+    notifier.placeToken('ck:missing', toRow: 1, toIndex: 0);
+
+    final s = container.read(customKeysProvider);
+    expect(s.row0, before.row0);
+    expect(s.row1, before.row1);
+    expect(s.row2, before.row2);
+  });
+
+  test('placeToken state survives provider recreation', () async {
+    SharedPreferences.setMockInitialValues({});
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    container.read(customKeysProvider);
+    await Future<void>.delayed(Duration.zero);
+    final notifier = container.read(customKeysProvider.notifier);
+    notifier.placeToken('esc', toRow: 0, toIndex: 0);
+    await Future<void>.delayed(Duration.zero);
+
+    final container2 = ProviderContainer();
+    addTearDown(container2.dispose);
+    container2.read(customKeysProvider);
+    await Future<void>.delayed(Duration.zero);
+    final s = container2.read(customKeysProvider);
+    expect(s.row0, ['esc']);
+    expect(s.row1.contains('esc'), isFalse);
+  });
+
+  test('customized row2 without num tokens gains num1..num4 once', () async {
+    SharedPreferences.setMockInitialValues({
+      CustomKeysNotifier.row2Key: jsonEncode(['left']),
+    });
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    container.read(customKeysProvider);
+    await Future<void>.delayed(Duration.zero);
+
+    expect(container.read(customKeysProvider).row2, [
+      'left',
+      ...CustomKeyRows.directInputExtras,
+    ]);
+
+    final container2 = ProviderContainer();
+    addTearDown(container2.dispose);
+    container2.read(customKeysProvider);
+    await Future<void>.delayed(Duration.zero);
+    expect(container2.read(customKeysProvider).row2, [
+      'left',
+      ...CustomKeyRows.directInputExtras,
+    ]);
+  });
+
+  test('default row2 is not touched by the num migration', () async {
+    SharedPreferences.setMockInitialValues({});
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    container.read(customKeysProvider);
+    await Future<void>.delayed(Duration.zero);
+
+    expect(container.read(customKeysProvider).row2, CustomKeyRows.standardRow2);
+  });
+
+  // _persist() writes every row key on every load, so "key present" never means
+  // "user customized it": a persisted default row2 must stay default, otherwise
+  // the bar loses its legacy layout for everyone who never edited a row.
+  test('persisted default row2 is not touched by the num migration', () async {
+    SharedPreferences.setMockInitialValues({
+      CustomKeysNotifier.row2Key: jsonEncode(CustomKeyRows.standardRow2),
+    });
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    container.read(customKeysProvider);
+    await Future<void>.delayed(Duration.zero);
+
+    expect(container.read(customKeysProvider).row2, CustomKeyRows.standardRow2);
+    expect(
+      container.read(customKeysProvider).unusedTokens(),
+      CustomKeyRows.directInputExtras,
+    );
+  });
+}

--- a/test/screens/custom_keys/custom_keys_screen_test.dart
+++ b/test/screens/custom_keys/custom_keys_screen_test.dart
@@ -1,0 +1,419 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:flutter_muxpod/providers/custom_keys_provider.dart';
+import 'package:flutter_muxpod/screens/custom_keys/custom_keys_screen.dart';
+import 'package:flutter_muxpod/services/custom_keys/custom_key_button.dart';
+
+void main() {
+  Future<void> pumpScreen(
+    WidgetTester tester,
+    ProviderContainer container,
+  ) async {
+    // Tall viewport so every strip (including the bottom shelf) is laid out
+    // and hittable without scrolling.
+    tester.view.physicalSize = const Size(1080, 1920);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: const MaterialApp(home: CustomKeysScreen()),
+      ),
+    );
+    // Flush the async SharedPreferences load.
+    await tester.pump();
+  }
+
+  Future<void> addButton(
+    WidgetTester tester,
+    String label,
+    String stepValue,
+  ) async {
+    await tester.tap(find.text('+ Add button'));
+    await tester.pumpAndSettle();
+    await tester.enterText(find.byKey(const Key('label-field')), label);
+    await tester.enterText(find.byKey(const Key('step-value-0')), stepValue);
+    await tester.tap(find.text('Save'));
+    await tester.pumpAndSettle();
+  }
+
+  /// Long-press a chip to start the drag, move to [to]'s centre and release.
+  Future<void> dragChip(WidgetTester tester, Finder from, Finder to) async {
+    final gesture = await tester.startGesture(tester.getCenter(from));
+    await tester.pump(const Duration(milliseconds: 600));
+    await gesture.moveTo(tester.getCenter(to));
+    await tester.pump();
+    await gesture.up();
+    await tester.pumpAndSettle();
+  }
+
+  String tokenOf(ProviderContainer container, String label) {
+    final s = container.read(customKeysProvider);
+    final b = s.buttons.firstWhere((b) => b.label == label);
+    return 'ck:${b.id.substring(3)}';
+  }
+
+  group('CustomKeysScreen', () {
+    testWidgets('empty state shows headers and default layout chips', (
+      tester,
+    ) async {
+      SharedPreferences.setMockInitialValues({});
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      await pumpScreen(tester, container);
+
+      expect(find.text('Custom Buttons'), findsOneWidget);
+      expect(find.text('Buttons'), findsOneWidget);
+      expect(find.text('Layout — Custom Row'), findsOneWidget);
+      expect(find.text('Layout — Row 1'), findsOneWidget);
+      expect(find.text('Layout — Row 2'), findsOneWidget);
+      expect(find.text('Unused'), findsOneWidget);
+      expect(
+        find.text('Drag buttons here to hide them from the bar.'),
+        findsOneWidget,
+      );
+
+      // Default row 1 standard chips (tokenLabel casing).
+      expect(find.text('ESC'), findsOneWidget);
+      expect(find.text('TAB'), findsOneWidget);
+      expect(find.text('ENTER'), findsOneWidget);
+      // Default row 2 standard chips.
+      expect(find.text('PgUp'), findsOneWidget);
+      expect(find.text('Right'), findsOneWidget);
+      // The direct-input extras default onto the unused shelf.
+      expect(find.byKey(const Key('chip-shelf-num1')), findsOneWidget);
+      expect(find.text('1'), findsOneWidget);
+
+      // The per-row '+' pickers are gone; dragging replaces them.
+      expect(find.byKey(const Key('row-0-add')), findsNothing);
+      expect(find.byKey(const Key('row-1-add')), findsNothing);
+      expect(find.byKey(const Key('row-2-add')), findsNothing);
+    });
+
+    testWidgets('custom row section renders its chips', (tester) async {
+      SharedPreferences.setMockInitialValues({});
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      await pumpScreen(tester, container);
+
+      expect(find.text('Layout — Custom Row'), findsOneWidget);
+
+      await addButton(tester, 'Top Chip', 't');
+      final token = tokenOf(container, 'Top Chip');
+      expect(find.byKey(Key('chip-0-$token')), findsOneWidget);
+    });
+
+    testWidgets('add button appears in list and row 0', (tester) async {
+      SharedPreferences.setMockInitialValues({});
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      await pumpScreen(tester, container);
+
+      await addButton(tester, 'My Button', 'hello');
+
+      // '+ Add button' now auto-places the button on the custom (top) row.
+      final token = tokenOf(container, 'My Button');
+      final s = container.read(customKeysProvider);
+      expect(s.buttons.single.label, 'My Button');
+      expect(s.row0, contains(token));
+      expect(s.unplacedButtons(), isEmpty);
+
+      // Appears in the library list and in the row 0 chip.
+      expect(find.text('My Button'), findsNWidgets(2));
+      expect(find.text("'hello'"), findsOneWidget);
+    });
+
+    testWidgets('add button lands at the head of the custom row', (
+      tester,
+    ) async {
+      SharedPreferences.setMockInitialValues({});
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      await pumpScreen(tester, container);
+
+      await addButton(tester, 'First', '1');
+      await addButton(tester, 'Second', '2');
+
+      final first = tokenOf(container, 'First');
+      final second = tokenOf(container, 'Second');
+      final s = container.read(customKeysProvider);
+      expect(s.row0.first, second);
+      expect(s.row0[1], first);
+      expect(s.unplacedButtons(), isEmpty);
+    });
+
+    testWidgets('edit button pre-filled then save updates', (tester) async {
+      SharedPreferences.setMockInitialValues({});
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      await pumpScreen(tester, container);
+
+      await addButton(tester, 'Original', 'first');
+      // Open the editor from the library list tile (the chip shares the label).
+      await tester.tap(find.widgetWithText(ListTile, 'Original'));
+      await tester.pumpAndSettle();
+
+      final labelField = tester.widget<TextField>(
+        find.byKey(const Key('label-field')),
+      );
+      expect(labelField.controller!.text, 'Original');
+      final valueField = tester.widget<TextField>(
+        find.byKey(const Key('step-value-0')),
+      );
+      expect(valueField.controller!.text, 'first');
+
+      await tester.enterText(find.byKey(const Key('label-field')), 'Renamed');
+      await tester.enterText(find.byKey(const Key('step-value-0')), 'second');
+      await tester.tap(find.text('Save'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Renamed'), findsNWidgets(2));
+      expect(find.text('Original'), findsNothing);
+      expect(
+        container.read(customKeysProvider).buttons.single.label,
+        'Renamed',
+      );
+      expect(
+        container.read(customKeysProvider).buttons.single.steps.single.value,
+        'second',
+      );
+    });
+
+    testWidgets('delete removes from list and from layout tokens', (
+      tester,
+    ) async {
+      SharedPreferences.setMockInitialValues({});
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      await pumpScreen(tester, container);
+
+      await addButton(tester, 'Doomed', 'x');
+      // '+ Add button' auto-places it on the custom (top) row.
+      final token = tokenOf(container, 'Doomed');
+      expect(container.read(customKeysProvider).row0, contains(token));
+
+      final id = container.read(customKeysProvider).buttons.single.id;
+      await tester.tap(find.byKey(Key('delete-$id')));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Doomed'), findsNothing);
+      expect(container.read(customKeysProvider).buttons, isEmpty);
+      expect(
+        container.read(customKeysProvider).row0,
+        CustomKeyRows.standardRow0,
+      );
+    });
+
+    testWidgets('standard token drags from row 1 to row 0 index 0', (
+      tester,
+    ) async {
+      SharedPreferences.setMockInitialValues({});
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      await pumpScreen(tester, container);
+
+      // Drag ESC out of row 1 into the leading slot of the custom row.
+      await dragChip(
+        tester,
+        find.byKey(const Key('chip-1-esc')),
+        find.byKey(const Key('slot-0-0')),
+      );
+
+      final s = container.read(customKeysProvider);
+      expect(s.row0.first, 'esc');
+      expect(s.row1, isNot(contains('esc')));
+      expect(s.row1.first, 'tab');
+    });
+
+    testWidgets('custom chip drags from row 0 to row 2 trailing slot', (
+      tester,
+    ) async {
+      SharedPreferences.setMockInitialValues({});
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      await pumpScreen(tester, container);
+
+      await addButton(tester, 'Wanderer', 'w');
+      final token = tokenOf(container, 'Wanderer');
+
+      // Row 2 keeps its 9 default standard tokens, so its trailing slot is 9.
+      await dragChip(
+        tester,
+        find.byKey(Key('chip-0-$token')),
+        find.byKey(const Key('slot-2-9')),
+      );
+
+      final s = container.read(customKeysProvider);
+      expect(s.row0, CustomKeyRows.standardRow0);
+      expect(s.row2.last, token);
+      expect(s.row2.length, 10);
+    });
+
+    testWidgets('within-row drag to a later slot reorders', (tester) async {
+      SharedPreferences.setMockInitialValues({});
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      await pumpScreen(tester, container);
+
+      await addButton(tester, 'A', 'a');
+      await addButton(tester, 'B', 'b');
+      await addButton(tester, 'C', 'c');
+      final a = tokenOf(container, 'A');
+      final b = tokenOf(container, 'B');
+      final c = tokenOf(container, 'C');
+      var s = container.read(customKeysProvider);
+      expect(s.row0, [c, b, a]);
+
+      // Drag C (the leading chip) to the trailing slot (index 3).
+      await dragChip(
+        tester,
+        find.byKey(Key('chip-0-$c')),
+        find.byKey(const Key('slot-0-3')),
+      );
+
+      s = container.read(customKeysProvider);
+      expect(s.row0, [b, a, c]);
+    });
+
+    testWidgets('chip drags onto shelf and becomes unused', (tester) async {
+      SharedPreferences.setMockInitialValues({});
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      await pumpScreen(tester, container);
+
+      // Drag a standard row-1 chip onto the shelf.
+      await dragChip(
+        tester,
+        find.byKey(const Key('chip-1-esc')),
+        find.byKey(const Key('slot-shelf')),
+      );
+
+      final s = container.read(customKeysProvider);
+      expect(s.row1, isNot(contains('esc')));
+      expect(s.unusedTokens(), contains('esc'));
+      expect(find.byKey(const Key('chip-shelf-esc')), findsOneWidget);
+    });
+
+    testWidgets('chip drags out of the shelf into a row', (tester) async {
+      SharedPreferences.setMockInitialValues({});
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      await pumpScreen(tester, container);
+
+      // num1 starts unused on the shelf; drag it into row 0's leading slot.
+      await dragChip(
+        tester,
+        find.byKey(const Key('chip-shelf-num1')),
+        find.byKey(const Key('slot-0-0')),
+      );
+
+      final s = container.read(customKeysProvider);
+      expect(s.row0.first, 'num1');
+      expect(s.unusedTokens(), isNot(contains('num1')));
+    });
+
+    testWidgets('tapping a custom chip opens the editor', (tester) async {
+      SharedPreferences.setMockInitialValues({});
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      await pumpScreen(tester, container);
+
+      await addButton(tester, 'Chip Edit', 'x');
+      final token = tokenOf(container, 'Chip Edit');
+
+      await tester.tap(find.byKey(Key('chip-0-$token')));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('label-field')), findsOneWidget);
+      // The old move sheet and per-row '+' picker are gone.
+      expect(find.text('Move Left'), findsNothing);
+      expect(find.text('Move Right'), findsNothing);
+      expect(find.text('Move to Row 1'), findsNothing);
+      expect(find.byKey(const Key('row-1-add')), findsNothing);
+    });
+
+    testWidgets('persists across provider recreation', (tester) async {
+      SharedPreferences.setMockInitialValues({});
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      await pumpScreen(tester, container);
+
+      await addButton(tester, 'Persist Me', 'abc');
+      await tester.runAsync(
+        () => Future<void>.delayed(const Duration(milliseconds: 20)),
+      );
+
+      final fresh = ProviderContainer();
+      addTearDown(fresh.dispose);
+      fresh.read(customKeysProvider); // triggers async load
+      await tester.runAsync(
+        () => Future<void>.delayed(const Duration(milliseconds: 20)),
+      );
+
+      final s = fresh.read(customKeysProvider);
+      expect(s.buttons.single.label, 'Persist Me');
+    });
+
+    testWidgets('edit placed button save unchanged keeps it', (tester) async {
+      SharedPreferences.setMockInitialValues({});
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      await pumpScreen(tester, container);
+
+      await addButton(tester, 'Keep', 'same');
+      final token = tokenOf(container, 'Keep');
+
+      // Open the editor from the library list tile (the chip shares the label).
+      await tester.tap(find.widgetWithText(ListTile, 'Keep'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Save'));
+      await tester.pumpAndSettle();
+
+      final s = container.read(customKeysProvider);
+      expect(s.buttons.single.label, 'Keep');
+      expect(s.buttons.single.steps.single.value, 'same');
+      expect(s.row0, contains(token));
+      expect(find.text('Keep'), findsNWidgets(2));
+    });
+
+    testWidgets('delete from edit dialog removes button and tokens', (
+      tester,
+    ) async {
+      SharedPreferences.setMockInitialValues({});
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      await pumpScreen(tester, container);
+
+      await addButton(tester, 'Gone', 'g');
+      final token = tokenOf(container, 'Gone');
+      expect(container.read(customKeysProvider).row0, contains(token));
+
+      // Open the editor from the library list tile.
+      await tester.tap(find.widgetWithText(ListTile, 'Gone'));
+      await tester.pumpAndSettle();
+
+      // Delete → confirmation dialog → confirm.
+      await tester.tap(find.byKey(const Key('dialog-delete')));
+      await tester.pumpAndSettle();
+      expect(find.text('Delete button?'), findsOneWidget);
+      await tester.tap(
+        find.descendant(
+          of: find.widgetWithText(AlertDialog, 'Delete button?'),
+          matching: find.text('Delete'),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final s = container.read(customKeysProvider);
+      expect(s.buttons, isEmpty);
+      expect(s.row0, CustomKeyRows.standardRow0);
+      expect(s.row1, CustomKeyRows.standardRow1);
+      expect(s.row2, CustomKeyRows.standardRow2);
+      expect(find.text('Gone'), findsNothing);
+    });
+  });
+}

--- a/test/screens/custom_keys/custom_keys_screen_test.dart
+++ b/test/screens/custom_keys/custom_keys_screen_test.dart
@@ -88,10 +88,11 @@ void main() {
       expect(find.byKey(const Key('chip-shelf-num1')), findsOneWidget);
       expect(find.text('1'), findsOneWidget);
 
-      // The per-row '+' pickers are gone; dragging replaces them.
-      expect(find.byKey(const Key('row-0-add')), findsNothing);
-      expect(find.byKey(const Key('row-1-add')), findsNothing);
-      expect(find.byKey(const Key('row-2-add')), findsNothing);
+      // Each row header offers "new button in this row" and "delete row".
+      expect(find.byKey(const Key('row-0-add')), findsOneWidget);
+      expect(find.byKey(const Key('row-2-delete')), findsOneWidget);
+      // An empty row says why it is invisible in the bar.
+      expect(find.text('Empty — hidden in the bar'), findsOneWidget);
     });
 
     testWidgets('custom row section renders its chips', (tester) async {
@@ -326,11 +327,10 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.byKey(const Key('label-field')), findsOneWidget);
-      // The old move sheet and per-row '+' picker are gone.
+      // The old move sheet and insert picker are gone; dragging replaces them.
       expect(find.text('Move Left'), findsNothing);
       expect(find.text('Move Right'), findsNothing);
       expect(find.text('Move to Row 1'), findsNothing);
-      expect(find.byKey(const Key('row-1-add')), findsNothing);
     });
 
     testWidgets('persists across provider recreation', (tester) async {
@@ -517,6 +517,53 @@ void main() {
       await tester.pumpAndSettle();
       expect(container.read(customKeysProvider).rows, [<String>[]]);
       expect(find.text('Layout — Row 1'), findsOneWidget);
+    });
+
+    // The reported bug: a button created while looking at row N must land in
+    // row N, not in the top row (an empty new row renders nothing in the bar,
+    // so the button looked lost).
+    testWidgets('the row header + creates the button in that row', (
+      tester,
+    ) async {
+      SharedPreferences.setMockInitialValues({});
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      await pumpScreen(tester, container);
+
+      await tester.tap(find.byKey(const Key('add-row')));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const Key('row-3-add')));
+      await tester.pumpAndSettle();
+      await tester.enterText(find.byKey(const Key('label-field')), 'InRow4');
+      await tester.enterText(find.byKey(const Key('step-value-0')), 'x');
+      await tester.tap(find.text('Save'));
+      await tester.pumpAndSettle();
+
+      final s = container.read(customKeysProvider);
+      final token = tokenOf(container, 'InRow4');
+      expect(s.rows[3], [token]);
+      expect(s.rows[0], isEmpty);
+      expect(s.unplacedButtons(), isEmpty);
+    });
+
+    // The global add keeps its fast path: head of the topmost row.
+    testWidgets('+ Add button still lands at the head of the top row', (
+      tester,
+    ) async {
+      SharedPreferences.setMockInitialValues({});
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      await pumpScreen(tester, container);
+
+      await addButton(tester, 'TopOne', 'a');
+      await addButton(tester, 'TopTwo', 'b');
+
+      final s = container.read(customKeysProvider);
+      expect(s.rows[0], [
+        tokenOf(container, 'TopTwo'),
+        tokenOf(container, 'TopOne'),
+      ]);
     });
   });
 }

--- a/test/screens/custom_keys/custom_keys_screen_test.dart
+++ b/test/screens/custom_keys/custom_keys_screen_test.dart
@@ -68,9 +68,9 @@ void main() {
 
       expect(find.text('Custom Buttons'), findsOneWidget);
       expect(find.text('Buttons'), findsOneWidget);
-      expect(find.text('Layout — Custom Row'), findsOneWidget);
       expect(find.text('Layout — Row 1'), findsOneWidget);
       expect(find.text('Layout — Row 2'), findsOneWidget);
+      expect(find.text('Layout — Row 3'), findsOneWidget);
       expect(find.text('Unused'), findsOneWidget);
       expect(
         find.text('Drag buttons here to hide them from the bar.'),
@@ -100,7 +100,7 @@ void main() {
       addTearDown(container.dispose);
       await pumpScreen(tester, container);
 
-      expect(find.text('Layout — Custom Row'), findsOneWidget);
+      expect(find.text('Layout — Row 1'), findsOneWidget);
 
       await addButton(tester, 'Top Chip', 't');
       final token = tokenOf(container, 'Top Chip');
@@ -119,7 +119,7 @@ void main() {
       final token = tokenOf(container, 'My Button');
       final s = container.read(customKeysProvider);
       expect(s.buttons.single.label, 'My Button');
-      expect(s.row0, contains(token));
+      expect(s.rows[0], contains(token));
       expect(s.unplacedButtons(), isEmpty);
 
       // Appears in the library list and in the row 0 chip.
@@ -141,8 +141,8 @@ void main() {
       final first = tokenOf(container, 'First');
       final second = tokenOf(container, 'Second');
       final s = container.read(customKeysProvider);
-      expect(s.row0.first, second);
-      expect(s.row0[1], first);
+      expect(s.rows[0].first, second);
+      expect(s.rows[0][1], first);
       expect(s.unplacedButtons(), isEmpty);
     });
 
@@ -194,7 +194,7 @@ void main() {
       await addButton(tester, 'Doomed', 'x');
       // '+ Add button' auto-places it on the custom (top) row.
       final token = tokenOf(container, 'Doomed');
-      expect(container.read(customKeysProvider).row0, contains(token));
+      expect(container.read(customKeysProvider).rows[0], contains(token));
 
       final id = container.read(customKeysProvider).buttons.single.id;
       await tester.tap(find.byKey(Key('delete-$id')));
@@ -202,10 +202,7 @@ void main() {
 
       expect(find.text('Doomed'), findsNothing);
       expect(container.read(customKeysProvider).buttons, isEmpty);
-      expect(
-        container.read(customKeysProvider).row0,
-        CustomKeyRows.standardRow0,
-      );
+      expect(container.read(customKeysProvider).rows[0], <String>[]);
     });
 
     testWidgets('standard token drags from row 1 to row 0 index 0', (
@@ -224,9 +221,9 @@ void main() {
       );
 
       final s = container.read(customKeysProvider);
-      expect(s.row0.first, 'esc');
-      expect(s.row1, isNot(contains('esc')));
-      expect(s.row1.first, 'tab');
+      expect(s.rows[0].first, 'esc');
+      expect(s.rows[1], isNot(contains('esc')));
+      expect(s.rows[1].first, 'tab');
     });
 
     testWidgets('custom chip drags from row 0 to row 2 trailing slot', (
@@ -248,9 +245,9 @@ void main() {
       );
 
       final s = container.read(customKeysProvider);
-      expect(s.row0, CustomKeyRows.standardRow0);
-      expect(s.row2.last, token);
-      expect(s.row2.length, 10);
+      expect(s.rows[0], <String>[]);
+      expect(s.rows[2].last, token);
+      expect(s.rows[2].length, 10);
     });
 
     testWidgets('within-row drag to a later slot reorders', (tester) async {
@@ -266,7 +263,7 @@ void main() {
       final b = tokenOf(container, 'B');
       final c = tokenOf(container, 'C');
       var s = container.read(customKeysProvider);
-      expect(s.row0, [c, b, a]);
+      expect(s.rows[0], [c, b, a]);
 
       // Drag C (the leading chip) to the trailing slot (index 3).
       await dragChip(
@@ -276,7 +273,7 @@ void main() {
       );
 
       s = container.read(customKeysProvider);
-      expect(s.row0, [b, a, c]);
+      expect(s.rows[0], [b, a, c]);
     });
 
     testWidgets('chip drags onto shelf and becomes unused', (tester) async {
@@ -293,7 +290,7 @@ void main() {
       );
 
       final s = container.read(customKeysProvider);
-      expect(s.row1, isNot(contains('esc')));
+      expect(s.rows[1], isNot(contains('esc')));
       expect(s.unusedTokens(), contains('esc'));
       expect(find.byKey(const Key('chip-shelf-esc')), findsOneWidget);
     });
@@ -312,7 +309,7 @@ void main() {
       );
 
       final s = container.read(customKeysProvider);
-      expect(s.row0.first, 'num1');
+      expect(s.rows[0].first, 'num1');
       expect(s.unusedTokens(), isNot(contains('num1')));
     });
 
@@ -376,7 +373,7 @@ void main() {
       final s = container.read(customKeysProvider);
       expect(s.buttons.single.label, 'Keep');
       expect(s.buttons.single.steps.single.value, 'same');
-      expect(s.row0, contains(token));
+      expect(s.rows[0], contains(token));
       expect(find.text('Keep'), findsNWidgets(2));
     });
 
@@ -390,7 +387,7 @@ void main() {
 
       await addButton(tester, 'Gone', 'g');
       final token = tokenOf(container, 'Gone');
-      expect(container.read(customKeysProvider).row0, contains(token));
+      expect(container.read(customKeysProvider).rows[0], contains(token));
 
       // Open the editor from the library list tile.
       await tester.tap(find.widgetWithText(ListTile, 'Gone'));
@@ -410,10 +407,116 @@ void main() {
 
       final s = container.read(customKeysProvider);
       expect(s.buttons, isEmpty);
-      expect(s.row0, CustomKeyRows.standardRow0);
-      expect(s.row1, CustomKeyRows.standardRow1);
-      expect(s.row2, CustomKeyRows.standardRow2);
+      expect(s.rows[0], <String>[]);
+      expect(s.rows[1], CustomKeyRows.standardRow1);
+      expect(s.rows[2], CustomKeyRows.standardRow2);
       expect(find.text('Gone'), findsNothing);
+    });
+
+    // Defends the add-row contract: a new empty strip appears at the bottom and
+    // accepts a dropped token.
+    testWidgets('+ Add row appends a strip that accepts a chip', (
+      tester,
+    ) async {
+      SharedPreferences.setMockInitialValues({});
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      await pumpScreen(tester, container);
+
+      await tester.tap(find.byKey(const Key('add-row')));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Layout — Row 4'), findsOneWidget);
+      expect(container.read(customKeysProvider).rows.length, 4);
+
+      await dragChip(
+        tester,
+        find.byKey(const Key('chip-1-esc')),
+        find.byKey(const Key('slot-3-0')),
+      );
+
+      expect(container.read(customKeysProvider).rows[3], ['esc']);
+      expect(
+        container.read(customKeysProvider).rows[1].contains('esc'),
+        isFalse,
+      );
+    });
+
+    // Defends the cap: the bar has finite height, so the affordance goes dead.
+    testWidgets('the add-row tile is disabled at maxRows', (tester) async {
+      SharedPreferences.setMockInitialValues({});
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      await pumpScreen(tester, container);
+
+      for (
+        var i = container.read(customKeysProvider).rows.length;
+        i < CustomKeyRows.maxRows;
+        i++
+      ) {
+        await tester.tap(find.byKey(const Key('add-row')));
+        await tester.pumpAndSettle();
+      }
+
+      expect(
+        container.read(customKeysProvider).rows.length,
+        CustomKeyRows.maxRows,
+      );
+      // At maxRows the tile can sit below the fold; scroll it in before reading.
+      await tester.scrollUntilVisible(
+        find.byKey(const Key('add-row')),
+        200,
+        scrollable: find.byType(Scrollable).first,
+      );
+      final button = tester.widget<TextButton>(
+        find.byKey(const Key('add-row')),
+      );
+      expect(button.onPressed, isNull);
+    });
+
+    // Defends the delete-row contract: the strip goes, the chips come back as
+    // unused, and the remaining headers renumber.
+    testWidgets('deleting a row frees its chips and renumbers headers', (
+      tester,
+    ) async {
+      SharedPreferences.setMockInitialValues({});
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      await pumpScreen(tester, container);
+
+      // Row 2 (index 1) is the modifier row.
+      await tester.tap(find.byKey(const Key('row-1-delete')));
+      await tester.pumpAndSettle();
+
+      expect(container.read(customKeysProvider).rows.length, 2);
+      expect(find.text('Layout — Row 3'), findsNothing);
+      expect(
+        container.read(customKeysProvider).unusedTokens(),
+        containsAll(CustomKeyRows.standardRow1),
+      );
+      // The freed chip is reachable on the shelf.
+      expect(find.byKey(const Key('chip-shelf-esc')), findsOneWidget);
+    });
+
+    // Defends the empty-layout edge: every row can be deleted and a row can be
+    // created again from scratch.
+    testWidgets('all rows can be deleted and one added back', (tester) async {
+      SharedPreferences.setMockInitialValues({});
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      await pumpScreen(tester, container);
+
+      for (var i = 0; i < 3; i++) {
+        await tester.tap(find.byKey(const Key('row-0-delete')));
+        await tester.pumpAndSettle();
+      }
+      expect(container.read(customKeysProvider).rows, isEmpty);
+      expect(find.text('Layout — Row 1'), findsNothing);
+
+      await tester.tap(find.byKey(const Key('add-row')));
+      await tester.pumpAndSettle();
+      expect(container.read(customKeysProvider).rows, [<String>[]]);
+      expect(find.text('Layout — Row 1'), findsOneWidget);
     });
   });
 }

--- a/test/screens/settings_screen_test.dart
+++ b/test/screens/settings_screen_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_muxpod/l10n/app_localizations.dart';
 import 'package:flutter_muxpod/providers/settings_provider.dart';
 import 'package:flutter_muxpod/screens/settings/settings_screen.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:flutter_muxpod/services/keychain/secure_storage.dart';
 
 Widget _buildApp() {
   return const ProviderScope(
@@ -182,7 +183,12 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      await scrollUntilFound(tester, find.text('Scroll Send Input'));
+      // Scroll to the note itself: asserting on a sibling below the tile makes
+      // the test depend on where the section lands in the list.
+      await scrollUntilFound(
+        tester,
+        find.text('Wheel send is unverified; falling back to key send.'),
+      );
       expect(
         find.text('Wheel send is unverified; falling back to key send.'),
         findsOneWidget,
@@ -281,6 +287,71 @@ void main() {
       expect(find.text('System'), findsOneWidget);
       expect(find.text('日本語'), findsOneWidget);
       expect(find.text('English'), findsOneWidget);
+    });
+
+    testWidgets(
+      'Clear SSH Host Keys clears stored fingerprints after confirm',
+      (tester) async {
+        SecureStorageService.setTestValues({
+          'hostkey_192.168.1.3_22_ssh-ed25519': 'aa:bb:cc',
+          'password_conn1': 'secret',
+        });
+        addTearDown(() => SecureStorageService.setTestValues(null));
+
+        await tester.pumpWidget(_buildApp());
+        await tester.pumpAndSettle();
+
+        await scrollUntilFound(tester, find.text('Clear SSH Host Keys'));
+        await tester.ensureVisible(find.text('Clear SSH Host Keys'));
+        await tester.pumpAndSettle();
+        await tester.tap(find.text('Clear SSH Host Keys'));
+        await tester.pumpAndSettle();
+
+        // 確認ダイアログ
+        expect(find.text('Clear SSH host keys?'), findsOneWidget);
+
+        await tester.tap(find.text('Clear'));
+        await tester.pumpAndSettle();
+
+        final service = SecureStorageService();
+        expect(
+          await service.getHostKeyFingerprint('192.168.1.3', 22, 'ssh-ed25519'),
+          isNull,
+        );
+        // 認証情報は残る
+        expect(await service.getPassword('conn1'), 'secret');
+        expect(find.text('Cleared 1 saved host key'), findsOneWidget);
+      },
+    );
+
+    testWidgets('Clear SSH Host Keys cancel keeps fingerprints', (
+      tester,
+    ) async {
+      SecureStorageService.setTestValues({
+        'hostkey_192.168.1.3_22_ssh-ed25519': 'aa:bb:cc',
+      });
+      addTearDown(() => SecureStorageService.setTestValues(null));
+
+      await tester.pumpWidget(_buildApp());
+      await tester.pumpAndSettle();
+
+      await scrollUntilFound(tester, find.text('Clear SSH Host Keys'));
+      await tester.ensureVisible(find.text('Clear SSH Host Keys'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Clear SSH Host Keys'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Cancel'));
+      await tester.pumpAndSettle();
+
+      expect(
+        await SecureStorageService().getHostKeyFingerprint(
+          '192.168.1.3',
+          22,
+          'ssh-ed25519',
+        ),
+        'aa:bb:cc',
+      );
     });
   });
 }

--- a/test/screens/terminal/terminal_custom_keys_e2e_test.dart
+++ b/test/screens/terminal/terminal_custom_keys_e2e_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:flutter_muxpod/providers/custom_keys_provider.dart';
+import 'package:flutter_muxpod/services/custom_keys/custom_key_button.dart';
 import 'package:flutter_muxpod/providers/settings_provider.dart';
 import 'package:flutter_muxpod/screens/terminal/terminal_screen.dart';
 import 'package:flutter_muxpod/widgets/special_keys_bar.dart';
@@ -24,7 +25,11 @@ void main() {
         ],
       },
     ]),
-    'custom_key_row1_v1': jsonEncode(['ck:0001_dead']),
+    'custom_key_rows_v1': jsonEncode([
+      <String>[],
+      ['ck:0001_dead'],
+      CustomKeyRows.standardRow2,
+    ]),
   };
 
   // 標準 row1 + 多数のカスタムボタンで行を溢れさせ、末尾への自動スクロールを
@@ -56,7 +61,7 @@ void main() {
     }
     return {
       'custom_key_buttons_v1': jsonEncode(buttons),
-      'custom_key_row1_v1': jsonEncode(row1),
+      'custom_key_rows_v1': jsonEncode([<String>[], row1, <String>[]]),
     };
   }
 
@@ -107,8 +112,8 @@ void main() {
       final state = container.read(customKeysProvider);
       final added = state.buttons.firstWhere((b) => b.label == 'Fresh Button');
       final token = 'ck:${added.id.substring(3)}';
-      expect(state.row0, contains(token));
-      expect(state.row0.first, token);
+      expect(state.rows[0], contains(token));
+      expect(state.rows[0].first, token);
       expect(find.widgetWithText(ListTile, 'Fresh Button'), findsOneWidget);
       // Contract: the added button lands as a draggable chip in the Layout —
       // Custom Row strip (Key('chip-$row-$token')), not the removed `+` ActionChip.
@@ -189,9 +194,9 @@ void main() {
 
       final state = container.read(customKeysProvider);
       expect(state.buttons, isEmpty);
-      expect(state.row0.contains('ck:0001_dead'), isFalse);
-      expect(state.row1.contains('ck:0001_dead'), isFalse);
-      expect(state.row2.contains('ck:0001_dead'), isFalse);
+      expect(state.rows[0].contains('ck:0001_dead'), isFalse);
+      expect(state.rows[1].contains('ck:0001_dead'), isFalse);
+      expect(state.rows[2].contains('ck:0001_dead'), isFalse);
     });
 
     testWidgets('editor dialog input text is visible (onSurface) and present', (
@@ -248,7 +253,11 @@ void main() {
             },
           ]),
           'custom_key_row0_v1': jsonEncode(<String>[]),
-          'custom_key_row1_v1': jsonEncode(['ck:0001_dead']),
+          'custom_key_rows_v1': jsonEncode([
+            <String>[],
+            ['ck:0001_dead'],
+            CustomKeyRows.standardRow2,
+          ]),
           'custom_key_row2_v1': jsonEncode(<String>[]),
         });
 

--- a/test/screens/terminal/terminal_custom_keys_e2e_test.dart
+++ b/test/screens/terminal/terminal_custom_keys_e2e_test.dart
@@ -1,0 +1,268 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:flutter_muxpod/providers/custom_keys_provider.dart';
+import 'package:flutter_muxpod/providers/settings_provider.dart';
+import 'package:flutter_muxpod/screens/terminal/terminal_screen.dart';
+import 'package:flutter_muxpod/widgets/special_keys_bar.dart';
+
+import '../../helpers/terminal_test_scaffold.dart';
+
+void main() {
+  // 単一カスタムボタン + row1 トークンのシード（長押し削除・ダイアログ入力用）。
+  Map<String, Object> singleSeedPrefs() => {
+    'custom_key_buttons_v1': jsonEncode([
+      {
+        'id': 'ck_0001_dead',
+        'label': 'Del Me',
+        'steps': [
+          {'type': 'text', 'value': 'hi'},
+        ],
+      },
+    ]),
+    'custom_key_row1_v1': jsonEncode(['ck:0001_dead']),
+  };
+
+  // 標準 row1 + 多数のカスタムボタンで行を溢れさせ、末尾への自動スクロールを
+  // 検証するシード。行がビューポート（1080px）を超えると、新規ボタンはスクロール
+  // しない限り画面外になる。
+  Map<String, Object> crowdedSeedPrefs() {
+    final buttons = <Map<String, Object>>[];
+    final row1 = <String>[
+      'esc',
+      'tab',
+      'ctrl',
+      'alt',
+      'shift',
+      'enter',
+      'senter',
+      'slash',
+      'dash',
+    ];
+    for (var i = 1; i <= 20; i++) {
+      final suffix = 'seed${i.toString().padLeft(2, '0')}_aaaa';
+      buttons.add({
+        'id': 'ck_$suffix',
+        'label': 'Seed $i',
+        'steps': [
+          {'type': 'text', 'value': 's$i'},
+        ],
+      });
+      row1.add('ck:$suffix');
+    }
+    return {
+      'custom_key_buttons_v1': jsonEncode(buttons),
+      'custom_key_row1_v1': jsonEncode(row1),
+    };
+  }
+
+  // pumpTerminalScreen は SharedPreferences を空にリセットしてから pump するため、
+  // 再シードして notifier を invalidate し、シードを再読み込みさせる。
+  Future<ProviderContainer> seedAndReload(
+    WidgetTester tester,
+    Map<String, Object> prefs,
+  ) async {
+    SharedPreferences.setMockInitialValues(prefs);
+    final container = ProviderScope.containerOf(
+      tester.element(find.byType(TerminalScreen)),
+    );
+    container.invalidate(customKeysProvider);
+    await tester.pumpAndSettle();
+    return container;
+  }
+
+  group('TerminalScreen custom key buttons E2E', () {
+    testWidgets('add → auto-place → visible on the top bar row', (
+      tester,
+    ) async {
+      await TerminalTestScaffold.pumpTerminalScreen(tester);
+      final container = await seedAndReload(tester, crowdedSeedPrefs());
+
+      // 鉛筆（管理）ボタンで CustomKeysScreen を開く。
+      await tester.tap(
+        find.descendant(
+          of: find.byType(SpecialKeysBar),
+          matching: find.byIcon(Icons.edit_outlined),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(find.text('Custom Buttons'), findsOneWidget);
+
+      // エディタダイアログで新規ボタンを追加。
+      await tester.tap(find.text('+ Add button'));
+      await tester.pumpAndSettle();
+      await tester.enterText(
+        find.byKey(const Key('label-field')),
+        'Fresh Button',
+      );
+      await tester.enterText(find.byKey(const Key('step-value-0')), 'hello');
+      await tester.tap(find.text('Save'));
+      await tester.pumpAndSettle();
+
+      // ボタン一覧と Layout Custom Row チップの両方に出現し、row0 先頭に配置される。
+      final state = container.read(customKeysProvider);
+      final added = state.buttons.firstWhere((b) => b.label == 'Fresh Button');
+      final token = 'ck:${added.id.substring(3)}';
+      expect(state.row0, contains(token));
+      expect(state.row0.first, token);
+      expect(find.widgetWithText(ListTile, 'Fresh Button'), findsOneWidget);
+      // Contract: the added button lands as a draggable chip in the Layout —
+      // Custom Row strip (Key('chip-$row-$token')), not the removed `+` ActionChip.
+      expect(find.byKey(Key('chip-0-$token')), findsOneWidget);
+
+      // ターミナルへ戻る。
+      await tester.pageBack();
+      await tester.pumpAndSettle();
+
+      // 新規ボタンがトップバー行に可視・ヒット可能（自動スクロールで先頭が出現）。
+      final inBar = find.descendant(
+        of: find.byType(SpecialKeysBar),
+        matching: find.text('Fresh Button'),
+      );
+      expect(inBar, findsOneWidget);
+      expect(inBar.hitTestable(), findsOneWidget);
+    });
+
+    testWidgets('direct input shows typed text and sends it exactly once', (
+      tester,
+    ) async {
+      final client = await TerminalTestScaffold.pumpTerminalScreen(
+        tester,
+        settings: const AppSettings(
+          keepScreenOn: false,
+          directInputEnabled: true,
+        ),
+      );
+
+      final inputField = find.byWidgetPredicate(
+        (w) => w is TextField && w.decoration?.hintText == 'Type here...',
+      );
+      expect(inputField, findsOneWidget);
+
+      await tester.tap(inputField);
+      await tester.pump();
+      await tester.enterText(inputField, 'models');
+      await tester.pump();
+
+      // (a) 入力したテキストが欄に残って可視（クリアされない）。
+      final editable = tester.widget<EditableText>(
+        find.descendant(of: inputField, matching: find.byType(EditableText)),
+      );
+      expect(editable.controller.text, contains('models'));
+
+      // (b) 'models' がターミナルへちょうど1回だけ送信される（リテラル送信）。
+      final sent = client.sendKeysCommands
+          .where((c) => c.contains('models'))
+          .toList();
+      expect(sent.length, 1);
+      expect(sent.single, contains('-l -- models'));
+    });
+
+    testWidgets('long-press delete removes button and its row tokens', (
+      tester,
+    ) async {
+      await TerminalTestScaffold.pumpTerminalScreen(tester);
+      final container = await seedAndReload(tester, singleSeedPrefs());
+
+      expect(find.text('Del Me'), findsOneWidget);
+
+      await tester.longPress(find.text('Del Me'));
+      await tester.pumpAndSettle();
+
+      // エディタダイアログ: 削除 → 確認。
+      expect(find.byKey(const Key('dialog-delete')), findsOneWidget);
+      await tester.tap(find.byKey(const Key('dialog-delete')));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Delete button?'), findsOneWidget);
+      await tester.tap(
+        find.descendant(
+          of: find.widgetWithText(AlertDialog, 'Delete button?'),
+          matching: find.text('Delete'),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final state = container.read(customKeysProvider);
+      expect(state.buttons, isEmpty);
+      expect(state.row0.contains('ck:0001_dead'), isFalse);
+      expect(state.row1.contains('ck:0001_dead'), isFalse);
+      expect(state.row2.contains('ck:0001_dead'), isFalse);
+    });
+
+    testWidgets('editor dialog input text is visible (onSurface) and present', (
+      tester,
+    ) async {
+      await TerminalTestScaffold.pumpTerminalScreen(tester);
+      await seedAndReload(tester, singleSeedPrefs());
+
+      // バーのカスタムボタン長押しでエディタダイアログを開く。
+      await tester.longPress(find.text('Del Me'));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byKey(const Key('label-field')), 'Edited');
+      await tester.enterText(find.byKey(const Key('step-value-0')), 'typed');
+      await tester.pump();
+
+      // テーマの onSurface（ライト/ダーク両対応）と比較し、可視テキスト色を検証。
+      final onSurface = Theme.of(
+        tester.element(find.byKey(const Key('label-field'))),
+      ).colorScheme.onSurface;
+
+      final labelEditable = tester.widget<EditableText>(
+        find.descendant(
+          of: find.byKey(const Key('label-field')),
+          matching: find.byType(EditableText),
+        ),
+      );
+      expect(labelEditable.controller.text, 'Edited');
+      expect(labelEditable.style.color, onSurface);
+
+      final stepEditable = tester.widget<EditableText>(
+        find.descendant(
+          of: find.byKey(const Key('step-value-0')),
+          matching: find.byType(EditableText),
+        ),
+      );
+      expect(stepEditable.controller.text, 'typed');
+      expect(stepEditable.style.color, onSurface);
+    });
+    testWidgets(
+      'custom button seeded into row1 is tappable and sends its steps once',
+      (tester) async {
+        // Defends Bar contract: custom ck: tokens render in any row (row1 here)
+        // and execute their steps exactly once per tap through the terminal.
+        final client = await TerminalTestScaffold.pumpTerminalScreen(tester);
+        await seedAndReload(tester, {
+          'custom_key_buttons_v1': jsonEncode([
+            {
+              'id': 'ck_0001_dead',
+              'label': 'Del Me',
+              'steps': [
+                {'type': 'text', 'value': 'unique_step_42'},
+              ],
+            },
+          ]),
+          'custom_key_row0_v1': jsonEncode(<String>[]),
+          'custom_key_row1_v1': jsonEncode(['ck:0001_dead']),
+          'custom_key_row2_v1': jsonEncode(<String>[]),
+        });
+
+        expect(find.text('Del Me'), findsOneWidget);
+
+        await tester.tap(find.text('Del Me'));
+        await tester.pumpAndSettle();
+
+        final sent = client.sendKeysCommands
+            .where((c) => c.contains('unique_step_42'))
+            .toList();
+        expect(sent.length, 1);
+        expect(sent.single, contains('-l -- unique_step_42'));
+      },
+    );
+  });
+}

--- a/test/screens/terminal/terminal_custom_keys_test.dart
+++ b/test/screens/terminal/terminal_custom_keys_test.dart
@@ -23,7 +23,11 @@ void main() {
         ],
       },
     ]),
-    'custom_key_row1_v1': jsonEncode(['ck:0001_dead']),
+    'custom_key_rows_v1': jsonEncode([
+      <String>[],
+      ['ck:0001_dead'],
+      CustomKeyRows.standardRow2,
+    ]),
   };
 
   // pumpTerminalScreen resets SharedPreferences to empty before pumping, so
@@ -81,9 +85,9 @@ void main() {
 
       final state = container.read(customKeysProvider);
       expect(state.buttons, isEmpty);
-      expect(state.row0.contains('ck:0001_dead'), isFalse);
-      expect(state.row1.contains('ck:0001_dead'), isFalse);
-      expect(state.row2.contains('ck:0001_dead'), isFalse);
+      expect(state.rows[0].contains('ck:0001_dead'), isFalse);
+      expect(state.rows[1].contains('ck:0001_dead'), isFalse);
+      expect(state.rows[2].contains('ck:0001_dead'), isFalse);
     });
     testWidgets('standard token seeded into row0 renders in the terminal bar', (
       tester,
@@ -91,9 +95,11 @@ void main() {
       // Defends Bar contract: rows are authoritative end to end — a standard
       // token may live in any row ('esc', normally row 1, is placed in row 0).
       final prefs = <String, Object>{
-        'custom_key_row0_v1': jsonEncode(['esc']),
-        'custom_key_row1_v1': jsonEncode(<String>[]),
-        'custom_key_row2_v1': jsonEncode(<String>[]),
+        'custom_key_rows_v1': jsonEncode([
+          ['esc'],
+          <String>[],
+          <String>[],
+        ]),
       };
       await TerminalTestScaffold.pumpTerminalScreen(tester);
       await seedAndReload(tester, prefs);
@@ -113,9 +119,11 @@ void main() {
         // Defends Bar contract: an empty rendered row renders nothing, and the
         // manage (pencil) button pins to the first row that renders (row 2 here).
         final prefs = <String, Object>{
-          'custom_key_row0_v1': jsonEncode(<String>[]),
-          'custom_key_row1_v1': jsonEncode(<String>[]),
-          'custom_key_row2_v1': jsonEncode(CustomKeyRows.standardRow2),
+          'custom_key_rows_v1': jsonEncode([
+            <String>[],
+            <String>[],
+            CustomKeyRows.standardRow2,
+          ]),
         };
         await TerminalTestScaffold.pumpTerminalScreen(tester);
         await seedAndReload(tester, prefs);
@@ -152,5 +160,59 @@ void main() {
         );
       },
     );
+
+    testWidgets('a fourth user-created row renders and sends in the terminal', (
+      tester,
+    ) async {
+      // Defends the dynamic-rows contract end to end: a layout the user built
+      // with "+ Add row" reaches the bar, and its button sends its steps.
+      final prefs = <String, Object>{
+        'custom_key_buttons_v1': jsonEncode([
+          {
+            'id': 'ck_0042_row4',
+            'label': 'Row4',
+            'steps': [
+              {'type': 'text', 'value': 'from_row_four'},
+            ],
+          },
+        ]),
+        'custom_key_rows_v1': jsonEncode([
+          <String>[],
+          CustomKeyRows.standardRow1,
+          CustomKeyRows.standardRow2,
+          ['ck:0042_row4'],
+        ]),
+      };
+      final client = await TerminalTestScaffold.pumpTerminalScreen(tester);
+      await seedAndReload(tester, prefs);
+
+      final button = find.descendant(
+        of: find.byType(SpecialKeysBar),
+        matching: find.text('Row4'),
+      );
+      expect(button, findsOneWidget);
+      // Below the navigation row, i.e. it really is a fourth row.
+      expect(
+        tester.getTopLeft(button).dy,
+        greaterThan(
+          tester
+              .getTopLeft(
+                find.descendant(
+                  of: find.byType(SpecialKeysBar),
+                  matching: find.text('PgUp'),
+                ),
+              )
+              .dy,
+        ),
+      );
+
+      await tester.tap(button);
+      await tester.pumpAndSettle();
+
+      final sent = client.sendKeysCommands
+          .where((c) => c.contains('from_row_four'))
+          .toList();
+      expect(sent.length, 1);
+    });
   });
 }

--- a/test/screens/terminal/terminal_custom_keys_test.dart
+++ b/test/screens/terminal/terminal_custom_keys_test.dart
@@ -1,0 +1,156 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:flutter_muxpod/providers/custom_keys_provider.dart';
+import 'package:flutter_muxpod/screens/terminal/terminal_screen.dart';
+import 'package:flutter_muxpod/services/custom_keys/custom_key_button.dart';
+import 'package:flutter_muxpod/widgets/special_keys_bar.dart';
+
+import '../../helpers/terminal_test_scaffold.dart';
+
+void main() {
+  Map<String, Object> seedPrefs() => {
+    'custom_key_buttons_v1': jsonEncode([
+      {
+        'id': 'ck_0001_dead',
+        'label': 'Del Me',
+        'steps': [
+          {'type': 'text', 'value': 'hi'},
+        ],
+      },
+    ]),
+    'custom_key_row1_v1': jsonEncode(['ck:0001_dead']),
+  };
+
+  // pumpTerminalScreen resets SharedPreferences to empty before pumping, so
+  // re-seed and invalidate the notifier to reload the rows from prefs.
+  Future<ProviderContainer> seedAndReload(
+    WidgetTester tester,
+    Map<String, Object> prefs,
+  ) async {
+    SharedPreferences.setMockInitialValues(prefs);
+    final container = ProviderScope.containerOf(
+      tester.element(find.byType(TerminalScreen)),
+    );
+    container.invalidate(customKeysProvider);
+    await tester.pumpAndSettle();
+    return container;
+  }
+
+  group('TerminalScreen custom key buttons', () {
+    testWidgets('long-press → editor delete removes the button', (
+      tester,
+    ) async {
+      // Seed the prefs the real CustomKeysNotifier reads on load.
+      SharedPreferences.setMockInitialValues(seedPrefs());
+
+      await TerminalTestScaffold.pumpTerminalScreen(tester);
+
+      // pumpTerminalScreen resets SharedPreferences to empty before pumping, so
+      // re-seed and invalidate the notifier to reload the button from prefs.
+      SharedPreferences.setMockInitialValues(seedPrefs());
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(TerminalScreen)),
+      );
+      container.invalidate(customKeysProvider);
+      await tester.pumpAndSettle();
+
+      // The custom button shows in the top row of the special keys bar.
+      expect(find.text('Del Me'), findsOneWidget);
+
+      await tester.longPress(find.text('Del Me'));
+      await tester.pumpAndSettle();
+
+      // Editor dialog: delete → confirm.
+      expect(find.byKey(const Key('dialog-delete')), findsOneWidget);
+      await tester.tap(find.byKey(const Key('dialog-delete')));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Delete button?'), findsOneWidget);
+      await tester.tap(
+        find.descendant(
+          of: find.widgetWithText(AlertDialog, 'Delete button?'),
+          matching: find.text('Delete'),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final state = container.read(customKeysProvider);
+      expect(state.buttons, isEmpty);
+      expect(state.row0.contains('ck:0001_dead'), isFalse);
+      expect(state.row1.contains('ck:0001_dead'), isFalse);
+      expect(state.row2.contains('ck:0001_dead'), isFalse);
+    });
+    testWidgets('standard token seeded into row0 renders in the terminal bar', (
+      tester,
+    ) async {
+      // Defends Bar contract: rows are authoritative end to end — a standard
+      // token may live in any row ('esc', normally row 1, is placed in row 0).
+      final prefs = <String, Object>{
+        'custom_key_row0_v1': jsonEncode(['esc']),
+        'custom_key_row1_v1': jsonEncode(<String>[]),
+        'custom_key_row2_v1': jsonEncode(<String>[]),
+      };
+      await TerminalTestScaffold.pumpTerminalScreen(tester);
+      await seedAndReload(tester, prefs);
+
+      expect(
+        find.descendant(
+          of: find.byType(SpecialKeysBar),
+          matching: find.text('ESC'),
+        ),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets(
+      'empty row1 renders no modifier row while the pencil stays reachable',
+      (tester) async {
+        // Defends Bar contract: an empty rendered row renders nothing, and the
+        // manage (pencil) button pins to the first row that renders (row 2 here).
+        final prefs = <String, Object>{
+          'custom_key_row0_v1': jsonEncode(<String>[]),
+          'custom_key_row1_v1': jsonEncode(<String>[]),
+          'custom_key_row2_v1': jsonEncode(CustomKeyRows.standardRow2),
+        };
+        await TerminalTestScaffold.pumpTerminalScreen(tester);
+        await seedAndReload(tester, prefs);
+
+        // Row 1 is the modifier row: its tokens (ESC/TAB) must not render.
+        expect(
+          find.descendant(
+            of: find.byType(SpecialKeysBar),
+            matching: find.text('ESC'),
+          ),
+          findsNothing,
+        );
+        expect(
+          find.descendant(
+            of: find.byType(SpecialKeysBar),
+            matching: find.text('TAB'),
+          ),
+          findsNothing,
+        );
+        // Row 2 still renders, and the pencil is pinned to it.
+        expect(
+          find.descendant(
+            of: find.byType(SpecialKeysBar),
+            matching: find.text('PgUp'),
+          ),
+          findsOneWidget,
+        );
+        expect(
+          find.descendant(
+            of: find.byType(SpecialKeysBar),
+            matching: find.byIcon(Icons.edit_outlined),
+          ),
+          findsOneWidget,
+        );
+      },
+    );
+  });
+}

--- a/test/services/custom_keys/custom_key_button_test.dart
+++ b/test/services/custom_keys/custom_key_button_test.dart
@@ -1,0 +1,113 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_muxpod/services/custom_keys/custom_key_button.dart';
+
+void main() {
+  group('CustomKeyStep', () {
+    test('round-trips all step types', () {
+      for (final type in CustomKeyStepType.values) {
+        final value = switch (type) {
+          CustomKeyStepType.text => '/models',
+          CustomKeyStepType.key => 'Enter',
+          CustomKeyStepType.pause => '300',
+        };
+        final step = CustomKeyStep(type: type, value: value);
+        expect(CustomKeyStep.fromJson(step.toJson()), isNotNull);
+        expect(CustomKeyStep.fromJson(step.toJson())!.type, type);
+        expect(CustomKeyStep.fromJson(step.toJson())!.value, value);
+      }
+    });
+
+    test('rejects invalid values', () {
+      expect(CustomKeyStep.isValid(CustomKeyStepType.text, ''), isFalse);
+      expect(CustomKeyStep.isValid(CustomKeyStepType.text, '  '), isFalse);
+      expect(CustomKeyStep.isValid(CustomKeyStepType.key, ''), isFalse);
+      expect(CustomKeyStep.isValid(CustomKeyStepType.pause, 'abc'), isFalse);
+      expect(CustomKeyStep.isValid(CustomKeyStepType.pause, '-5'), isFalse);
+      expect(CustomKeyStep.isValid(CustomKeyStepType.pause, '0'), isFalse);
+      expect(CustomKeyStep.isValid(CustomKeyStepType.pause, '300'), isTrue);
+      expect(CustomKeyStep.fromJson({'type': 'nope', 'value': 'x'}), isNull);
+    });
+  });
+
+  group('CustomKeyButton', () {
+    test('round-trips', () {
+      final b = CustomKeyButton(
+        id: 'ck_1_a1b2',
+        label: '/models',
+        steps: [CustomKeyStep(type: CustomKeyStepType.text, value: '/models')],
+      );
+      final parsed = CustomKeyButton.fromJson(b.toJson());
+      expect(parsed, isNotNull);
+      expect(parsed!.id, 'ck_1_a1b2');
+      expect(parsed.label, '/models');
+      expect(parsed.steps.single.value, '/models');
+    });
+
+    test('rejects missing id / empty label / empty steps', () {
+      expect(CustomKeyButton.fromJson({'label': 'x', 'steps': []}), isNull);
+      expect(
+        CustomKeyButton.fromJson({'id': 'ck_1', 'label': '', 'steps': []}),
+        isNull,
+      );
+    });
+
+    test('newId has ck_ prefix and unique suffixes', () {
+      expect(CustomKeyButton.newId(), startsWith('ck_'));
+      expect(CustomKeyButton.newId(), isNot(CustomKeyButton.newId()));
+    });
+  });
+
+  group('CustomKeyRows', () {
+    test('token helpers', () {
+      expect(CustomKeyRows.isStandardToken('esc'), isTrue);
+      expect(CustomKeyRows.isStandardToken('num3'), isTrue);
+      expect(CustomKeyRows.isCustomToken('ck:1'), isTrue);
+      expect(CustomKeyRows.isCustomToken('esc'), isFalse);
+      expect(CustomKeyRows.isKnownToken('enter', const {}), isTrue);
+      expect(CustomKeyRows.isKnownToken('ck:1', const {'ck:1'}), isTrue);
+      expect(CustomKeyRows.isKnownToken('ck:9', const {'ck:1'}), isFalse);
+    });
+
+    test(
+      'tokenLabel maps every standard token and null for custom/unknown',
+      () {
+        expect(CustomKeyRows.tokenLabel('esc'), 'ESC');
+        expect(CustomKeyRows.tokenLabel('tab'), 'TAB');
+        expect(CustomKeyRows.tokenLabel('ctrl'), 'CTRL');
+        expect(CustomKeyRows.tokenLabel('alt'), 'ALT');
+        expect(CustomKeyRows.tokenLabel('shift'), 'SHIFT');
+        expect(CustomKeyRows.tokenLabel('enter'), 'ENTER');
+        expect(CustomKeyRows.tokenLabel('senter'), 'S-RET');
+        expect(CustomKeyRows.tokenLabel('slash'), '/');
+        expect(CustomKeyRows.tokenLabel('dash'), '-');
+        expect(CustomKeyRows.tokenLabel('pgup'), 'PgUp');
+        expect(CustomKeyRows.tokenLabel('pgdn'), 'PgDn');
+        expect(CustomKeyRows.tokenLabel('left'), 'Left');
+        expect(CustomKeyRows.tokenLabel('up'), 'Up');
+        expect(CustomKeyRows.tokenLabel('down'), 'Down');
+        expect(CustomKeyRows.tokenLabel('right'), 'Right');
+        expect(CustomKeyRows.tokenLabel('image'), 'Image');
+        expect(CustomKeyRows.tokenLabel('di_toggle'), 'Direct Input');
+        expect(CustomKeyRows.tokenLabel('input'), 'Input');
+        expect(CustomKeyRows.tokenLabel('num1'), '1');
+        expect(CustomKeyRows.tokenLabel('num2'), '2');
+        expect(CustomKeyRows.tokenLabel('num3'), '3');
+        expect(CustomKeyRows.tokenLabel('num4'), '4');
+        expect(CustomKeyRows.tokenLabel('ck:1'), isNull);
+        expect(CustomKeyRows.tokenLabel('bogus'), isNull);
+      },
+    );
+
+    test('allLayoutTokens composes the three rows in canonical order', () {
+      expect(CustomKeyRows.allLayoutTokens, [
+        ...CustomKeyRows.standardRow1,
+        ...CustomKeyRows.standardRow2,
+        ...CustomKeyRows.directInputExtras,
+      ]);
+    });
+
+    test('shelfRow is the unused-bucket sentinel', () {
+      expect(CustomKeyRows.shelfRow, -1);
+    });
+  });
+}

--- a/test/services/keychain/secure_storage_test.dart
+++ b/test/services/keychain/secure_storage_test.dart
@@ -2,6 +2,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_muxpod/services/keychain/secure_storage.dart';
 
 void main() {
+  setUp(() => SecureStorageService.setTestValues({}));
+
   tearDown(() {
     SecureStorageService.setTestValues(null);
     SecureStorageService.setTestThrowKeys(null);
@@ -40,6 +42,91 @@ void main() {
       final storage = SecureStorageService();
 
       expect(await storage.getPrivateKey('k1'), 'PRIVATE_KEY');
+    });
+  });
+
+  group('SecureStorageService host keys', () {
+    test(
+      'deleteAllHostKeyFingerprints removes only hostkey_* entries',
+      () async {
+        SecureStorageService.setTestValues({
+          'hostkey_192.168.1.3_22_ssh-ed25519': 'aa:bb:cc',
+          'hostkey_example.test_2222_ssh-rsa': 'dd:ee:ff',
+          'password_conn1': 'secret',
+          'privatekey_k1': 'pem',
+        });
+        final service = SecureStorageService();
+        await service.deleteAllHostKeyFingerprints();
+
+        expect(
+          await service.getHostKeyFingerprint('192.168.1.3', 22, 'ssh-ed25519'),
+          isNull,
+        );
+        expect(
+          await service.getHostKeyFingerprint('example.test', 2222, 'ssh-rsa'),
+          isNull,
+        );
+        // 認証情報は消えない
+        expect(await service.getPassword('conn1'), 'secret');
+        expect(await service.getPrivateKey('k1'), 'pem');
+      },
+    );
+
+    test('deleteAllHostKeyFingerprints reports how many it removed', () async {
+      final service = SecureStorageService();
+      await service.saveHostKeyFingerprint('a.test', 22, 'ssh-ed25519', 'aa');
+      await service.saveHostKeyFingerprint('b.test', 22, 'ssh-rsa', 'bb');
+
+      expect(await service.deleteAllHostKeyFingerprints(), 2);
+      expect(await service.deleteAllHostKeyFingerprints(), 0);
+    });
+
+    test(
+      'deleteAllHostKeyFingerprints is a no-op when nothing is stored',
+      () async {
+        final service = SecureStorageService();
+        expect(await service.deleteAllHostKeyFingerprints(), 0);
+        expect(
+          await service.getHostKeyFingerprint('192.168.1.3', 22, 'ssh-ed25519'),
+          isNull,
+        );
+      },
+    );
+
+    test('saved fingerprints are indexed by key name', () async {
+      final service = SecureStorageService();
+      await service.saveHostKeyFingerprint('a.test', 22, 'ssh-ed25519', 'aa');
+
+      expect(
+        await service.readValue('hostkey_index'),
+        'hostkey_a.test_22_ssh-ed25519',
+      );
+
+      await service.deleteHostKeyFingerprint('a.test', 22, 'ssh-ed25519');
+      expect(await service.readValue('hostkey_index'), '');
+    });
+
+    test('a clear removes an indexed pin whose value is unreadable', () async {
+      // 索引には載っているが、読み取ると復号不能で落ちるエントリ。個別削除は
+      // 復号を伴わないので、それでも消えなければならない（本機能の本来の用途）。
+      SecureStorageService.setTestValues({
+        'hostkey_index': 'hostkey_broken.test_22_ssh-ed25519',
+        'hostkey_broken.test_22_ssh-ed25519': 'corrupt',
+        'password_conn1': 'secret',
+      });
+      SecureStorageService.setTestThrowKeys({
+        'hostkey_broken.test_22_ssh-ed25519',
+      });
+      final service = SecureStorageService();
+
+      expect(await service.deleteAllHostKeyFingerprints(), 1);
+      SecureStorageService.setTestThrowKeys(null);
+      expect(
+        await service.getHostKeyFingerprint('broken.test', 22, 'ssh-ed25519'),
+        isNull,
+      );
+      expect(await service.readValue('hostkey_index'), isNull);
+      expect(await service.getPassword('conn1'), 'secret');
     });
   });
 }

--- a/test/widgets/custom_key_button_editor_dialog_test.dart
+++ b/test/widgets/custom_key_button_editor_dialog_test.dart
@@ -1,0 +1,630 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:flutter_muxpod/services/custom_keys/custom_key_button.dart';
+import 'package:flutter_muxpod/widgets/dialogs/custom_key_button_editor_dialog.dart';
+
+void main() {
+  group('CustomKeyButtonEditorDialog', () {
+    Future<void> openDialog(
+      WidgetTester tester, {
+      required String initialLabel,
+      required List<CustomKeyStep> initialSteps,
+      required void Function((String, List<CustomKeyStep>)? result) onResult,
+      VoidCallback? onDelete,
+    }) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (context) => ElevatedButton(
+                onPressed: () async {
+                  final result =
+                      await showDialog<(String, List<CustomKeyStep>)>(
+                        context: context,
+                        builder: (_) => CustomKeyButtonEditorDialog(
+                          initialLabel: initialLabel,
+                          initialSteps: initialSteps,
+                          onDelete: onDelete,
+                        ),
+                      );
+                  onResult(result);
+                },
+                child: const Text('Open'),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets('empty label shows error and keeps dialog open', (
+      tester,
+    ) async {
+      (String, List<CustomKeyStep>)? result;
+      var completed = false;
+      await openDialog(
+        tester,
+        initialLabel: '',
+        initialSteps: const [
+          CustomKeyStep(type: CustomKeyStepType.text, value: 'hello'),
+        ],
+        onResult: (r) {
+          result = r;
+          completed = true;
+        },
+      );
+
+      await tester.enterText(find.byKey(const Key('label-field')), '   ');
+      await tester.tap(find.text('Save'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Label is required'), findsOneWidget);
+      expect(find.byType(CustomKeyButtonEditorDialog), findsOneWidget);
+      expect(completed, isFalse);
+      expect(result, isNull);
+    });
+
+    testWidgets('zero steps shows error and keeps dialog open', (tester) async {
+      (String, List<CustomKeyStep>)? result;
+      var completed = false;
+      await openDialog(
+        tester,
+        initialLabel: 'My Button',
+        initialSteps: const [],
+        onResult: (r) {
+          result = r;
+          completed = true;
+        },
+      );
+
+      await tester.tap(find.text('Save'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('At least one step'), findsOneWidget);
+      expect(find.byType(CustomKeyButtonEditorDialog), findsOneWidget);
+      expect(completed, isFalse);
+      expect(result, isNull);
+    });
+
+    testWidgets('invalid pause shows error and keeps dialog open', (
+      tester,
+    ) async {
+      (String, List<CustomKeyStep>)? result;
+      var completed = false;
+      await openDialog(
+        tester,
+        initialLabel: 'My Button',
+        initialSteps: const [
+          CustomKeyStep(type: CustomKeyStepType.pause, value: 'abc'),
+        ],
+        onResult: (r) {
+          result = r;
+          completed = true;
+        },
+      );
+
+      await tester.tap(find.text('Save'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Invalid pause value'), findsOneWidget);
+      expect(find.byType(CustomKeyButtonEditorDialog), findsOneWidget);
+      expect(completed, isFalse);
+      expect(result, isNull);
+    });
+
+    testWidgets('empty text step value shows error and keeps dialog open', (
+      tester,
+    ) async {
+      (String, List<CustomKeyStep>)? result;
+      var completed = false;
+      await openDialog(
+        tester,
+        initialLabel: 'My Button',
+        initialSteps: const [
+          CustomKeyStep(type: CustomKeyStepType.text, value: 'hello'),
+        ],
+        onResult: (r) {
+          result = r;
+          completed = true;
+        },
+      );
+
+      await tester.enterText(find.byKey(const Key('step-value-0')), '   ');
+      await tester.tap(find.text('Save'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Step value is required'), findsOneWidget);
+      expect(find.byType(CustomKeyButtonEditorDialog), findsOneWidget);
+      expect(completed, isFalse);
+      expect(result, isNull);
+    });
+
+    testWidgets('empty key step value shows error and keeps dialog open', (
+      tester,
+    ) async {
+      (String, List<CustomKeyStep>)? result;
+      var completed = false;
+      await openDialog(
+        tester,
+        initialLabel: 'My Button',
+        initialSteps: const [
+          CustomKeyStep(type: CustomKeyStepType.key, value: 'Enter'),
+        ],
+        onResult: (r) {
+          result = r;
+          completed = true;
+        },
+      );
+
+      await tester.enterText(find.byKey(const Key('step-value-0')), '   ');
+      await tester.tap(find.text('Save'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Step value is required'), findsOneWidget);
+      expect(find.byType(CustomKeyButtonEditorDialog), findsOneWidget);
+      expect(completed, isFalse);
+      expect(result, isNull);
+    });
+
+    testWidgets('adds, reorders, and deletes steps then pops valid record', (
+      tester,
+    ) async {
+      (String, List<CustomKeyStep>)? result;
+      await openDialog(
+        tester,
+        initialLabel: 'My Button',
+        initialSteps: const [
+          CustomKeyStep(type: CustomKeyStepType.text, value: 'a'),
+          CustomKeyStep(type: CustomKeyStepType.text, value: 'b'),
+        ],
+        onResult: (r) => result = r,
+      );
+
+      // Pre-filled label.
+      final labelField = tester.widget<TextField>(
+        find.byKey(const Key('label-field')),
+      );
+      expect(labelField.controller!.text, 'My Button');
+
+      // Add a pause step.
+      await tester.tap(find.text('+ Add step'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('step-type-2')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Pause').last);
+      await tester.pumpAndSettle();
+      await tester.enterText(find.byKey(const Key('step-value-2')), '500');
+
+      // Add a key step.
+      await tester.tap(find.text('+ Add step'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('step-type-3')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Key').last);
+      await tester.pumpAndSettle();
+      await tester.enterText(find.byKey(const Key('step-value-3')), 'C-c');
+
+      // Reorder: move the pause step (index 2) up.
+      await tester.tap(find.byKey(const Key('step-up-2')));
+      await tester.pumpAndSettle();
+
+      // Delete the 'b' step (now at index 2).
+      await tester.tap(find.byKey(const Key('step-delete-2')));
+      await tester.pumpAndSettle();
+
+      // Save.
+      await tester.tap(find.text('Save'));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(CustomKeyButtonEditorDialog), findsNothing);
+      expect(result, isNotNull);
+      expect(result!.$1, 'My Button');
+      expect(result!.$2.length, 3);
+      expect(result!.$2[0].type, CustomKeyStepType.text);
+      expect(result!.$2[0].value, 'a');
+      expect(result!.$2[1].type, CustomKeyStepType.pause);
+      expect(result!.$2[1].value, '500');
+      expect(result!.$2[2].type, CustomKeyStepType.key);
+      expect(result!.$2[2].value, 'C-c');
+    });
+
+    testWidgets('cancel pops null', (tester) async {
+      (String, List<CustomKeyStep>)? result;
+      await openDialog(
+        tester,
+        initialLabel: 'My Button',
+        initialSteps: const [
+          CustomKeyStep(type: CustomKeyStepType.text, value: 'a'),
+        ],
+        onResult: (r) => result = r,
+      );
+
+      await tester.tap(find.text('Cancel'));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(CustomKeyButtonEditorDialog), findsNothing);
+      expect(result, isNull);
+    });
+
+    testWidgets('text fields render typed text with onSurface color', (
+      tester,
+    ) async {
+      await openDialog(
+        tester,
+        initialLabel: 'My Button',
+        initialSteps: const [
+          CustomKeyStep(type: CustomKeyStepType.text, value: 'hello'),
+        ],
+        onResult: (_) {},
+      );
+
+      final harnessContext = tester.element(find.text('Open'));
+      final onSurface = Theme.of(harnessContext).colorScheme.onSurface;
+
+      await tester.enterText(
+        find.byKey(const Key('label-field')),
+        'Visible text',
+      );
+      await tester.enterText(find.byKey(const Key('step-value-0')), 'typed');
+      await tester.pump();
+
+      EditableText editableText(Finder field) => tester.widget<EditableText>(
+        find.descendant(of: field, matching: find.byType(EditableText)),
+      );
+
+      expect(
+        editableText(find.byKey(const Key('label-field'))).style.color,
+        onSurface,
+      );
+      expect(
+        editableText(find.byKey(const Key('step-value-0'))).style.color,
+        onSurface,
+      );
+    });
+
+    testWidgets('delete button confirms and fires onDelete once', (
+      tester,
+    ) async {
+      var deleteCount = 0;
+      (String, List<CustomKeyStep>)? result;
+      await openDialog(
+        tester,
+        initialLabel: 'My Button',
+        initialSteps: const [
+          CustomKeyStep(type: CustomKeyStepType.text, value: 'a'),
+        ],
+        onDelete: () => deleteCount++,
+        onResult: (r) => result = r,
+      );
+
+      expect(find.byKey(const Key('dialog-delete')), findsOneWidget);
+
+      await tester.tap(find.byKey(const Key('dialog-delete')));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Delete button?'), findsOneWidget);
+
+      await tester.tap(
+        find.descendant(
+          of: find.byType(AlertDialog).last,
+          matching: find.text('Delete'),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(CustomKeyButtonEditorDialog), findsNothing);
+      expect(deleteCount, 1);
+      expect(result, isNull);
+    });
+
+    testWidgets('cancel on delete confirm keeps dialog open', (tester) async {
+      var deleteCount = 0;
+      await openDialog(
+        tester,
+        initialLabel: 'My Button',
+        initialSteps: const [
+          CustomKeyStep(type: CustomKeyStepType.text, value: 'a'),
+        ],
+        onDelete: () => deleteCount++,
+        onResult: (_) {},
+      );
+
+      await tester.tap(find.byKey(const Key('dialog-delete')));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Delete button?'), findsOneWidget);
+
+      await tester.tap(
+        find.descendant(
+          of: find.byType(AlertDialog).last,
+          matching: find.text('Cancel'),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(CustomKeyButtonEditorDialog), findsOneWidget);
+      expect(find.text('Delete button?'), findsNothing);
+      expect(deleteCount, 0);
+    });
+
+    testWidgets('no delete button without onDelete', (tester) async {
+      await openDialog(
+        tester,
+        initialLabel: 'My Button',
+        initialSteps: const [
+          CustomKeyStep(type: CustomKeyStepType.text, value: 'a'),
+        ],
+        onResult: (_) {},
+      );
+
+      expect(find.byKey(const Key('dialog-delete')), findsNothing);
+    });
+
+    testWidgets(
+      'step value field stays full-width and shows typed text at 2x text scale',
+      (tester) async {
+        // Regression: with a large system font scale the old single-row step
+        // layout crushed the value field into a tiny square (dropdown + icons
+        // grew and squeezed the Expanded field). The field must keep a usable
+        // width so typed text is visible.
+        await tester.binding.setSurfaceSize(const Size(411, 891));
+        addTearDown(() => tester.binding.setSurfaceSize(null));
+
+        await tester.pumpWidget(
+          MediaQuery(
+            data: const MediaQueryData(
+              size: Size(411, 891),
+              devicePixelRatio: 1,
+              textScaler: TextScaler.linear(2.0),
+            ),
+            child: MaterialApp(
+              home: Scaffold(
+                body: Builder(
+                  builder: (context) => ElevatedButton(
+                    onPressed: () {
+                      showDialog<(String, List<CustomKeyStep>)>(
+                        context: context,
+                        builder: (context) => CustomKeyButtonEditorDialog(
+                          initialLabel: 'B',
+                          initialSteps: const [
+                            CustomKeyStep(
+                              type: CustomKeyStepType.text,
+                              value: '',
+                            ),
+                          ],
+                        ),
+                      );
+                    },
+                    child: const Text('Open'),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+
+        await tester.tap(find.text('Open'));
+        await tester.pumpAndSettle();
+
+        final field = find.byKey(const Key('step-value-0'));
+        expect(field, findsOneWidget);
+        // Full-width field, not a crushed square: wider than tall, and wide
+        // enough to show typed text at 2x scale.
+        final size = tester.getSize(field);
+        expect(size.width, greaterThan(200));
+        expect(size.width, greaterThan(size.height));
+
+        await tester.enterText(field, 'models');
+        await tester.pump();
+        final editable = tester.widget<EditableText>(
+          find.descendant(of: field, matching: find.byType(EditableText)),
+        );
+        expect(editable.controller.text, 'models');
+      },
+    );
+
+    testWidgets('step actions are inset from the value field edges', (
+      tester,
+    ) async {
+      await openDialog(
+        tester,
+        initialLabel: 'My Button',
+        initialSteps: const [
+          CustomKeyStep(type: CustomKeyStepType.text, value: 'a'),
+        ],
+        onResult: (_) {},
+      );
+
+      final field = tester.getRect(find.byKey(const Key('step-value-0')));
+      final dropdown = tester.getRect(find.byKey(const Key('step-type-0')));
+      final delete = tester.getRect(find.byKey(const Key('step-delete-0')));
+
+      // Trailing icons must not hug the dialog edge, and the type selector
+      // lines up with the field's content inset.
+      expect(field.right - delete.right, closeTo(8, 0.5));
+      expect(dropdown.left - field.left, closeTo(16, 0.5));
+      expect(delete.right, lessThan(field.right));
+    });
+
+    testWidgets('step actions stay inside the dialog on a narrow screen', (
+      tester,
+    ) async {
+      // 308dp wide (small phone / enlarged display size) at 1.3x text scale:
+      // the type selector must shrink instead of the Row overflowing and
+      // painting the trailing actions outside the dialog card.
+      tester.view.physicalSize = const Size(308 * 3, 700 * 3);
+      tester.view.devicePixelRatio = 3;
+      addTearDown(tester.view.reset);
+
+      await tester.pumpWidget(
+        MediaQuery(
+          data: const MediaQueryData(textScaler: TextScaler.linear(1.3)),
+          child: MaterialApp(
+            home: Scaffold(
+              body: Builder(
+                builder: (context) => ElevatedButton(
+                  onPressed: () => showDialog<(String, List<CustomKeyStep>)>(
+                    context: context,
+                    builder: (_) => const CustomKeyButtonEditorDialog(
+                      initialLabel: 'My Button',
+                      initialSteps: [
+                        CustomKeyStep(type: CustomKeyStepType.text, value: 'a'),
+                      ],
+                    ),
+                  ),
+                  child: const Text('Open'),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+
+      expect(tester.takeException(), isNull);
+
+      final field = tester.getRect(find.byKey(const Key('step-value-0')));
+      final delete = tester.getRect(find.byKey(const Key('step-delete-0')));
+      final up = tester.getRect(find.byKey(const Key('step-up-0')));
+      expect(field.right - delete.right, closeTo(8, 0.5));
+      expect(up.left, greaterThan(field.left));
+    });
+
+    testWidgets('type label stays legible on a phone-width dialog', (
+      tester,
+    ) async {
+      // 411dp phone at 2x text scale: the dialog content box (~283px) barely
+      // fits the row's fixed parts, so the clamped selector must still keep a
+      // readable label instead of collapsing to a bare arrow.
+      tester.view.physicalSize = const Size(411 * 3, 891 * 3);
+      tester.view.devicePixelRatio = 3;
+      addTearDown(tester.view.reset);
+
+      await tester.pumpWidget(
+        MediaQuery(
+          data: const MediaQueryData(textScaler: TextScaler.linear(2)),
+          child: MaterialApp(
+            home: Scaffold(
+              body: Builder(
+                builder: (context) => ElevatedButton(
+                  onPressed: () => showDialog<(String, List<CustomKeyStep>)>(
+                    context: context,
+                    builder: (_) => const CustomKeyButtonEditorDialog(
+                      initialLabel: 'My Button',
+                      initialSteps: [
+                        CustomKeyStep(type: CustomKeyStepType.text, value: 'a'),
+                      ],
+                    ),
+                  ),
+                  child: const Text('Open'),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+
+      expect(tester.takeException(), isNull);
+
+      final field = tester.getRect(find.byKey(const Key('step-value-0')));
+      final delete = tester.getRect(find.byKey(const Key('step-delete-0')));
+      expect(delete.right, lessThan(field.right));
+      // Action tap targets are font-independent (40px), so the row's footprint
+      // does not grow with the system font.
+      expect(delete.width, closeTo(40, 0.5));
+      // The selected type stays legible instead of ellipsising to nothing.
+      expect(tester.getSize(find.text('Text')).width, greaterThan(30));
+    });
+
+    testWidgets('delete, cancel and save share one horizontal row', (
+      tester,
+    ) async {
+      await openDialog(
+        tester,
+        initialLabel: 'My Button',
+        initialSteps: const [
+          CustomKeyStep(type: CustomKeyStepType.text, value: 'a'),
+        ],
+        onDelete: () {},
+        onResult: (_) {},
+      );
+
+      final delete = tester.getRect(find.text('Delete'));
+      final cancel = tester.getRect(find.text('Cancel'));
+      final save = tester.getRect(find.text('Save'));
+      // Same baseline row, left-to-right order, Delete pinned to the left.
+      expect(cancel.center.dy, closeTo(delete.center.dy, 1));
+      expect(save.center.dy, closeTo(delete.center.dy, 1));
+      expect(delete.right, lessThan(cancel.left));
+      expect(cancel.right, lessThan(save.left));
+      // Labels are shown whole: a shrunk cell used to render "Dele"/"Can"/"S".
+      for (final label in ['Delete', 'Cancel', 'Save']) {
+        final paragraph = tester.renderObject<RenderParagraph>(
+          find.text(label),
+        );
+        expect(
+          paragraph.size.width,
+          closeTo(paragraph.getMaxIntrinsicWidth(double.infinity), 0.5),
+          reason: '$label is clipped',
+        );
+      }
+    });
+
+    testWidgets('action labels stay whole on a narrow dialog', (tester) async {
+      // 308dp phone at 1.3x text scale: the three buttons must still show full
+      // labels side by side instead of clipping to "Dele"/"Can"/"S".
+      tester.view.physicalSize = const Size(308 * 3, 700 * 3);
+      tester.view.devicePixelRatio = 3;
+      addTearDown(tester.view.reset);
+
+      await tester.pumpWidget(
+        MediaQuery(
+          data: const MediaQueryData(textScaler: TextScaler.linear(1.3)),
+          child: MaterialApp(
+            home: Scaffold(
+              body: Builder(
+                builder: (context) => ElevatedButton(
+                  onPressed: () => showDialog<(String, List<CustomKeyStep>)>(
+                    context: context,
+                    builder: (_) => CustomKeyButtonEditorDialog(
+                      initialLabel: 'My Button',
+                      initialSteps: const [
+                        CustomKeyStep(type: CustomKeyStepType.text, value: 'a'),
+                      ],
+                      onDelete: () {},
+                    ),
+                  ),
+                  child: const Text('Open'),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+
+      expect(tester.takeException(), isNull);
+      final card = tester.getRect(find.byType(AlertDialog));
+      for (final label in ['Delete', 'Cancel', 'Save']) {
+        final paragraph = tester.renderObject<RenderParagraph>(
+          find.text(label),
+        );
+        expect(
+          paragraph.size.width,
+          closeTo(paragraph.getMaxIntrinsicWidth(double.infinity), 0.5),
+          reason: '$label is clipped',
+        );
+        expect(tester.getRect(find.text(label)).right, lessThan(card.right));
+      }
+    });
+  });
+}

--- a/test/widgets/custom_key_button_widget_test.dart
+++ b/test/widgets/custom_key_button_widget_test.dart
@@ -4,27 +4,39 @@ import 'package:flutter_muxpod/services/custom_keys/custom_key_button.dart';
 import 'package:flutter_muxpod/widgets/custom_key_button_widget.dart';
 
 void main() {
-  Widget wrap(Widget child) => MaterialApp(home: Scaffold(body: Center(child: child)));
+  Widget wrap(Widget child) => MaterialApp(
+    home: Scaffold(body: Center(child: child)),
+  );
 
   CustomKeyButton makeButton() => CustomKeyButton(
-        id: 'ck_1_a1b2',
-        label: '/models',
-        steps: const [
-          CustomKeyStep(type: CustomKeyStepType.text, value: '/models'),
-          CustomKeyStep(type: CustomKeyStepType.key, value: 'Enter'),
-        ],
-      );
+    id: 'ck_1_a1b2',
+    label: '/models',
+    steps: const [
+      CustomKeyStep(type: CustomKeyStepType.text, value: '/models'),
+      CustomKeyStep(type: CustomKeyStepType.key, value: 'Enter'),
+    ],
+  );
 
   testWidgets('tap executes steps in order via callbacks', (tester) async {
     final sent = <String>[];
     final kinds = <String>[];
-    await tester.pumpWidget(wrap(CustomKeyButtonWidget(
-      button: makeButton(),
-      onKeyPressed: (t) { sent.add(t); kinds.add('text'); },
-      onSpecialKeyPressed: (t) { sent.add(t); kinds.add('key'); },
-      onEdit: (_) {},
-      hapticFeedback: false,
-    )));
+    await tester.pumpWidget(
+      wrap(
+        CustomKeyButtonWidget(
+          button: makeButton(),
+          onKeyPressed: (t) {
+            sent.add(t);
+            kinds.add('text');
+          },
+          onSpecialKeyPressed: (t) {
+            sent.add(t);
+            kinds.add('key');
+          },
+          onEdit: (_) {},
+          hapticFeedback: false,
+        ),
+      ),
+    );
     await tester.tap(find.text('/models'));
     await tester.pump();
     expect(kinds, ['text', 'key']);
@@ -33,21 +45,25 @@ void main() {
 
   testWidgets('pause delays the following step', (tester) async {
     final order = <String>[];
-    await tester.pumpWidget(wrap(CustomKeyButtonWidget(
-      button: CustomKeyButton(
-        id: 'ck_2',
-        label: 'P',
-        steps: const [
-          CustomKeyStep(type: CustomKeyStepType.text, value: 'a'),
-          CustomKeyStep(type: CustomKeyStepType.pause, value: '300'),
-          CustomKeyStep(type: CustomKeyStepType.text, value: 'b'),
-        ],
+    await tester.pumpWidget(
+      wrap(
+        CustomKeyButtonWidget(
+          button: CustomKeyButton(
+            id: 'ck_2',
+            label: 'P',
+            steps: const [
+              CustomKeyStep(type: CustomKeyStepType.text, value: 'a'),
+              CustomKeyStep(type: CustomKeyStepType.pause, value: '300'),
+              CustomKeyStep(type: CustomKeyStepType.text, value: 'b'),
+            ],
+          ),
+          onKeyPressed: (t) => order.add(t),
+          onSpecialKeyPressed: (_) {},
+          onEdit: (_) {},
+          hapticFeedback: false,
+        ),
       ),
-      onKeyPressed: (t) => order.add(t),
-      onSpecialKeyPressed: (_) {},
-      onEdit: (_) {},
-      hapticFeedback: false,
-    )));
+    );
     await tester.tap(find.text('P'));
     await tester.pump();
     expect(order, ['a']);
@@ -57,21 +73,25 @@ void main() {
 
   testWidgets('pause value with trailing space still delays', (tester) async {
     final order = <String>[];
-    await tester.pumpWidget(wrap(CustomKeyButtonWidget(
-      button: CustomKeyButton(
-        id: 'ck_5',
-        label: 'T',
-        steps: const [
-          CustomKeyStep(type: CustomKeyStepType.text, value: 'a'),
-          CustomKeyStep(type: CustomKeyStepType.pause, value: '300 '),
-          CustomKeyStep(type: CustomKeyStepType.text, value: 'b'),
-        ],
+    await tester.pumpWidget(
+      wrap(
+        CustomKeyButtonWidget(
+          button: CustomKeyButton(
+            id: 'ck_5',
+            label: 'T',
+            steps: const [
+              CustomKeyStep(type: CustomKeyStepType.text, value: 'a'),
+              CustomKeyStep(type: CustomKeyStepType.pause, value: '300 '),
+              CustomKeyStep(type: CustomKeyStepType.text, value: 'b'),
+            ],
+          ),
+          onKeyPressed: (t) => order.add(t),
+          onSpecialKeyPressed: (_) {},
+          onEdit: (_) {},
+          hapticFeedback: false,
+        ),
       ),
-      onKeyPressed: (t) => order.add(t),
-      onSpecialKeyPressed: (_) {},
-      onEdit: (_) {},
-      hapticFeedback: false,
-    )));
+    );
     await tester.tap(find.text('T'));
     await tester.pump();
     expect(order, ['a']);
@@ -82,33 +102,41 @@ void main() {
   testWidgets('long-press fires onEdit with the button', (tester) async {
     CustomKeyButton? edited;
     final b = makeButton();
-    await tester.pumpWidget(wrap(CustomKeyButtonWidget(
-      button: b,
-      onKeyPressed: (_) {},
-      onSpecialKeyPressed: (_) {},
-      onEdit: (btn) => edited = btn,
-      hapticFeedback: false,
-    )));
+    await tester.pumpWidget(
+      wrap(
+        CustomKeyButtonWidget(
+          button: b,
+          onKeyPressed: (_) {},
+          onSpecialKeyPressed: (_) {},
+          onEdit: (btn) => edited = btn,
+          hapticFeedback: false,
+        ),
+      ),
+    );
     await tester.longPress(find.text('/models'));
     expect(edited?.id, b.id);
   });
 
   testWidgets('re-entry guard ignores taps while executing', (tester) async {
     var tapCount = 0;
-    await tester.pumpWidget(wrap(CustomKeyButtonWidget(
-      button: CustomKeyButton(
-        id: 'ck_3',
-        label: 'Slow',
-        steps: const [
-          CustomKeyStep(type: CustomKeyStepType.pause, value: '500'),
-          CustomKeyStep(type: CustomKeyStepType.text, value: 'x'),
-        ],
+    await tester.pumpWidget(
+      wrap(
+        CustomKeyButtonWidget(
+          button: CustomKeyButton(
+            id: 'ck_3',
+            label: 'Slow',
+            steps: const [
+              CustomKeyStep(type: CustomKeyStepType.pause, value: '500'),
+              CustomKeyStep(type: CustomKeyStepType.text, value: 'x'),
+            ],
+          ),
+          onKeyPressed: (_) => tapCount++,
+          onSpecialKeyPressed: (_) {},
+          onEdit: (_) {},
+          hapticFeedback: false,
+        ),
       ),
-      onKeyPressed: (_) => tapCount++,
-      onSpecialKeyPressed: (_) {},
-      onEdit: (_) {},
-      hapticFeedback: false,
-    )));
+    );
     await tester.tap(find.text('Slow'));
     await tester.pump();
     await tester.tap(find.text('Slow'), warnIfMissed: false);
@@ -116,23 +144,29 @@ void main() {
     expect(tapCount, 1);
   });
 
-  testWidgets('invalid pause value is skipped, sequence continues', (tester) async {
+  testWidgets('invalid pause value is skipped, sequence continues', (
+    tester,
+  ) async {
     final order = <String>[];
-    await tester.pumpWidget(wrap(CustomKeyButtonWidget(
-      button: CustomKeyButton(
-        id: 'ck_4',
-        label: 'Q',
-        steps: const [
-          CustomKeyStep(type: CustomKeyStepType.text, value: 'a'),
-          CustomKeyStep(type: CustomKeyStepType.pause, value: 'zzz'),
-          CustomKeyStep(type: CustomKeyStepType.text, value: 'b'),
-        ],
+    await tester.pumpWidget(
+      wrap(
+        CustomKeyButtonWidget(
+          button: CustomKeyButton(
+            id: 'ck_4',
+            label: 'Q',
+            steps: const [
+              CustomKeyStep(type: CustomKeyStepType.text, value: 'a'),
+              CustomKeyStep(type: CustomKeyStepType.pause, value: 'zzz'),
+              CustomKeyStep(type: CustomKeyStepType.text, value: 'b'),
+            ],
+          ),
+          onKeyPressed: (t) => order.add(t),
+          onSpecialKeyPressed: (_) {},
+          onEdit: (_) {},
+          hapticFeedback: false,
+        ),
       ),
-      onKeyPressed: (t) => order.add(t),
-      onSpecialKeyPressed: (_) {},
-      onEdit: (_) {},
-      hapticFeedback: false,
-    )));
+    );
     await tester.tap(find.text('Q'));
     await tester.pump();
     expect(order, ['a', 'b']);

--- a/test/widgets/custom_key_button_widget_test.dart
+++ b/test/widgets/custom_key_button_widget_test.dart
@@ -1,0 +1,140 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_muxpod/services/custom_keys/custom_key_button.dart';
+import 'package:flutter_muxpod/widgets/custom_key_button_widget.dart';
+
+void main() {
+  Widget wrap(Widget child) => MaterialApp(home: Scaffold(body: Center(child: child)));
+
+  CustomKeyButton makeButton() => CustomKeyButton(
+        id: 'ck_1_a1b2',
+        label: '/models',
+        steps: const [
+          CustomKeyStep(type: CustomKeyStepType.text, value: '/models'),
+          CustomKeyStep(type: CustomKeyStepType.key, value: 'Enter'),
+        ],
+      );
+
+  testWidgets('tap executes steps in order via callbacks', (tester) async {
+    final sent = <String>[];
+    final kinds = <String>[];
+    await tester.pumpWidget(wrap(CustomKeyButtonWidget(
+      button: makeButton(),
+      onKeyPressed: (t) { sent.add(t); kinds.add('text'); },
+      onSpecialKeyPressed: (t) { sent.add(t); kinds.add('key'); },
+      onEdit: (_) {},
+      hapticFeedback: false,
+    )));
+    await tester.tap(find.text('/models'));
+    await tester.pump();
+    expect(kinds, ['text', 'key']);
+    expect(sent, ['/models', 'Enter']);
+  });
+
+  testWidgets('pause delays the following step', (tester) async {
+    final order = <String>[];
+    await tester.pumpWidget(wrap(CustomKeyButtonWidget(
+      button: CustomKeyButton(
+        id: 'ck_2',
+        label: 'P',
+        steps: const [
+          CustomKeyStep(type: CustomKeyStepType.text, value: 'a'),
+          CustomKeyStep(type: CustomKeyStepType.pause, value: '300'),
+          CustomKeyStep(type: CustomKeyStepType.text, value: 'b'),
+        ],
+      ),
+      onKeyPressed: (t) => order.add(t),
+      onSpecialKeyPressed: (_) {},
+      onEdit: (_) {},
+      hapticFeedback: false,
+    )));
+    await tester.tap(find.text('P'));
+    await tester.pump();
+    expect(order, ['a']);
+    await tester.pump(const Duration(milliseconds: 350));
+    expect(order, ['a', 'b']);
+  });
+
+  testWidgets('pause value with trailing space still delays', (tester) async {
+    final order = <String>[];
+    await tester.pumpWidget(wrap(CustomKeyButtonWidget(
+      button: CustomKeyButton(
+        id: 'ck_5',
+        label: 'T',
+        steps: const [
+          CustomKeyStep(type: CustomKeyStepType.text, value: 'a'),
+          CustomKeyStep(type: CustomKeyStepType.pause, value: '300 '),
+          CustomKeyStep(type: CustomKeyStepType.text, value: 'b'),
+        ],
+      ),
+      onKeyPressed: (t) => order.add(t),
+      onSpecialKeyPressed: (_) {},
+      onEdit: (_) {},
+      hapticFeedback: false,
+    )));
+    await tester.tap(find.text('T'));
+    await tester.pump();
+    expect(order, ['a']);
+    await tester.pump(const Duration(milliseconds: 350));
+    expect(order, ['a', 'b']);
+  });
+
+  testWidgets('long-press fires onEdit with the button', (tester) async {
+    CustomKeyButton? edited;
+    final b = makeButton();
+    await tester.pumpWidget(wrap(CustomKeyButtonWidget(
+      button: b,
+      onKeyPressed: (_) {},
+      onSpecialKeyPressed: (_) {},
+      onEdit: (btn) => edited = btn,
+      hapticFeedback: false,
+    )));
+    await tester.longPress(find.text('/models'));
+    expect(edited?.id, b.id);
+  });
+
+  testWidgets('re-entry guard ignores taps while executing', (tester) async {
+    var tapCount = 0;
+    await tester.pumpWidget(wrap(CustomKeyButtonWidget(
+      button: CustomKeyButton(
+        id: 'ck_3',
+        label: 'Slow',
+        steps: const [
+          CustomKeyStep(type: CustomKeyStepType.pause, value: '500'),
+          CustomKeyStep(type: CustomKeyStepType.text, value: 'x'),
+        ],
+      ),
+      onKeyPressed: (_) => tapCount++,
+      onSpecialKeyPressed: (_) {},
+      onEdit: (_) {},
+      hapticFeedback: false,
+    )));
+    await tester.tap(find.text('Slow'));
+    await tester.pump();
+    await tester.tap(find.text('Slow'), warnIfMissed: false);
+    await tester.pump(const Duration(milliseconds: 600));
+    expect(tapCount, 1);
+  });
+
+  testWidgets('invalid pause value is skipped, sequence continues', (tester) async {
+    final order = <String>[];
+    await tester.pumpWidget(wrap(CustomKeyButtonWidget(
+      button: CustomKeyButton(
+        id: 'ck_4',
+        label: 'Q',
+        steps: const [
+          CustomKeyStep(type: CustomKeyStepType.text, value: 'a'),
+          CustomKeyStep(type: CustomKeyStepType.pause, value: 'zzz'),
+          CustomKeyStep(type: CustomKeyStepType.text, value: 'b'),
+        ],
+      ),
+      onKeyPressed: (t) => order.add(t),
+      onSpecialKeyPressed: (_) {},
+      onEdit: (_) {},
+      hapticFeedback: false,
+    )));
+    await tester.tap(find.text('Q'));
+    await tester.pump();
+    expect(order, ['a', 'b']);
+  });
+}

--- a/test/widgets/special_keys_bar_test.dart
+++ b/test/widgets/special_keys_bar_test.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_muxpod/services/custom_keys/custom_key_button.dart';
+import 'package:flutter_muxpod/widgets/custom_key_button_widget.dart';
 import 'package:flutter_muxpod/l10n/app_localizations.dart';
 import 'package:flutter_muxpod/widgets/special_keys_bar.dart';
 
@@ -9,6 +11,7 @@ void main() {
   Widget buildWidget({
     required bool directInputEnabled,
     VoidCallback? onImagePickRequested,
+    List<String> row0Tokens = const <String>[],
   }) {
     return MaterialApp(
       localizationsDelegates: AppLocalizations.localizationsDelegates,
@@ -25,6 +28,7 @@ void main() {
               directInputEnabled: directInputEnabled,
               onDirectInputToggle: () {},
               onImagePickRequested: onImagePickRequested,
+              row0Tokens: row0Tokens,
             ),
           ),
         ),
@@ -37,7 +41,11 @@ void main() {
   // width would trip an unrelated font-fallback overflow in the modifier row
   // under the test's default (non-monospace) font, which does not occur
   // on-device.
-  Widget harness({required bool directInput, double width = 720}) {
+  Widget harness({
+    required bool directInput,
+    double width = 720,
+    List<String> row0Tokens = const <String>[],
+  }) {
     return MaterialApp(
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
@@ -54,6 +62,7 @@ void main() {
               onDirectInputToggle: () {},
               directInputEnabled: directInput,
               hapticFeedback: false,
+              row0Tokens: row0Tokens,
             ),
           ),
         ),
@@ -64,6 +73,56 @@ void main() {
   Finder horizontalScroller() => find.byWidgetPredicate(
     (w) => w is SingleChildScrollView && w.scrollDirection == Axis.horizontal,
   );
+
+  CustomKeyButton ck(String id, String label) => CustomKeyButton(
+    id: id,
+    label: label,
+    steps: const [CustomKeyStep(type: CustomKeyStepType.text, value: 'x')],
+  );
+
+  String ckToken(String id) => 'ck:${id.substring(3)}';
+
+  Widget customHarness({
+    bool directInput = false,
+    double width = 720,
+    List<CustomKeyButton> customButtons = const [],
+    List<String> row0Tokens = const <String>[],
+    List<String>? row1Tokens,
+    List<String>? row2Tokens,
+    void Function(CustomKeyButton)? onCustomButtonEdit,
+    VoidCallback? onManageButtons,
+    void Function(String)? onKeyPressed,
+    void Function(String)? onSpecialKeyPressed,
+    VoidCallback? onImagePickRequested,
+  }) {
+    return MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(
+        body: Align(
+          alignment: Alignment.bottomCenter,
+          child: SizedBox(
+            width: width,
+            child: SpecialKeysBar(
+              onKeyPressed: onKeyPressed ?? (_) {},
+              onSpecialKeyPressed: onSpecialKeyPressed ?? (_) {},
+              onInputTap: () {},
+              onImagePickRequested: onImagePickRequested,
+              onDirectInputToggle: () {},
+              directInputEnabled: directInput,
+              hapticFeedback: false,
+              customButtons: customButtons,
+              row0Tokens: row0Tokens,
+              row1Tokens: row1Tokens ?? CustomKeyRows.standardRow1,
+              row2Tokens: row2Tokens ?? CustomKeyRows.standardRow2,
+              onCustomButtonEdit: onCustomButtonEdit,
+              onManageButtons: onManageButtons,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
 
   group('SpecialKeysBar', () {
     testWidgets(
@@ -122,5 +181,575 @@ void main() {
         expect(find.text('Cmd'), findsOneWidget);
       },
     );
+    testWidgets(
+      'default bar at 320 with image pick has no overflow and shows pencil',
+      (tester) async {
+        await tester.binding.setSurfaceSize(const Size(320, 640));
+        addTearDown(() => tester.binding.setSurfaceSize(null));
+
+        await tester.pumpWidget(
+          buildWidget(directInputEnabled: false, onImagePickRequested: () {}),
+        );
+        await tester.pump();
+
+        expect(tester.takeException(), isNull);
+        expect(find.byIcon(Icons.edit_outlined), findsOneWidget);
+      },
+    );
+  });
+
+  group('SpecialKeysBar custom buttons', () {
+    testWidgets('custom buttons render at token positions in order', (
+      tester,
+    ) async {
+      final a = ck('ck_1_a', 'A');
+      final b = ck('ck_2_b', 'B');
+      await tester.pumpWidget(
+        customHarness(
+          customButtons: [a, b],
+          row1Tokens: ['esc', ckToken('ck_1_a'), 'tab', ckToken('ck_2_b')],
+        ),
+      );
+      await tester.pump();
+
+      final customA = find.byWidgetPredicate(
+        (w) => w is CustomKeyButtonWidget && w.button.id == 'ck_1_a',
+      );
+      final customB = find.byWidgetPredicate(
+        (w) => w is CustomKeyButtonWidget && w.button.id == 'ck_2_b',
+      );
+      expect(customA, findsOneWidget);
+      expect(customB, findsOneWidget);
+      expect(find.text('A'), findsOneWidget);
+      expect(find.text('B'), findsOneWidget);
+
+      final aX = tester.getTopLeft(find.text('A')).dx;
+      final bX = tester.getTopLeft(find.text('B')).dx;
+      expect(aX, lessThan(bX));
+    });
+
+    testWidgets('tapping a custom button fires onKeyPressed with text step', (
+      tester,
+    ) async {
+      final pressed = <String>[];
+      await tester.pumpWidget(
+        customHarness(
+          customButtons: [ck('ck_1_a', 'A')],
+          row1Tokens: ['esc', ckToken('ck_1_a')],
+          onKeyPressed: pressed.add,
+        ),
+      );
+      await tester.pump();
+
+      await tester.tap(find.text('A'));
+      await tester.pump();
+
+      expect(pressed, ['x']);
+    });
+
+    testWidgets('long-pressing a custom button fires onCustomButtonEdit', (
+      tester,
+    ) async {
+      CustomKeyButton? edited;
+      await tester.pumpWidget(
+        customHarness(
+          customButtons: [ck('ck_1_a', 'A')],
+          row1Tokens: ['esc', ckToken('ck_1_a')],
+          onCustomButtonEdit: (b) => edited = b,
+        ),
+      );
+      await tester.pump();
+
+      await tester.longPress(find.text('A'));
+      await tester.pump();
+
+      expect(edited?.id, 'ck_1_a');
+    });
+
+    testWidgets(
+      'pencil button is present, in row 1, and fires onManageButtons',
+      (tester) async {
+        var managed = 0;
+        await tester.pumpWidget(
+          customHarness(onManageButtons: () => managed++),
+        );
+        await tester.pump();
+
+        final pencil = find.byIcon(Icons.edit_outlined);
+        expect(pencil, findsOneWidget);
+
+        // Pencil button matches the row-1 button height (32) and is pinned
+        // above row 2. Measure the button container, not the icon glyph.
+        final pencilButton = find
+            .ancestor(of: pencil, matching: find.byType(GestureDetector))
+            .first;
+        expect(tester.getSize(pencilButton).height, 32);
+        expect(tester.getSize(pencilButton).width, 32);
+
+        // Pencil is the trailing fixed element of row 1 (modifier row), so it
+        // sits above row 2's navigation controls.
+        final pencilY = tester.getTopLeft(pencil).dy;
+        final row2Y = tester.getTopLeft(find.text('PgUp')).dy;
+        expect(pencilY, lessThan(row2Y));
+
+        await tester.tap(pencil);
+        await tester.pump();
+
+        expect(managed, 1);
+      },
+    );
+
+    testWidgets(
+      'customized direct-input row renders only the tokens it holds',
+      (tester) async {
+        await tester.pumpWidget(
+          customHarness(
+            directInput: true,
+            customButtons: [ck('ck_1_a', 'A')],
+            row2Tokens: [ckToken('ck_1_a')],
+          ),
+        );
+        await tester.pump();
+
+        expect(find.text('A'), findsOneWidget);
+        // Numbers are no longer auto-appended: rows render exactly what they
+        // hold, subject to the mode skips.
+        expect(find.text('1'), findsNothing);
+        expect(find.text('2'), findsNothing);
+        expect(find.text('3'), findsNothing);
+        expect(find.text('4'), findsNothing);
+      },
+    );
+
+    testWidgets('row-2 custom buttons render at 36px height', (tester) async {
+      await tester.pumpWidget(
+        customHarness(
+          customButtons: [ck('ck_1_a', 'A')],
+          row2Tokens: [ckToken('ck_1_a')],
+        ),
+      );
+      await tester.pump();
+
+      final finder = find.byWidgetPredicate(
+        (w) => w is CustomKeyButtonWidget && w.button.id == 'ck_1_a',
+      );
+      expect(finder, findsOneWidget);
+      expect(tester.getSize(finder).height, 36);
+    });
+
+    testWidgets(
+      'custom row-1 tokens render in a horizontal scroller without overflow',
+      (tester) async {
+        await tester.binding.setSurfaceSize(const Size(320, 640));
+        addTearDown(() => tester.binding.setSurfaceSize(null));
+
+        await tester.pumpWidget(
+          customHarness(
+            width: 320,
+            customButtons: [ck('ck_1_a', 'A')],
+            row1Tokens: ['esc', ckToken('ck_1_a'), 'tab'],
+          ),
+        );
+        await tester.pump();
+
+        expect(tester.takeException(), isNull);
+        expect(horizontalScroller(), findsAtLeastNWidgets(1));
+        expect(find.text('A'), findsOneWidget);
+      },
+    );
+
+    testWidgets('custom button tap resets software modifiers', (tester) async {
+      final keys = <String>[];
+      final specials = <String>[];
+      await tester.pumpWidget(
+        customHarness(
+          customButtons: [ck('ck_1_a', 'A')],
+          row1Tokens: ['ctrl', 'slash', ckToken('ck_1_a')],
+          onKeyPressed: keys.add,
+          onSpecialKeyPressed: specials.add,
+        ),
+      );
+      await tester.pump();
+
+      await tester.tap(find.text('CTRL'));
+      await tester.pump();
+
+      await tester.tap(find.text('A'));
+      await tester.pump();
+      expect(keys, ['x']);
+      expect(specials, isEmpty);
+
+      await tester.tap(find.text('/'));
+      await tester.pump();
+      expect(keys, contains('/'));
+      expect(specials, isNot(contains('C-/')));
+    });
+    testWidgets('row-0 custom button renders above the modifier row', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        customHarness(
+          customButtons: [ck('ck_1_a', 'A')],
+          row0Tokens: [ckToken('ck_1_a')],
+        ),
+      );
+      await tester.pump();
+
+      final customY = tester.getTopLeft(find.text('A')).dy;
+      final escY = tester.getTopLeft(find.text('ESC')).dy;
+      expect(customY, lessThan(escY));
+    });
+
+    testWidgets('empty row-0 renders no extra top row', (tester) async {
+      await tester.pumpWidget(customHarness());
+      await tester.pump();
+
+      expect(horizontalScroller(), findsNothing);
+      expect(find.text('ESC'), findsOneWidget);
+    });
+
+    testWidgets(
+      'tapping a row-0 custom button fires onKeyPressed with text step',
+      (tester) async {
+        final pressed = <String>[];
+        await tester.pumpWidget(
+          customHarness(
+            customButtons: [ck('ck_1_a', 'A')],
+            row0Tokens: [ckToken('ck_1_a')],
+            onKeyPressed: pressed.add,
+          ),
+        );
+        await tester.pump();
+
+        await tester.tap(find.text('A'));
+        await tester.pump();
+
+        expect(pressed, ['x']);
+      },
+    );
+  });
+
+  group('SpecialKeysBar arbitrary layout', () {
+    testWidgets('a standard nav token in row0 renders in the top row', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        customHarness(row0Tokens: const ['pgup'], row2Tokens: const <String>[]),
+      );
+      await tester.pump();
+
+      expect(find.text('PgUp'), findsOneWidget);
+      final pgupY = tester.getTopLeft(find.text('PgUp')).dy;
+      final escY = tester.getTopLeft(find.text('ESC')).dy;
+      expect(pgupY, lessThan(escY));
+    });
+
+    testWidgets('a custom token in row2 still renders there (regression)', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        customHarness(
+          customButtons: [ck('ck_1_a', 'A')],
+          row2Tokens: [ckToken('ck_1_a')],
+        ),
+      );
+      await tester.pump();
+
+      expect(find.text('A'), findsOneWidget);
+      final aY = tester.getTopLeft(find.text('A')).dy;
+      final escY = tester.getTopLeft(find.text('ESC')).dy;
+      expect(aY, greaterThan(escY));
+    });
+
+    testWidgets('reordered row1 without custom tokens honours the order', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        customHarness(
+          row1Tokens: const [
+            'tab',
+            'esc',
+            'ctrl',
+            'alt',
+            'shift',
+            'enter',
+            'senter',
+            'slash',
+            'dash',
+          ],
+        ),
+      );
+      await tester.pump();
+
+      final tabX = tester.getTopLeft(find.text('TAB')).dx;
+      final escX = tester.getTopLeft(find.text('ESC')).dx;
+      expect(tabX, lessThan(escX));
+    });
+
+    testWidgets('row1 reduced to a single token renders only that token', (
+      tester,
+    ) async {
+      await tester.pumpWidget(customHarness(row1Tokens: const ['esc']));
+      await tester.pump();
+
+      expect(find.text('ESC'), findsOneWidget);
+      expect(find.text('TAB'), findsNothing);
+      expect(find.text('CTRL'), findsNothing);
+      expect(find.text('ALT'), findsNothing);
+    });
+
+    testWidgets('empty row1 renders no modifier row and keeps the pencil', (
+      tester,
+    ) async {
+      await tester.pumpWidget(customHarness(row1Tokens: const <String>[]));
+      await tester.pump();
+
+      expect(find.text('ESC'), findsNothing);
+      expect(find.text('TAB'), findsNothing);
+      expect(find.byIcon(Icons.edit_outlined), findsOneWidget);
+    });
+
+    testWidgets('num1 in row1 renders only when direct input is enabled', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        customHarness(
+          directInput: true,
+          row1Tokens: const ['num1'],
+          row2Tokens: const <String>[],
+        ),
+      );
+      await tester.pump();
+      expect(find.text('1'), findsOneWidget);
+
+      await tester.pumpWidget(
+        customHarness(
+          directInput: false,
+          row1Tokens: const ['num1'],
+          row2Tokens: const <String>[],
+        ),
+      );
+      await tester.pump();
+      expect(find.text('1'), findsNothing);
+    });
+
+    testWidgets('input in row0 renders only when direct input is off', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        customHarness(
+          directInput: false,
+          row0Tokens: const ['input'],
+          row2Tokens: const <String>[],
+        ),
+      );
+      await tester.pump();
+      expect(find.text('Cmd'), findsOneWidget);
+
+      await tester.pumpWidget(
+        customHarness(
+          directInput: true,
+          row0Tokens: const ['input'],
+          row2Tokens: const <String>[],
+        ),
+      );
+      await tester.pump();
+      expect(find.text('Cmd'), findsNothing);
+    });
+  });
+
+  group('SpecialKeysBar direct input field', () {
+    Finder directInputField() => find.byType(TextField);
+
+    String visibleText(WidgetTester tester) {
+      final field = tester.widget<TextField>(directInputField());
+      return field.controller!.text.replaceAll('\u200B', '');
+    }
+
+    testWidgets('typed text stays visible and is sent exactly once', (
+      tester,
+    ) async {
+      final keys = <String>[];
+      await tester.pumpWidget(
+        customHarness(directInput: true, onKeyPressed: keys.add),
+      );
+      await tester.pump();
+
+      await tester.enterText(directInputField(), 'models');
+      await tester.pump();
+
+      // The field keeps the typed text visible (not cleared to the sentinel).
+      expect(visibleText(tester), 'models');
+      expect(keys, ['models']);
+    });
+
+    testWidgets('deleting text sends BSpace for each removed char', (
+      tester,
+    ) async {
+      final keys = <String>[];
+      final specials = <String>[];
+      await tester.pumpWidget(
+        customHarness(
+          directInput: true,
+          onKeyPressed: keys.add,
+          onSpecialKeyPressed: specials.add,
+        ),
+      );
+      await tester.pump();
+
+      await tester.enterText(directInputField(), 'models');
+      await tester.pump();
+      expect(keys, ['models']);
+
+      await tester.enterText(directInputField(), 'mode');
+      await tester.pump();
+
+      expect(specials.where((k) => k == 'BSpace').length, 2);
+      expect(visibleText(tester), 'mode');
+    });
+
+    testWidgets('submit sends Enter and clears the field', (tester) async {
+      final specials = <String>[];
+      await tester.pumpWidget(
+        customHarness(directInput: true, onSpecialKeyPressed: specials.add),
+      );
+      await tester.pump();
+
+      await tester.enterText(directInputField(), 'models');
+      await tester.pump();
+      expect(visibleText(tester), 'models');
+
+      await tester.testTextInput.receiveAction(TextInputAction.send);
+      await tester.pump();
+
+      expect(specials, contains('Enter'));
+      expect(visibleText(tester), isEmpty);
+    });
+  });
+
+  group('SpecialKeysBar row auto-scroll', () {
+    testWidgets('row 1 scrolls to the end when a custom button is appended', (
+      tester,
+    ) async {
+      await tester.binding.setSurfaceSize(const Size(320, 640));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      final a = ck('ck_1_a', 'A');
+      final b = ck('ck_2_b', 'B');
+      final standards = [
+        'esc',
+        'tab',
+        'ctrl',
+        'alt',
+        'shift',
+        'enter',
+        'senter',
+        'slash',
+        'dash',
+      ];
+      final tokens = [...standards, ckToken('ck_1_a')];
+      final tokensPlus = [...tokens, ckToken('ck_2_b')];
+
+      Widget build(List<String> row1) =>
+          customHarness(width: 320, customButtons: [a, b], row1Tokens: row1);
+
+      await tester.pumpWidget(build(tokens));
+      await tester.pump();
+
+      // No scroll yet: the row starts at the left edge.
+      expect(tester.takeException(), isNull);
+
+      await tester.pumpWidget(build(tokensPlus));
+      await tester.pumpAndSettle();
+
+      // The row-1 horizontal scroller auto-scrolled to reveal the new button.
+      final scrolled = tester
+          .widgetList<SingleChildScrollView>(horizontalScroller())
+          .where((s) => s.controller != null && s.controller!.hasClients)
+          .where((s) => s.controller!.offset > 0);
+      expect(scrolled, isNotEmpty);
+    });
+
+    testWidgets('row 1 scrolls back to the start when a button is prepended', (
+      tester,
+    ) async {
+      await tester.binding.setSurfaceSize(const Size(320, 640));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      final a = ck('ck_1_a', 'A');
+      final b = ck('ck_2_b', 'B');
+      final standards = [
+        'esc',
+        'tab',
+        'ctrl',
+        'alt',
+        'shift',
+        'enter',
+        'senter',
+        'slash',
+        'dash',
+      ];
+      final tokens = [...standards, ckToken('ck_1_a')];
+      final prepended = [ckToken('ck_2_b'), ...tokens];
+
+      Widget build(List<String> row1) =>
+          customHarness(width: 320, customButtons: [a, b], row1Tokens: row1);
+
+      await tester.pumpWidget(build(tokens));
+      await tester.pump();
+
+      // Park the row away from the left edge first.
+      final controller = tester
+          .widgetList<SingleChildScrollView>(horizontalScroller())
+          .map((s) => s.controller)
+          .firstWhere((c) => c != null && c.hasClients)!;
+      controller.jumpTo(controller.position.maxScrollExtent);
+      await tester.pump();
+      expect(controller.offset, greaterThan(0));
+
+      await tester.pumpWidget(build(prepended));
+      await tester.pumpAndSettle();
+
+      // The new leading button is revealed instead of the row's tail.
+      expect(controller.offset, 0);
+    });
+    testWidgets('row 0 scrolls back to the start when a button is prepended', (
+      tester,
+    ) async {
+      await tester.binding.setSurfaceSize(const Size(320, 640));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      final buttons = [
+        for (var i = 0; i < 8; i++) ck('ck_${i + 1}_c${i + 1}', 'K$i'),
+      ];
+      final extra = ck('ck_9_c9', 'K8');
+      final allButtons = [...buttons, extra];
+      final tokens = buttons.map((b) => ckToken(b.id)).toList();
+      final prepended = [ckToken(extra.id), ...tokens];
+
+      Widget build(List<String> row0) => customHarness(
+        width: 320,
+        customButtons: allButtons,
+        row0Tokens: row0,
+      );
+
+      await tester.pumpWidget(build(tokens));
+      await tester.pump();
+
+      // Park the row away from the left edge first.
+      final controller = tester
+          .widgetList<SingleChildScrollView>(horizontalScroller())
+          .map((s) => s.controller)
+          .firstWhere((c) => c != null && c.hasClients)!;
+      controller.jumpTo(controller.position.maxScrollExtent);
+      await tester.pump();
+      expect(controller.offset, greaterThan(0));
+
+      await tester.pumpWidget(build(prepended));
+      await tester.pumpAndSettle();
+
+      // The new leading button is revealed instead of the row's tail.
+      expect(controller.offset, 0);
+    });
   });
 }

--- a/test/widgets/special_keys_bar_test.dart
+++ b/test/widgets/special_keys_bar_test.dart
@@ -28,7 +28,11 @@ void main() {
               directInputEnabled: directInputEnabled,
               onDirectInputToggle: () {},
               onImagePickRequested: onImagePickRequested,
-              row0Tokens: row0Tokens,
+              rows: [
+                row0Tokens,
+                CustomKeyRows.standardRow1,
+                CustomKeyRows.standardRow2,
+              ],
             ),
           ),
         ),
@@ -62,7 +66,11 @@ void main() {
               onDirectInputToggle: () {},
               directInputEnabled: directInput,
               hapticFeedback: false,
-              row0Tokens: row0Tokens,
+              rows: [
+                row0Tokens,
+                CustomKeyRows.standardRow1,
+                CustomKeyRows.standardRow2,
+              ],
             ),
           ),
         ),
@@ -89,6 +97,7 @@ void main() {
     List<String> row0Tokens = const <String>[],
     List<String>? row1Tokens,
     List<String>? row2Tokens,
+    List<List<String>>? rows,
     void Function(CustomKeyButton)? onCustomButtonEdit,
     VoidCallback? onManageButtons,
     void Function(String)? onKeyPressed,
@@ -112,9 +121,13 @@ void main() {
               directInputEnabled: directInput,
               hapticFeedback: false,
               customButtons: customButtons,
-              row0Tokens: row0Tokens,
-              row1Tokens: row1Tokens ?? CustomKeyRows.standardRow1,
-              row2Tokens: row2Tokens ?? CustomKeyRows.standardRow2,
+              rows:
+                  rows ??
+                  [
+                    row0Tokens,
+                    row1Tokens ?? CustomKeyRows.standardRow1,
+                    row2Tokens ?? CustomKeyRows.standardRow2,
+                  ],
               onCustomButtonEdit: onCustomButtonEdit,
               onManageButtons: onManageButtons,
             ),
@@ -349,7 +362,11 @@ void main() {
       },
     );
 
-    testWidgets('row-2 custom buttons render at 36px height', (tester) async {
+    // Rows are interchangeable, so custom buttons are one height everywhere
+    // (32); only the fixed nav glyph buttons keep their own 36x36 box.
+    testWidgets('custom buttons render at 32px height in any row', (
+      tester,
+    ) async {
       await tester.pumpWidget(
         customHarness(
           customButtons: [ck('ck_1_a', 'A')],
@@ -362,7 +379,7 @@ void main() {
         (w) => w is CustomKeyButtonWidget && w.button.id == 'ck_1_a',
       );
       expect(finder, findsOneWidget);
-      expect(tester.getSize(finder).height, 36);
+      expect(tester.getSize(finder).height, 32);
     });
 
     testWidgets(
@@ -778,6 +795,85 @@ void main() {
 
       // The new leading button is revealed instead of the row's tail.
       expect(controller.offset, 0);
+    });
+  });
+
+  group('SpecialKeysBar dynamic rows', () {
+    // Defends the rows contract: a user-created fourth row renders below the
+    // third and its buttons work.
+    testWidgets('a fourth row renders at the bottom and its token sends', (
+      tester,
+    ) async {
+      final sent = <String>[];
+      final a = ck('ck_9_z', 'Z');
+      await tester.pumpWidget(
+        customHarness(
+          customButtons: [a],
+          rows: [
+            const <String>[],
+            CustomKeyRows.standardRow1,
+            CustomKeyRows.standardRow2,
+            [ckToken(a.id)],
+          ],
+          onKeyPressed: sent.add,
+        ),
+      );
+      await tester.pump();
+
+      expect(find.text('Z'), findsOneWidget);
+      expect(
+        tester.getTopLeft(find.text('Z')).dy,
+        greaterThan(tester.getTopLeft(find.text('PgUp')).dy),
+      );
+
+      await tester.tap(find.text('Z'));
+      await tester.pump();
+      expect(sent, ['x']);
+    });
+
+    // Defends reachability: with no rows at all the editor entry point stays.
+    testWidgets('an empty layout still shows exactly one pencil', (
+      tester,
+    ) async {
+      var managed = 0;
+      await tester.pumpWidget(
+        customHarness(
+          rows: const <List<String>>[],
+          onManageButtons: () => managed++,
+        ),
+      );
+      await tester.pump();
+
+      expect(find.byIcon(Icons.edit_outlined), findsOneWidget);
+      expect(find.text('ESC'), findsNothing);
+      expect(find.text('PgUp'), findsNothing);
+
+      await tester.tap(find.byIcon(Icons.edit_outlined));
+      await tester.pump();
+      expect(managed, 1);
+    });
+    // Defends that the legacy fast paths are keyed on row CONTENT, not on row
+    // index: a default nav row keeps its stretched Input button at index 1,
+    // where the nav row never used to be. (It cannot be tested at index 0
+    // because the first rendering row hosts the pencil, which the legacy nav
+    // layout has no slot for.)
+    testWidgets('a default nav row keeps the legacy layout at any index', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        customHarness(
+          rows: [CustomKeyRows.standardRow1, CustomKeyRows.standardRow2],
+        ),
+      );
+      await tester.pump();
+
+      expect(find.text('Cmd'), findsOneWidget);
+      expect(
+        tester.getTopLeft(find.text('ESC')).dy,
+        lessThan(tester.getTopLeft(find.text('PgUp')).dy),
+      );
+      // Both rows are on legacy paths, so no row needs a horizontal scroller.
+      expect(horizontalScroller(), findsNothing);
     });
   });
 }

--- a/test/widgets/special_keys_bar_test.dart
+++ b/test/widgets/special_keys_bar_test.dart
@@ -267,7 +267,7 @@ void main() {
     });
 
     testWidgets(
-      'pencil button is present, in row 1, and fires onManageButtons',
+      'pencil hosts on row 1 while the custom row is empty and fires onManageButtons',
       (tester) async {
         var managed = 0;
         await tester.pumpWidget(
@@ -298,6 +298,34 @@ void main() {
         expect(managed, 1);
       },
     );
+
+    testWidgets('pencil moves to the custom row once that row has tokens', (
+      tester,
+    ) async {
+      final a = ck('ck_1_a', 'A');
+      await tester.pumpWidget(
+        customHarness(customButtons: [a], row0Tokens: [ckToken(a.id)]),
+      );
+      await tester.pump();
+
+      final pencil = find.byIcon(Icons.edit_outlined);
+      // Exactly one: the legacy row-1 layout must drop its own pencil instead
+      // of rendering a second one.
+      expect(pencil, findsOneWidget);
+
+      // Same row as the custom button, above the untouched modifier row.
+      expect(
+        tester.getTopLeft(pencil).dy,
+        closeTo(tester.getTopLeft(find.text('A')).dy, 6),
+      );
+      expect(
+        tester.getTopLeft(pencil).dy,
+        lessThan(tester.getTopLeft(find.text('ESC')).dy),
+      );
+      // Row 1 keeps its default stretched layout.
+      expect(find.text('ESC'), findsOneWidget);
+      expect(find.text('-'), findsOneWidget);
+    });
 
     testWidgets(
       'customized direct-input row renders only the tokens it holds',


### PR DESCRIPTION
## Custom key buttons

Lets the user define their own buttons for the special keys bar and lay the bar
out freely. A button is an ordered list of steps — literal text, a tmux key name
or a pause — so one tap can send `/models` followed by `Enter`.

### What it adds

- **Buttons library** — create / edit / delete buttons in `Settings → Buttons →
  Custom Buttons`. Each button is a label plus steps (`text` / `key` / `pause`);
  steps run in order, `key` reuses the bar's existing key vocabulary
  (`Enter`, `Escape`, `C-c`, `S-Enter`, `BSpace`, …).
- **Free bar layout** — the bar is no longer three hard-coded rows. Rows are a
  user-ordered list (up to 6): add a row, delete a row, drag any chip (standard
  or custom) to any position in any row, or park it on the *Unused* shelf to
  hide it from the bar. A row that exactly equals a historical default row still
  renders through the old stretched layout, so the default bar is unchanged
  byte-for-byte for anyone who never opens the editor.
- **Reachability** — a pencil button sits at the end of the first rendering row
  and opens the full editor; long-press on a custom button opens a quick editor
  for that button. Tapping a custom button resets software modifiers exactly like
  a standard key.
- **Persistence** — global, in `shared_preferences` (`custom_key_buttons_v1`,
  `custom_key_rows_v1`). Corrupt or partially invalid data degrades instead of
  crashing: a bad button entry is dropped, a bad layout falls back to the
  default rows.

### Screenshots

<details>
<summary>Editor, action dialog, bar in the terminal</summary>

**Buttons library and layout strips** — drag chips between rows and the Unused shelf; `+` on a row header creates a button directly in that row.

<img src="https://raw.githubusercontent.com/labi-le/mux-pod/media/custom-key-buttons/editor.png" width="420">

**Action dialog** — a button as an ordered list of steps: text `/models`, then key `Enter`.

<img src="https://raw.githubusercontent.com/labi-le/mux-pod/media/custom-key-buttons/dialog.png" width="300">

**Result in the terminal** — one tap on `models` typed `/models` and pressed Enter.

<img src="https://raw.githubusercontent.com/labi-le/mux-pod/media/custom-key-buttons/bar_demo.png" width="420">

</details>

### Also in this branch

`settings: clear SSH host keys safely and expose custom buttons` adds a
`Settings → Security → Clear SSH Host Keys` recovery action. It deletes only the
pinned host-key fingerprints: they are indexed by key name, so the wipe never
calls `FlutterSecureStorage.readAll()`, which on Android silently deletes the
*whole* preferences file when a single entry is undecryptable
(`resetOnError` defaults to `true` since flutter_secure_storage 10.0.0). Saved
passwords, private keys and connections are left intact.

### Notes

- Spec and data model: `specs/004-custom-key-buttons/`.
- UI strings are English, code comments follow the repo's Japanese convention.
- `flutter analyze`: clean. `flutter test`: 1425 passing; the 6 failures on this
  branch also fail on `main` (`terminal_screen_herdr*`, `input_dialog`,
  `repro_ssh_hostkey_fingerprint`).
- Manually verified on device (Android 11, 1080x2340): create a button, drag it
  between rows and onto the shelf, add and delete a row, layout survives a
  restart, tap sends the steps once.
