### PR TITLE
fix: paint terminal row background to end of line and on empty lines

### DIFF
--- a/lib/screens/terminal/widgets/ansi_text_view.dart
+++ b/lib/screens/terminal/widgets/ansi_text_view.dart
@@ -855,6 +855,29 @@ class AnsiTextViewState extends ConsumerState<AnsiTextView> {
               );
             }
 
+            // 行背景レイヤー（C-001）: 背景色付き行は行末まで、空行は行全体を
+            // 塗る。テキストは実データのまま、背景を下層レイヤーで描画する。
+            // 背景 Container は IgnorePointer で包み、タップ・選択を奪わない。
+            final Color? lineBackground = _parser.effectiveLineBackgroundColor(
+              line,
+            );
+            if (lineBackground != null) {
+              lineWidget = Stack(
+                children: [
+                  // 幅 terminalWidth の背景（非 positioned 子として Stack を
+                  // pane 幅に固定し、テキスト幅より右側も塗る）。
+                  IgnorePointer(
+                    child: SizedBox(
+                      width: terminalWidth,
+                      height: _lineHeight,
+                      child: ColoredBox(color: lineBackground),
+                    ),
+                  ),
+                  lineWidget,
+                ],
+              );
+            }
+
             // 固定幅コンテナ（水平スクロール用）
             if (needsHorizontalScroll) {
               lineWidget = SizedBox(width: terminalWidth, child: lineWidget);

--- a/lib/services/terminal/ansi_parser.dart
+++ b/lib/services/terminal/ansi_parser.dart
@@ -529,7 +529,11 @@ class AnsiParser {
       fg = bg;
       bg = temp;
     }
-    return (foreground: fg, background: bg, paintBackground: style.inverse || bg != defaultBackground);
+    return (
+      foreground: fg,
+      background: bg,
+      paintBackground: style.inverse || bg != defaultBackground,
+    );
   }
 
   /// 行全体の有効背景色（行末まで延長・空行背景用）を返す。

--- a/lib/services/terminal/ansi_parser.dart
+++ b/lib/services/terminal/ansi_parser.dart
@@ -404,15 +404,11 @@ class AnsiParser {
     required String fontFamily,
   }) {
     final style = segment.style;
-    var fg = style.foreground ?? defaultForeground;
-    var bg = style.background ?? defaultBackground;
-
-    // 反転
-    if (style.inverse) {
-      final temp = fg;
-      fg = bg;
-      bg = temp;
-    }
+    final (:foreground, :background, :paintBackground) = resolvePaintColors(
+      style,
+    );
+    var fg = foreground;
+    final bg = background;
 
     // 薄暗い
     if (style.dim) {
@@ -431,7 +427,7 @@ class AnsiParser {
         fontFamily,
         fontSize: fontSize,
         color: fg,
-        backgroundColor: (style.inverse || bg != defaultBackground) ? bg : null,
+        backgroundColor: paintBackground ? bg : null,
         fontWeight: style.bold ? FontWeight.bold : FontWeight.normal,
         fontStyle: style.italic ? FontStyle.italic : FontStyle.normal,
         decoration: TextDecoration.combine([
@@ -517,6 +513,38 @@ class AnsiParser {
     }
 
     return (segments: segments, endStyle: currentStyle);
+  }
+
+  /// セグメント/行スタイルから描画用の前景色・背景色と「背景を描くか」を決定する。
+  ///
+  /// inverse 時は前背景を入れ替え、`inverse || 背景≠default` のときのみ背景を
+  /// 描画する。[_segmentToTextSpan]（セグメント描画）と
+  /// [effectiveLineBackgroundColor]（行背景レイヤー）の単一ソース（R3）。
+  ({Color foreground, Color background, bool paintBackground})
+  resolvePaintColors(AnsiStyle style) {
+    var fg = style.foreground ?? defaultForeground;
+    var bg = style.background ?? defaultBackground;
+    if (style.inverse) {
+      final temp = fg;
+      fg = bg;
+      bg = temp;
+    }
+    return (foreground: fg, background: bg, paintBackground: style.inverse || bg != defaultBackground);
+  }
+
+  /// 行全体の有効背景色（行末まで延長・空行背景用）を返す。
+  ///
+  /// 行末の空白セルは最終セグメントと同じスタイルを持つため、最終セグメント
+  /// （空行は [ParsedLine.endStyle]）から inverse 適用後の有効背景色を導出する。
+  /// デフォルト背景と等しい場合は null（背景レイヤー不要）を返す。
+  Color? effectiveLineBackgroundColor(ParsedLine line) {
+    final style = line.segments.isEmpty
+        ? line.endStyle
+        : line.segments.last.style;
+    final (:foreground, :background, :paintBackground) = resolvePaintColors(
+      style,
+    );
+    return paintBackground ? background : null;
   }
 
   /// ParsedLineをTextSpanに変換

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -69,10 +69,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -605,14 +605,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.5"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      sha256: "53385261521cc4a0c4658fd0ad07a7d14591cf8fc33abbceae306ddb974888dc"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.7.2"
   json_annotation:
     dependency: transitive
     description:
@@ -705,26 +697,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:
@@ -1062,26 +1054,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
+      sha256: "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20"
       url: "https://pub.dev"
     source: hosted
-    version: "1.26.3"
+    version: "1.31.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.11"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
+      sha256: "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.12"
+    version: "0.6.17"
   typed_data:
     dependency: transitive
     description:

--- a/test/screens/terminal/ansi_text_view_bg_test.dart
+++ b/test/screens/terminal/ansi_text_view_bg_test.dart
@@ -51,9 +51,7 @@ void main() {
   int countColoredBoxes(WidgetTester tester, Color color) {
     return tester
         .widgetList<ColoredBox>(
-          find.byWidgetPredicate(
-            (w) => w is ColoredBox && w.color == color,
-          ),
+          find.byWidgetPredicate((w) => w is ColoredBox && w.color == color),
         )
         .length;
   }
@@ -62,20 +60,14 @@ void main() {
     await tester.pumpWidget(buildSubject('\x1b[42mgreen text\x1b[0m'));
     await tester.pumpAndSettle();
 
-    expect(
-      countColoredBoxes(tester, greenBackground),
-      greaterThanOrEqualTo(1),
-    );
+    expect(countColoredBoxes(tester, greenBackground), greaterThanOrEqualTo(1));
   });
 
   testWidgets('SGRのみの空行にも背景レイヤーが描画される', (tester) async {
     await tester.pumpWidget(buildSubject('before\n\x1b[42m\nafter'));
     await tester.pumpAndSettle();
 
-    expect(
-      countColoredBoxes(tester, greenBackground),
-      greaterThanOrEqualTo(1),
-    );
+    expect(countColoredBoxes(tester, greenBackground), greaterThanOrEqualTo(1));
   });
 
   testWidgets('デフォルト背景の行には追加の背景レイヤーが無い', (tester) async {

--- a/test/screens/terminal/ansi_text_view_bg_test.dart
+++ b/test/screens/terminal/ansi_text_view_bg_test.dart
@@ -1,0 +1,146 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_muxpod/providers/settings_provider.dart';
+import 'package:flutter_muxpod/providers/terminal_display_provider.dart';
+import 'package:flutter_muxpod/screens/terminal/widgets/ansi_text_view.dart';
+
+import '../../helpers/fake_settings_notifier.dart';
+
+/// C-001: 背景色付き行の行末までの背景描画・空行の背景描画を検証する。
+///
+/// テスト環境（Ahem フォント）では実機フォントの「行末スペースに背景が
+/// 塗られない」挙動を再現できないため、ここでは背景レイヤー（ColoredBox）
+/// の構造存在を検証する。実機での見た目は REPRO 手順 + ピクセル解析で
+/// 検証する（bugfix レポート参照）。
+class _FixedTerminalDisplayNotifier extends TerminalDisplayNotifier {
+  @override
+  TerminalDisplayState build() => const TerminalDisplayState(
+    paneWidth: 80,
+    paneHeight: 24,
+    screenWidth: 400.0,
+    screenHeight: 800.0,
+    calculatedFontSize: 14.0,
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  // ANSI 緑背景 (42) = standardColors[2]
+  const greenBackground = Color(0xFF0DBC79);
+  // デフォルト背景
+  const defaultBackground = Color(0xFF1E1E1E);
+
+  Widget buildSubject(String text) {
+    return ProviderScope(
+      overrides: [
+        settingsProvider.overrideWith(() => FakeSettingsNotifier()),
+        terminalDisplayProvider.overrideWith(
+          () => _FixedTerminalDisplayNotifier(),
+        ),
+      ],
+      child: MaterialApp(
+        home: Scaffold(
+          body: AnsiTextView(text: text, paneWidth: 80, paneHeight: 24),
+        ),
+      ),
+    );
+  }
+
+  int countColoredBoxes(WidgetTester tester, Color color) {
+    return tester
+        .widgetList<ColoredBox>(
+          find.byWidgetPredicate(
+            (w) => w is ColoredBox && w.color == color,
+          ),
+        )
+        .length;
+  }
+
+  testWidgets('背景色付き行に背景レイヤーが描画される', (tester) async {
+    await tester.pumpWidget(buildSubject('\x1b[42mgreen text\x1b[0m'));
+    await tester.pumpAndSettle();
+
+    expect(
+      countColoredBoxes(tester, greenBackground),
+      greaterThanOrEqualTo(1),
+    );
+  });
+
+  testWidgets('SGRのみの空行にも背景レイヤーが描画される', (tester) async {
+    await tester.pumpWidget(buildSubject('before\n\x1b[42m\nafter'));
+    await tester.pumpAndSettle();
+
+    expect(
+      countColoredBoxes(tester, greenBackground),
+      greaterThanOrEqualTo(1),
+    );
+  });
+
+  testWidgets('デフォルト背景の行には追加の背景レイヤーが無い', (tester) async {
+    await tester.pumpWidget(buildSubject('plain line'));
+    await tester.pumpAndSettle();
+
+    // デフォルト背景色の ColoredBox（Container 由来）のみで、
+    // 行単位の追加背景レイヤーが存在しないこと
+    final rowLayers = tester
+        .widgetList<ColoredBox>(
+          find.byWidgetPredicate(
+            (w) =>
+                w is ColoredBox &&
+                w.color == defaultBackground &&
+                w.child is SizedBox,
+          ),
+        )
+        .length;
+    expect(rowLayers, 0);
+  });
+
+  testWidgets('背景レイヤーはIgnorePointerで包まれタップを奪わない', (tester) async {
+    var tapped = false;
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          settingsProvider.overrideWith(() => FakeSettingsNotifier()),
+          terminalDisplayProvider.overrideWith(
+            () => _FixedTerminalDisplayNotifier(),
+          ),
+        ],
+        child: MaterialApp(
+          home: Scaffold(
+            body: AnsiTextView(
+              text: '\x1b[42mgreen\x1b[0m',
+              paneWidth: 80,
+              paneHeight: 24,
+              onTap: () => tapped = true,
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // 背景 ColoredBox の親チェーンに IgnorePointer が存在すること
+    final backgroundFinder = find.byWidgetPredicate(
+      (w) => w is ColoredBox && w.color == greenBackground,
+    );
+    expect(backgroundFinder, findsWidgets);
+    // 背景 ColoredBox の祖先に IgnorePointer が存在すること
+    final coloredBoxElement = tester.element(backgroundFinder.first);
+    var hasIgnorePointerAncestor = false;
+    coloredBoxElement.visitAncestorElements((ancestor) {
+      if (ancestor.widget is IgnorePointer) {
+        hasIgnorePointerAncestor = true;
+        return false;
+      }
+      return true;
+    });
+    expect(hasIgnorePointerAncestor, isTrue);
+
+    // タップが onTap に届くこと（背景レイヤーがヒットテストを妨げない）
+    await tester.tap(find.byType(AnsiTextView));
+    await tester.pump();
+    expect(tapped, isTrue);
+  });
+}

--- a/test/services/terminal/ansi_parser_test.dart
+++ b/test/services/terminal/ansi_parser_test.dart
@@ -174,5 +174,46 @@ void main() {
       // Swapped: BG should be 0xFFD4D4D4
       expect(cursorSpan.style!.backgroundColor, const Color(0xFFD4D4D4));
     });
+
+    group('effectiveLineBackgroundColor', () {
+      test('returns null for plain line (default background)', () {
+        final lines = parser.parseLines('plain text');
+        expect(parser.effectiveLineBackgroundColor(lines[0]), isNull);
+      });
+
+      test('returns segment background for colored line', () {
+        // 青背景 44 = standardColors[4] = 0xFF2472C8
+        final lines = parser.parseLines('\x1b[44mCOLORED-TEXT\x1b[49m');
+        expect(
+          parser.effectiveLineBackgroundColor(lines[0]),
+          const Color(0xFF2472C8),
+        );
+      });
+
+      test('returns endStyle background for empty line with SGR only', () {
+        // 緑背景 42 のみでテキスト無しの空行
+        final lines = parser.parseLines('\x1b[42m');
+        expect(lines[0].segments, isEmpty);
+        expect(
+          parser.effectiveLineBackgroundColor(lines[0]),
+          const Color(0xFF0DBC79),
+        );
+      });
+
+      test('returns inverse-swapped foreground for inverse line', () {
+        // 反転時は有効背景 = 元の前景（デフォルト前景）
+        final lines = parser.parseLines('\x1b[7mreversed');
+        expect(
+          parser.effectiveLineBackgroundColor(lines[0]),
+          const Color(0xFFD4D4D4), // defaultForeground
+        );
+      });
+
+      test('uses last segment style for trailing style', () {
+        // 前半は赤背景、後半はリセット済み → 有効背景は default → null
+        final lines = parser.parseLines('\x1b[41mRED\x1b[49m tail');
+        expect(parser.effectiveLineBackgroundColor(lines[0]), isNull);
+      });
+    });
   });
 }


### PR DESCRIPTION
## Summary
- Terminal rows with an ANSI background color only painted up to the last glyph; trailing cells (which tmux fills with real spaces) and empty lines carrying only a background SGR were not painted at all
- Root cause: the renderer only attached `backgroundColor` to text-bearing segments — there was no mechanism to extend the background to end of line or to paint empty lines (present since the initial RichText renderer, not a regression)
- Fix: derive each row's effective background color and draw it as a pane-width layer under the text, keeping the captured text data untouched

## Changes
- `lib/services/terminal/ansi_parser.dart`
  - Add `resolvePaintColors()` as the single source for effective fg/bg decisions (including inverse swap), shared by `_segmentToTextSpan` and row-background lookup
  - Add `effectiveLineBackgroundColor()`: derives a row background from the last segment (`endStyle` for empty lines); returns null when equal to the default background
- `lib/screens/terminal/widgets/ansi_text_view.dart`
  - Colored rows are wrapped in a `Stack` with a pane-width background layer (`IgnorePointer` + `ColoredBox`) under the existing `Text.rich`, so taps, long-press swipes, and selection pass through unchanged
- Tests
  - Unit tests for `effectiveLineBackgroundColor` (plain / colored / SGR-only empty line / inverse / trailing reset)
  - Widget tests for the background layer (colored & empty rows get a layer, default rows do not, tap-through via IgnorePointer)

## Test plan
- [x] `flutter test` full suite: 1308 passed, 0 failed
- [x] `make analyze`: No issues found
- [x] On-device verification (Android emulator, tmux pane 115x35): rows with blue/green/red backgrounds now paint to the right edge of the pane; empty SGR-only lines paint full width

### Before / After screenshots
| Before | After |
|---|---|
| ![before](https://file-store.mox.run/bg-color-before.png) | ![after](https://file-store.mox.run/bg-color-after.png) |

Before: blue background stops at `COLORED-TEXT` (x=8..158 of pane area x=8..1071); green/red empty lines have no background.
After: all three rows paint the full pane width.