### PR TITLE
fix: stabilize DirectInput text input on mobile IMEs

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -976,6 +976,8 @@
   "settingsInvertPaneNavigationDescription": "Reverse swipe direction for pane switching",
   "settingsCjkMode": "CJK Mode",
   "settingsCjkModeDescription": "In DirectInput, send text each time the keyboard commits a conversion, then clear the input field. Turn this on if Japanese/Chinese/Korean input is sent twice on iOS.",
+  "settingsKeepKeyboardOnEnter": "Keep Keyboard Open on Enter",
+  "settingsKeepKeyboardOnEnterDescription": "In DirectInput, keep the software keyboard open after pressing Enter to send.",
   "settingsTheme": "Theme",
   "settingsRemotePath": "Remote Path",
   "settingsOutputFormat": "Output Format",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -974,6 +974,8 @@
   },
   "settingsInvertPaneNavigation": "Invert Pane Navigation",
   "settingsInvertPaneNavigationDescription": "Reverse swipe direction for pane switching",
+  "settingsCjkMode": "CJK Mode",
+  "settingsCjkModeDescription": "In DirectInput, send text each time the keyboard commits a conversion, then clear the input field. Turn this on if Japanese/Chinese/Korean input is sent twice on iOS.",
   "settingsTheme": "Theme",
   "settingsRemotePath": "Remote Path",
   "settingsOutputFormat": "Output Format",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -974,6 +974,8 @@
   },
   "settingsInvertPaneNavigation": "ペイン切り替えを反転",
   "settingsInvertPaneNavigationDescription": "ペイン切り替えのスワイプ方向を反転",
+  "settingsCjkMode": "CJKモード",
+  "settingsCjkModeDescription": "DirectInputで、キーボードの変換確定ごとに文字を送信して入力欄を空にします。iOSで日本語などの入力が重複して送信される場合にオンにしてください。",
   "settingsTheme": "テーマ",
   "settingsRemotePath": "リモートパス",
   "settingsOutputFormat": "出力形式",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -976,6 +976,8 @@
   "settingsInvertPaneNavigationDescription": "ペイン切り替えのスワイプ方向を反転",
   "settingsCjkMode": "CJKモード",
   "settingsCjkModeDescription": "DirectInputで、キーボードの変換確定ごとに文字を送信して入力欄を空にします。iOSで日本語などの入力が重複して送信される場合にオンにしてください。",
+  "settingsKeepKeyboardOnEnter": "Enterでキーボードを閉じない",
+  "settingsKeepKeyboardOnEnterDescription": "DirectInputでEnterキーで送信してもソフトウェアキーボードを閉じないようにします。",
   "settingsTheme": "テーマ",
   "settingsRemotePath": "リモートパス",
   "settingsOutputFormat": "出力形式",

--- a/lib/providers/settings_provider.dart
+++ b/lib/providers/settings_provider.dart
@@ -243,7 +243,8 @@ class SettingsNotifier extends Notifier<AppSettings> {
   static const String _adjustModeKey = 'settings_adjust_mode';
   static const String _directInputEnabledKey = 'settings_direct_input_enabled';
   static const String _cjkModeKey = 'settings_cjk_mode';
-  static const String _keepKeyboardOnEnterKey = 'settings_keep_keyboard_on_enter';
+  static const String _keepKeyboardOnEnterKey =
+      'settings_keep_keyboard_on_enter';
   static const String _showTerminalCursorKey = 'settings_show_terminal_cursor';
   static const String _invertPaneNavKey = 'settings_invert_pane_nav';
   // inventory: SETTINGS-SCROLL-SEND-004

--- a/lib/providers/settings_provider.dart
+++ b/lib/providers/settings_provider.dart
@@ -39,6 +39,9 @@ class AppSettings {
   /// iOSのCJK系IMEで発生する多重送信回避用（設定UIはiOSのみ表示）。
   final bool cjkMode;
 
+  /// DirectInput: Enter送信後もソフトウェアキーボードを開いたままにするか。
+  final bool keepKeyboardOnEnter;
+
   /// ターミナルカーソルの表示設定
   final bool showTerminalCursor;
 
@@ -107,6 +110,7 @@ class AppSettings {
     this.adjustMode = 'autoFit',
     this.directInputEnabled = false,
     this.cjkMode = false,
+    this.keepKeyboardOnEnter = false,
     this.showTerminalCursor = true,
     this.invertPaneNavigation = false,
     // inventory: SETTINGS-SCROLL-SEND-002
@@ -152,6 +156,7 @@ class AppSettings {
     String? adjustMode,
     bool? directInputEnabled,
     bool? cjkMode,
+    bool? keepKeyboardOnEnter,
     bool? showTerminalCursor,
     bool? invertPaneNavigation,
     // inventory: SETTINGS-SCROLL-SEND-003
@@ -193,6 +198,7 @@ class AppSettings {
       adjustMode: adjustMode ?? this.adjustMode,
       directInputEnabled: directInputEnabled ?? this.directInputEnabled,
       cjkMode: cjkMode ?? this.cjkMode,
+      keepKeyboardOnEnter: keepKeyboardOnEnter ?? this.keepKeyboardOnEnter,
       showTerminalCursor: showTerminalCursor ?? this.showTerminalCursor,
       invertPaneNavigation: invertPaneNavigation ?? this.invertPaneNavigation,
       scrollSendInput: scrollSendInput ?? this.scrollSendInput,
@@ -237,6 +243,7 @@ class SettingsNotifier extends Notifier<AppSettings> {
   static const String _adjustModeKey = 'settings_adjust_mode';
   static const String _directInputEnabledKey = 'settings_direct_input_enabled';
   static const String _cjkModeKey = 'settings_cjk_mode';
+  static const String _keepKeyboardOnEnterKey = 'settings_keep_keyboard_on_enter';
   static const String _showTerminalCursorKey = 'settings_show_terminal_cursor';
   static const String _invertPaneNavKey = 'settings_invert_pane_nav';
   // inventory: SETTINGS-SCROLL-SEND-004
@@ -294,6 +301,7 @@ class SettingsNotifier extends Notifier<AppSettings> {
       adjustMode: prefs.getString(_adjustModeKey) ?? 'autoFit',
       directInputEnabled: prefs.getBool(_directInputEnabledKey) ?? false,
       cjkMode: prefs.getBool(_cjkModeKey) ?? false,
+      keepKeyboardOnEnter: prefs.getBool(_keepKeyboardOnEnterKey) ?? false,
       showTerminalCursor: prefs.getBool(_showTerminalCursorKey) ?? true,
       invertPaneNavigation: prefs.getBool(_invertPaneNavKey) ?? false,
       // inventory: SETTINGS-SCROLL-SEND-005
@@ -507,6 +515,12 @@ class SettingsNotifier extends Notifier<AppSettings> {
   Future<void> setCjkMode(bool value) async {
     state = state.copyWith(cjkMode: value);
     await _saveSetting(_cjkModeKey, value);
+  }
+
+  /// Enter送信後もソフトウェアキーボードを開いたままにする
+  Future<void> setKeepKeyboardOnEnter(bool value) async {
+    state = state.copyWith(keepKeyboardOnEnter: value);
+    await _saveSetting(_keepKeyboardOnEnterKey, value);
   }
 
   /// ターミナルカーソル表示設定を設定

--- a/lib/providers/settings_provider.dart
+++ b/lib/providers/settings_provider.dart
@@ -34,6 +34,11 @@ class AppSettings {
   /// DirectInputモード（入力した文字を即座にターミナルに送信）
   final bool directInputEnabled;
 
+  /// CJK Mode: IME確定ごとに全文送信して入力欄をクリアする旧来
+  /// （v0.7.0-pre4）のDirectInput挙動を使うか。
+  /// iOSのCJK系IMEで発生する多重送信回避用（設定UIはiOSのみ表示）。
+  final bool cjkMode;
+
   /// ターミナルカーソルの表示設定
   final bool showTerminalCursor;
 
@@ -101,6 +106,7 @@ class AppSettings {
     this.zoomFactor = 1.0,
     this.adjustMode = 'autoFit',
     this.directInputEnabled = false,
+    this.cjkMode = false,
     this.showTerminalCursor = true,
     this.invertPaneNavigation = false,
     // inventory: SETTINGS-SCROLL-SEND-002
@@ -145,6 +151,7 @@ class AppSettings {
     double? zoomFactor,
     String? adjustMode,
     bool? directInputEnabled,
+    bool? cjkMode,
     bool? showTerminalCursor,
     bool? invertPaneNavigation,
     // inventory: SETTINGS-SCROLL-SEND-003
@@ -185,6 +192,7 @@ class AppSettings {
       zoomFactor: zoomFactor ?? this.zoomFactor,
       adjustMode: adjustMode ?? this.adjustMode,
       directInputEnabled: directInputEnabled ?? this.directInputEnabled,
+      cjkMode: cjkMode ?? this.cjkMode,
       showTerminalCursor: showTerminalCursor ?? this.showTerminalCursor,
       invertPaneNavigation: invertPaneNavigation ?? this.invertPaneNavigation,
       scrollSendInput: scrollSendInput ?? this.scrollSendInput,
@@ -228,6 +236,7 @@ class SettingsNotifier extends Notifier<AppSettings> {
   static const String _zoomFactorKey = 'settings_zoom_factor';
   static const String _adjustModeKey = 'settings_adjust_mode';
   static const String _directInputEnabledKey = 'settings_direct_input_enabled';
+  static const String _cjkModeKey = 'settings_cjk_mode';
   static const String _showTerminalCursorKey = 'settings_show_terminal_cursor';
   static const String _invertPaneNavKey = 'settings_invert_pane_nav';
   // inventory: SETTINGS-SCROLL-SEND-004
@@ -284,6 +293,7 @@ class SettingsNotifier extends Notifier<AppSettings> {
       zoomFactor: prefs.getDouble(_zoomFactorKey) ?? 1.0,
       adjustMode: prefs.getString(_adjustModeKey) ?? 'autoFit',
       directInputEnabled: prefs.getBool(_directInputEnabledKey) ?? false,
+      cjkMode: prefs.getBool(_cjkModeKey) ?? false,
       showTerminalCursor: prefs.getBool(_showTerminalCursorKey) ?? true,
       invertPaneNavigation: prefs.getBool(_invertPaneNavKey) ?? false,
       // inventory: SETTINGS-SCROLL-SEND-005
@@ -491,6 +501,12 @@ class SettingsNotifier extends Notifier<AppSettings> {
   /// DirectInputモードをトグル
   Future<void> toggleDirectInput() async {
     await setDirectInputEnabled(!state.directInputEnabled);
+  }
+
+  /// CJK Mode（IME確定ごとに送信してクリアする旧来のDirectInput挙動）を設定
+  Future<void> setCjkMode(bool value) async {
+    state = state.copyWith(cjkMode: value);
+    await _saveSetting(_cjkModeKey, value);
   }
 
   /// ターミナルカーソル表示設定を設定

--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -320,7 +320,9 @@ class SettingsScreen extends ConsumerWidget {
                   subtitle: Text(l10n.settingsKeepKeyboardOnEnterDescription),
                   value: settings.keepKeyboardOnEnter,
                   onChanged: (value) {
-                    ref.read(settingsProvider.notifier).setKeepKeyboardOnEnter(value);
+                    ref
+                        .read(settingsProvider.notifier)
+                        .setKeepKeyboardOnEnter(value);
                   },
                 ),
                 // inventory: SETTINGS-UI-INPUT-001

--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -313,6 +313,16 @@ class SettingsScreen extends ConsumerWidget {
                       ref.read(settingsProvider.notifier).setCjkMode(value);
                     },
                   ),
+                // DirectInput: Enter送信後もソフトウェアキーボードを開いたままにする
+                SwitchListTile(
+                  secondary: const Icon(Icons.keyboard),
+                  title: Text(l10n.settingsKeepKeyboardOnEnter),
+                  subtitle: Text(l10n.settingsKeepKeyboardOnEnterDescription),
+                  value: settings.keepKeyboardOnEnter,
+                  onChanged: (value) {
+                    ref.read(settingsProvider.notifier).setKeepKeyboardOnEnter(value);
+                  },
+                ),
                 // inventory: SETTINGS-UI-INPUT-001
                 ListTile(
                   leading: const Icon(Icons.mouse),

--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -301,6 +301,18 @@ class SettingsScreen extends ConsumerWidget {
                         .setInvertPaneNavigation(value);
                   },
                 ),
+                // CJK Mode: iOSのCJK系IMEでDirectInputが多重送信される場合の
+                // 回避手段として旧来（v0.7.0-pre4）の確定送信挙動へ戻す（iOSのみ表示）
+                if (Theme.of(context).platform == TargetPlatform.iOS)
+                  SwitchListTile(
+                    secondary: const Icon(Icons.translate),
+                    title: Text(l10n.settingsCjkMode),
+                    subtitle: Text(l10n.settingsCjkModeDescription),
+                    value: settings.cjkMode,
+                    onChanged: (value) {
+                      ref.read(settingsProvider.notifier).setCjkMode(value);
+                    },
+                  ),
                 // inventory: SETTINGS-UI-INPUT-001
                 ListTile(
                   leading: const Icon(Icons.mouse),

--- a/lib/screens/terminal/terminal_screen.dart
+++ b/lib/screens/terminal/terminal_screen.dart
@@ -3125,6 +3125,11 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
                 Consumer(
                   builder: (context, ref, _) {
                     final customKeys = ref.watch(customKeysProvider);
+                    // cjkMode のみ select 監視: 親 build を再実行させず
+                    // SpecialKeysBar サブツリーだけ再構築する
+                    final cjkMode = ref.watch(
+                      settingsProvider.select((s) => s.cjkMode),
+                    );
                     return SpecialKeysBar(
                       // inventory: TERM-INPUT-006
                       onKeyPressed: _sendKeyWithOverlay,
@@ -3132,6 +3137,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
                       // inventory: TERM-INPUT-009
                       onInputTap: _showInputDialog,
                       directInputEnabled: _directInputEnabled,
+                      cjkMode: cjkMode,
                       onDirectInputToggle: () {
                         ref.read(settingsProvider.notifier).toggleDirectInput();
                       },

--- a/lib/screens/terminal/terminal_screen.dart
+++ b/lib/screens/terminal/terminal_screen.dart
@@ -3125,10 +3125,13 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
                 Consumer(
                   builder: (context, ref, _) {
                     final customKeys = ref.watch(customKeysProvider);
-                    // cjkMode のみ select 監視: 親 build を再実行させず
-                    // SpecialKeysBar サブツリーだけ再構築する
+                    // cjkMode / keepKeyboardOnEnter のみ select 監視: 親 build を
+                    // 再実行させず SpecialKeysBar サブツリーだけ再構築する
                     final cjkMode = ref.watch(
                       settingsProvider.select((s) => s.cjkMode),
+                    );
+                    final keepKeyboardOnEnter = ref.watch(
+                      settingsProvider.select((s) => s.keepKeyboardOnEnter),
                     );
                     return SpecialKeysBar(
                       // inventory: TERM-INPUT-006
@@ -3138,6 +3141,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
                       onInputTap: _showInputDialog,
                       directInputEnabled: _directInputEnabled,
                       cjkMode: cjkMode,
+                      keepKeyboardOnEnter: keepKeyboardOnEnter,
                       onDirectInputToggle: () {
                         ref.read(settingsProvider.notifier).toggleDirectInput();
                       },

--- a/lib/widgets/special_keys_bar.dart
+++ b/lib/widgets/special_keys_bar.dart
@@ -33,6 +33,12 @@ class SpecialKeysBar extends StatefulWidget {
   /// iOSのCJK系IMEで発生する多重送信回避用（設定画面はiOSのみ表示）。
   final bool cjkMode;
 
+  /// DirectInput: Enter送信後もソフトウェアキーボードを開いたままにするか。
+  /// フレームワーク既定では TextInputAction.send 受信時に unfocus されるため、
+  /// 送信後に同期 requestFocus() で unfocus をキャンセルして実現する
+  /// （ソフトキーボード経路のみ）。
+  final bool keepKeyboardOnEnter;
+
   /// 画像転送ボタンが押された時のコールバック
   final VoidCallback? onImagePickRequested;
 
@@ -58,6 +64,7 @@ class SpecialKeysBar extends StatefulWidget {
     this.directInputEnabled = false,
     this.onDirectInputToggle,
     this.cjkMode = false,
+    this.keepKeyboardOnEnter = false,
     this.onImagePickRequested,
     this.customButtons = const [],
     this.onCustomButtonEdit,
@@ -385,6 +392,16 @@ class _SpecialKeysBarState extends State<SpecialKeysBar> {
     }
     widget.onSpecialKeyPressed('Enter');
     _resetToSentinel();
+
+    // 「Enterでキーボードを閉じない」設定:
+    // unfocus() はマイクロタスク適用（focus_manager._markNextFocus）のため、
+    // onSubmitted 内の同期 requestFocus() で実質キャンセルでき、フィールドは
+    // フォーカスを一切失わない。フレームワークはこのパターンを明示サポート
+    // （editable_text.dart L3899-3906: onSubmitted内でフォーカスを戻した場合は
+    // _restartConnectionIfNeeded が接続を張り直してキーボードを開いたままリセット）。
+    if (widget.keepKeyboardOnEnter) {
+      _directInputFocusNode.requestFocus();
+    }
   }
 
   /// DirectInput: Backspaceキー送信

--- a/lib/widgets/special_keys_bar.dart
+++ b/lib/widgets/special_keys_bar.dart
@@ -28,6 +28,11 @@ class SpecialKeysBar extends StatefulWidget {
   /// DirectInputモードのトグルコールバック
   final VoidCallback? onDirectInputToggle;
 
+  /// CJK Mode: IME確定ごとに全文送信して入力欄をクリアする
+  /// 旧来（v0.7.0-pre4）のDirectInput挙動を使うか。
+  /// iOSのCJK系IMEで発生する多重送信回避用（設定画面はiOSのみ表示）。
+  final bool cjkMode;
+
   /// 画像転送ボタンが押された時のコールバック
   final VoidCallback? onImagePickRequested;
 
@@ -52,6 +57,7 @@ class SpecialKeysBar extends StatefulWidget {
     this.hapticFeedback = true,
     this.directInputEnabled = false,
     this.onDirectInputToggle,
+    this.cjkMode = false,
     this.onImagePickRequested,
     this.customButtons = const [],
     this.onCustomButtonEdit,
@@ -121,6 +127,10 @@ class _SpecialKeysBarState extends State<SpecialKeysBar> {
       _directInputController.clear();
       _isResettingController = false;
       _sentText = '';
+    }
+    // CJKモード切替時は入力欄をリセットし、旧モードのdelta状態を残さない
+    if (widget.cjkMode != oldWidget.cjkMode && widget.directInputEnabled) {
+      _resetToSentinel();
     }
     _syncRowControllers(widget.rows.length);
     // 新規トークンが追加された行を、その位置（先頭/末尾）まで自動スクロールする
@@ -241,6 +251,58 @@ class _SpecialKeysBarState extends State<SpecialKeysBar> {
 
     // Sentinelを除去して実際の入力テキストを取得
     final actualText = text.replaceAll(_sentinel, '');
+
+    // CJK Mode（v0.7.0-pre4挙動）: 確定テキストを全文送信してからsentinelへ
+    // リセットする。入力欄にテキストを残さないためiOSの自動補正（".."→"‥"
+    // 等）が働かず、IME確定時の重複挿入もcomposingテキストとの比較で除去される。
+    if (widget.cjkMode) {
+      if (actualText.isEmpty) return;
+
+      // 外付けキーボードの二重入力防止: _handleKeyEventで処理済みならスキップ
+      if (_isRecentKeyEventHandled()) {
+        _lastComposingText = null;
+        _resetToSentinel();
+        return;
+      }
+
+      // iOS重複検出: 確定テキストがcomposingテキストより長く、
+      // composingテキストで始まる場合、iOSの重複挿入とみなしcomposingテキストを使用
+      String textToSend = actualText;
+      if (_lastComposingText != null &&
+          actualText.length > _lastComposingText!.length &&
+          actualText.startsWith(_lastComposingText!)) {
+        textToSend = _lastComposingText!;
+      }
+      _lastComposingText = null;
+
+      // Send modifier+key when CTRL/ALT is active (non-composing path)
+      // This handles IMEs that commit without composing (e.g. Gboard English)
+      // tmux format: C-c (Ctrl+C), M-a (Alt+A), C-M-x (Ctrl+Alt+X)
+      if ((_ctrlPressed || _altPressed) &&
+          textToSend.length == 1 &&
+          RegExp(r'^[A-Za-z]$').hasMatch(textToSend)) {
+        if (widget.hapticFeedback) {
+          HapticFeedback.lightImpact();
+        }
+        final List<String> modifiers = [];
+        if (_ctrlPressed) {
+          modifiers.add('C');
+          setState(() => _ctrlPressed = false);
+        }
+        if (_altPressed) {
+          modifiers.add('M');
+          setState(() => _altPressed = false);
+        }
+        final prefix = modifiers.join('-');
+        widget.onSpecialKeyPressed('$prefix-${textToSend.toLowerCase()}');
+      } else {
+        widget.onKeyPressed(textToSend);
+      }
+
+      // 送信後にsentinelにリセット
+      _resetToSentinel();
+      return;
+    }
 
     // 外付けキーボードの二重入力防止: _handleKeyEventで処理済みならスキップ
     if (_isRecentKeyEventHandled()) {

--- a/lib/widgets/special_keys_bar.dart
+++ b/lib/widgets/special_keys_bar.dart
@@ -1052,6 +1052,16 @@ class _SpecialKeysBarState extends State<SpecialKeysBar> {
                 focusNode: _directInputFocusNode,
                 autofocus: true,
                 textInputAction: TextInputAction.send,
+                // ターミナルへのパススルー入力のため、OSによるテキスト書き換えを
+                // 無効化する（iOS自動補正の ".."→"‥" 置換、Smart Dashes /
+                // Smart Quotes、スペルチェックによる確定も防止）。
+                // ※ enableSuggestions: false は設定しないこと:
+                //   Androidエンジン（TextInputPlugin.inputTypeFromTextInputType）が
+                //   inputType に TYPE_TEXT_VARIATION_VISIBLE_PASSWORD を付加し、
+                //   IME変換（日本語入力）が不可能になるため。
+                autocorrect: false,
+                smartDashesType: SmartDashesType.disabled,
+                smartQuotesType: SmartQuotesType.disabled,
                 onSubmitted: _onDirectInputSubmitted,
                 style: GoogleFonts.jetBrainsMono(
                   fontSize: 14,

--- a/test/providers/settings_provider_test.dart
+++ b/test/providers/settings_provider_test.dart
@@ -308,23 +308,24 @@ void main() {
       expect(prefs.containsKey('settings_keep_keyboard_on_enter'), isFalse);
     });
 
-    test('setKeepKeyboardOnEnter で state が更新され SharedPreferences に保存される',
-        () async {
-      final container = ProviderContainer();
-      addTearDown(container.dispose);
+    test(
+      'setKeepKeyboardOnEnter で state が更新され SharedPreferences に保存される',
+      () async {
+        final container = ProviderContainer();
+        addTearDown(container.dispose);
 
-      await container.read(settingsProvider.notifier).reload();
-      await container
-          .read(settingsProvider.notifier)
-          .setKeepKeyboardOnEnter(true);
+        await container.read(settingsProvider.notifier).reload();
+        await container
+            .read(settingsProvider.notifier)
+            .setKeepKeyboardOnEnter(true);
 
-      expect(container.read(settingsProvider).keepKeyboardOnEnter, isTrue);
-      final prefs = await SharedPreferences.getInstance();
-      expect(prefs.getBool('settings_keep_keyboard_on_enter'), isTrue);
-    });
+        expect(container.read(settingsProvider).keepKeyboardOnEnter, isTrue);
+        final prefs = await SharedPreferences.getInstance();
+        expect(prefs.getBool('settings_keep_keyboard_on_enter'), isTrue);
+      },
+    );
 
-    test('保存した keepKeyboardOnEnter は新規コンテナ（再起動相当）の再読込で復元される',
-        () async {
+    test('保存した keepKeyboardOnEnter は新規コンテナ（再起動相当）の再読込で復元される', () async {
       final container = ProviderContainer();
       addTearDown(container.dispose);
       await container.read(settingsProvider.notifier).reload();

--- a/test/providers/settings_provider_test.dart
+++ b/test/providers/settings_provider_test.dart
@@ -295,4 +295,58 @@ void main() {
       expect(toggled.cjkMode, isFalse);
     });
   });
+
+  group('SettingsNotifier keepKeyboardOnEnter 永続化', () {
+    test('未保存時はデフォルト false になる', () async {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      await container.read(settingsProvider.notifier).reload();
+
+      expect(container.read(settingsProvider).keepKeyboardOnEnter, isFalse);
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.containsKey('settings_keep_keyboard_on_enter'), isFalse);
+    });
+
+    test('setKeepKeyboardOnEnter で state が更新され SharedPreferences に保存される',
+        () async {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      await container.read(settingsProvider.notifier).reload();
+      await container
+          .read(settingsProvider.notifier)
+          .setKeepKeyboardOnEnter(true);
+
+      expect(container.read(settingsProvider).keepKeyboardOnEnter, isTrue);
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getBool('settings_keep_keyboard_on_enter'), isTrue);
+    });
+
+    test('保存した keepKeyboardOnEnter は新規コンテナ（再起動相当）の再読込で復元される',
+        () async {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      await container.read(settingsProvider.notifier).reload();
+      await container
+          .read(settingsProvider.notifier)
+          .setKeepKeyboardOnEnter(true);
+
+      final restarted = ProviderContainer();
+      addTearDown(restarted.dispose);
+      await restarted.read(settingsProvider.notifier).reload();
+
+      expect(restarted.read(settingsProvider).keepKeyboardOnEnter, isTrue);
+    });
+
+    test('copyWith は keepKeyboardOnEnter を指定しない場合他の設定のみ変更する', () {
+      const base = AppSettings(keepKeyboardOnEnter: true);
+      final updated = base.copyWith(keepScreenOn: false);
+      expect(updated.keepKeyboardOnEnter, isTrue);
+      expect(updated.keepScreenOn, isFalse);
+
+      final toggled = base.copyWith(keepKeyboardOnEnter: false);
+      expect(toggled.keepKeyboardOnEnter, isFalse);
+    });
+  });
 }

--- a/test/providers/settings_provider_test.dart
+++ b/test/providers/settings_provider_test.dart
@@ -247,4 +247,52 @@ void main() {
       expect(container.read(settingsProvider).language, 'ja');
     });
   });
+
+  group('SettingsNotifier cjkMode 永続化', () {
+    test('未保存時はデフォルト false になる', () async {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      await container.read(settingsProvider.notifier).reload();
+
+      expect(container.read(settingsProvider).cjkMode, isFalse);
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.containsKey('settings_cjk_mode'), isFalse);
+    });
+
+    test('setCjkMode で state が更新され SharedPreferences に保存される', () async {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      await container.read(settingsProvider.notifier).reload();
+      await container.read(settingsProvider.notifier).setCjkMode(true);
+
+      expect(container.read(settingsProvider).cjkMode, isTrue);
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getBool('settings_cjk_mode'), isTrue);
+    });
+
+    test('保存した cjkMode は新規コンテナ（再起動相当）の再読込で復元される', () async {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      await container.read(settingsProvider.notifier).reload();
+      await container.read(settingsProvider.notifier).setCjkMode(true);
+
+      final restarted = ProviderContainer();
+      addTearDown(restarted.dispose);
+      await restarted.read(settingsProvider.notifier).reload();
+
+      expect(restarted.read(settingsProvider).cjkMode, isTrue);
+    });
+
+    test('copyWith は cjkMode を指定しない場合他の設定のみ変更する', () {
+      const base = AppSettings(cjkMode: true);
+      final updated = base.copyWith(keepScreenOn: false);
+      expect(updated.cjkMode, isTrue);
+      expect(updated.keepScreenOn, isFalse);
+
+      final toggled = base.copyWith(cjkMode: false);
+      expect(toggled.cjkMode, isFalse);
+    });
+  });
 }

--- a/test/screens/settings_screen_test.dart
+++ b/test/screens/settings_screen_test.dart
@@ -241,6 +241,12 @@ void main() {
       );
       expect(tester.widget<SwitchListTile>(tile).value, isFalse);
 
+      // タップ中心が画面内に収まるよう完全に画面内へスクロール
+      // （上流のBehaviorセクションにタイルが追加されると下段が押し下げられ、
+      //   scrollUntilFound 後のタイル中心が画面外になり得るため）
+      await tester.ensureVisible(tile);
+      await tester.pumpAndSettle();
+
       await tester.tap(tile);
       await tester.pumpAndSettle();
 
@@ -326,6 +332,62 @@ void main() {
       expect(tester.widget<SwitchListTile>(tile).value, isTrue);
       final prefs = await SharedPreferences.getInstance();
       expect(prefs.getBool('settings_cjk_mode'), isTrue);
+    });
+
+    testWidgets('Keep Keyboard on Enter toggle is shown and interactive (Android)',
+        (tester) async {
+      // setter が _saveSetting で SharedPreferences へ書き込むためモックする
+      SharedPreferences.setMockInitialValues({});
+      await tester.pumpWidget(_buildApp());
+      await tester.pumpAndSettle();
+
+      // 全プラットフォーム表示（ソフトキーボードはiOS/Android双方にある問題）
+      await scrollUntilFound(tester, find.text('Keep Keyboard Open on Enter'));
+      final tile = find.ancestor(
+        of: find.text('Keep Keyboard Open on Enter'),
+        matching: find.byType(SwitchListTile),
+      );
+      expect(tile, findsOneWidget);
+      // デフォルトは OFF
+      expect(tester.widget<SwitchListTile>(tile).value, isFalse);
+
+      // タップ中心が画面内に収まるよう完全に画面内へスクロール
+      await tester.ensureVisible(tile);
+      await tester.pumpAndSettle();
+
+      await tester.tap(tile);
+      await tester.pumpAndSettle();
+
+      expect(tester.widget<SwitchListTile>(tile).value, isTrue);
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getBool('settings_keep_keyboard_on_enter'), isTrue);
+    });
+
+    testWidgets('Keep Keyboard on Enter toggle is shown and interactive (iOS)', (
+      tester,
+    ) async {
+      // setter が _saveSetting で SharedPreferences へ書き込むためモックする
+      SharedPreferences.setMockInitialValues({});
+      await tester.pumpWidget(_buildApp(platform: TargetPlatform.iOS));
+      await tester.pumpAndSettle();
+
+      await scrollUntilFound(tester, find.text('Keep Keyboard Open on Enter'));
+      final tile = find.ancestor(
+        of: find.text('Keep Keyboard Open on Enter'),
+        matching: find.byType(SwitchListTile),
+      );
+      expect(tile, findsOneWidget);
+      expect(tester.widget<SwitchListTile>(tile).value, isFalse);
+
+      await tester.ensureVisible(tile);
+      await tester.pumpAndSettle();
+
+      await tester.tap(tile);
+      await tester.pumpAndSettle();
+
+      expect(tester.widget<SwitchListTile>(tile).value, isTrue);
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getBool('settings_keep_keyboard_on_enter'), isTrue);
     });
 
     testWidgets(

--- a/test/screens/settings_screen_test.dart
+++ b/test/screens/settings_screen_test.dart
@@ -334,61 +334,70 @@ void main() {
       expect(prefs.getBool('settings_cjk_mode'), isTrue);
     });
 
-    testWidgets('Keep Keyboard on Enter toggle is shown and interactive (Android)',
-        (tester) async {
-      // setter が _saveSetting で SharedPreferences へ書き込むためモックする
-      SharedPreferences.setMockInitialValues({});
-      await tester.pumpWidget(_buildApp());
-      await tester.pumpAndSettle();
+    testWidgets(
+      'Keep Keyboard on Enter toggle is shown and interactive (Android)',
+      (tester) async {
+        // setter が _saveSetting で SharedPreferences へ書き込むためモックする
+        SharedPreferences.setMockInitialValues({});
+        await tester.pumpWidget(_buildApp());
+        await tester.pumpAndSettle();
 
-      // 全プラットフォーム表示（ソフトキーボードはiOS/Android双方にある問題）
-      await scrollUntilFound(tester, find.text('Keep Keyboard Open on Enter'));
-      final tile = find.ancestor(
-        of: find.text('Keep Keyboard Open on Enter'),
-        matching: find.byType(SwitchListTile),
-      );
-      expect(tile, findsOneWidget);
-      // デフォルトは OFF
-      expect(tester.widget<SwitchListTile>(tile).value, isFalse);
+        // 全プラットフォーム表示（ソフトキーボードはiOS/Android双方にある問題）
+        await scrollUntilFound(
+          tester,
+          find.text('Keep Keyboard Open on Enter'),
+        );
+        final tile = find.ancestor(
+          of: find.text('Keep Keyboard Open on Enter'),
+          matching: find.byType(SwitchListTile),
+        );
+        expect(tile, findsOneWidget);
+        // デフォルトは OFF
+        expect(tester.widget<SwitchListTile>(tile).value, isFalse);
 
-      // タップ中心が画面内に収まるよう完全に画面内へスクロール
-      await tester.ensureVisible(tile);
-      await tester.pumpAndSettle();
+        // タップ中心が画面内に収まるよう完全に画面内へスクロール
+        await tester.ensureVisible(tile);
+        await tester.pumpAndSettle();
 
-      await tester.tap(tile);
-      await tester.pumpAndSettle();
+        await tester.tap(tile);
+        await tester.pumpAndSettle();
 
-      expect(tester.widget<SwitchListTile>(tile).value, isTrue);
-      final prefs = await SharedPreferences.getInstance();
-      expect(prefs.getBool('settings_keep_keyboard_on_enter'), isTrue);
-    });
+        expect(tester.widget<SwitchListTile>(tile).value, isTrue);
+        final prefs = await SharedPreferences.getInstance();
+        expect(prefs.getBool('settings_keep_keyboard_on_enter'), isTrue);
+      },
+    );
 
-    testWidgets('Keep Keyboard on Enter toggle is shown and interactive (iOS)', (
-      tester,
-    ) async {
-      // setter が _saveSetting で SharedPreferences へ書き込むためモックする
-      SharedPreferences.setMockInitialValues({});
-      await tester.pumpWidget(_buildApp(platform: TargetPlatform.iOS));
-      await tester.pumpAndSettle();
+    testWidgets(
+      'Keep Keyboard on Enter toggle is shown and interactive (iOS)',
+      (tester) async {
+        // setter が _saveSetting で SharedPreferences へ書き込むためモックする
+        SharedPreferences.setMockInitialValues({});
+        await tester.pumpWidget(_buildApp(platform: TargetPlatform.iOS));
+        await tester.pumpAndSettle();
 
-      await scrollUntilFound(tester, find.text('Keep Keyboard Open on Enter'));
-      final tile = find.ancestor(
-        of: find.text('Keep Keyboard Open on Enter'),
-        matching: find.byType(SwitchListTile),
-      );
-      expect(tile, findsOneWidget);
-      expect(tester.widget<SwitchListTile>(tile).value, isFalse);
+        await scrollUntilFound(
+          tester,
+          find.text('Keep Keyboard Open on Enter'),
+        );
+        final tile = find.ancestor(
+          of: find.text('Keep Keyboard Open on Enter'),
+          matching: find.byType(SwitchListTile),
+        );
+        expect(tile, findsOneWidget);
+        expect(tester.widget<SwitchListTile>(tile).value, isFalse);
 
-      await tester.ensureVisible(tile);
-      await tester.pumpAndSettle();
+        await tester.ensureVisible(tile);
+        await tester.pumpAndSettle();
 
-      await tester.tap(tile);
-      await tester.pumpAndSettle();
+        await tester.tap(tile);
+        await tester.pumpAndSettle();
 
-      expect(tester.widget<SwitchListTile>(tile).value, isTrue);
-      final prefs = await SharedPreferences.getInstance();
-      expect(prefs.getBool('settings_keep_keyboard_on_enter'), isTrue);
-    });
+        expect(tester.widget<SwitchListTile>(tile).value, isTrue);
+        final prefs = await SharedPreferences.getInstance();
+        expect(prefs.getBool('settings_keep_keyboard_on_enter'), isTrue);
+      },
+    );
 
     testWidgets(
       'Clear SSH Host Keys clears stored fingerprints after confirm',

--- a/test/screens/settings_screen_test.dart
+++ b/test/screens/settings_screen_test.dart
@@ -7,12 +7,14 @@ import 'package:flutter_muxpod/screens/settings/settings_screen.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:flutter_muxpod/services/keychain/secure_storage.dart';
 
-Widget _buildApp() {
-  return const ProviderScope(
+Widget _buildApp({TargetPlatform? platform}) {
+  return ProviderScope(
     child: MaterialApp(
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
-      home: SettingsScreen(),
+      // CJK ModeトグルのiOS限定表示を検証するためプラットフォームを上書きできる
+      theme: platform == null ? null : ThemeData(platform: platform),
+      home: const SettingsScreen(),
     ),
   );
 }
@@ -287,6 +289,43 @@ void main() {
       expect(find.text('System'), findsOneWidget);
       expect(find.text('日本語'), findsOneWidget);
       expect(find.text('English'), findsOneWidget);
+    });
+
+    testWidgets('CJK Mode toggle is hidden on non-iOS platforms', (
+      tester,
+    ) async {
+      SharedPreferences.setMockInitialValues({});
+      await tester.pumpWidget(_buildApp(platform: TargetPlatform.android));
+      await tester.pumpAndSettle();
+
+      expect(find.text('CJK Mode'), findsNothing);
+    });
+
+    testWidgets('CJK Mode toggle is shown and interactive on iOS', (
+      tester,
+    ) async {
+      // setter が _saveSetting で SharedPreferences へ書き込むためモックする
+      SharedPreferences.setMockInitialValues({});
+      await tester.pumpWidget(_buildApp(platform: TargetPlatform.iOS));
+      await tester.pumpAndSettle();
+
+      await scrollUntilFound(tester, find.text('CJK Mode'));
+      final tile = find.ancestor(
+        of: find.text('CJK Mode'),
+        matching: find.byType(SwitchListTile),
+      );
+      expect(tester.widget<SwitchListTile>(tile).value, isFalse);
+
+      // タップ中心が画面内に収まるよう完全に画面内へスクロール
+      await tester.ensureVisible(tile);
+      await tester.pumpAndSettle();
+
+      await tester.tap(tile);
+      await tester.pumpAndSettle();
+
+      expect(tester.widget<SwitchListTile>(tile).value, isTrue);
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getBool('settings_cjk_mode'), isTrue);
     });
 
     testWidgets(

--- a/test/widgets/special_keys_bar_test.dart
+++ b/test/widgets/special_keys_bar_test.dart
@@ -92,6 +92,7 @@ void main() {
 
   Widget customHarness({
     bool directInput = false,
+    bool cjkMode = false,
     double width = 720,
     List<CustomKeyButton> customButtons = const [],
     List<String> row0Tokens = const <String>[],
@@ -119,6 +120,7 @@ void main() {
               onImagePickRequested: onImagePickRequested,
               onDirectInputToggle: () {},
               directInputEnabled: directInput,
+              cjkMode: cjkMode,
               hapticFeedback: false,
               customButtons: customButtons,
               rows:
@@ -689,6 +691,90 @@ void main() {
       // TYPE_TEXT_VARIATION_VISIBLE_PASSWORD を付加し、IME変換（日本語入力）が
       // 不可能になるため（autocorrect=false と併用しない）。
       expect(field.enableSuggestions, isTrue);
+    });
+  });
+
+  group('SpecialKeysBar CJK mode (v0.7.0-pre4 behavior)', () {
+    Finder directInputField() => find.byType(TextField);
+
+    String visibleText(WidgetTester tester) {
+      final field = tester.widget<TextField>(directInputField());
+      return field.controller!.text.replaceAll('\u200B', '');
+    }
+
+    testWidgets('committed text is sent in full and the field clears', (
+      tester,
+    ) async {
+      final keys = <String>[];
+      await tester.pumpWidget(
+        customHarness(directInput: true, cjkMode: true, onKeyPressed: keys.add),
+      );
+      await tester.pump();
+
+      await tester.enterText(directInputField(), 'こんにちは');
+      await tester.pump();
+
+      // pre4挙動: 確定テキストを全文送信し、入力欄はsentinelへクリアされる
+      expect(keys, ['こんにちは']);
+      expect(visibleText(tester), isEmpty);
+
+      // 追加入力も毎回全文送信される（テキストは欄に残らない）
+      await tester.enterText(directInputField(), 'abc');
+      await tester.pump();
+      expect(keys, ['こんにちは', 'abc']);
+      expect(visibleText(tester), isEmpty);
+    });
+
+    testWidgets('iOS duplicate insertion is trimmed to composing text', (
+      tester,
+    ) async {
+      final keys = <String>[];
+      await tester.pumpWidget(
+        customHarness(directInput: true, cjkMode: true, onKeyPressed: keys.add),
+      );
+      await tester.pump();
+
+      // IME変換中（composing範囲付き）の更新: 送信しない
+      final field = tester.widget<TextField>(directInputField());
+      final controller = field.controller!;
+      controller.value = const TextEditingValue(
+        text: '\u200Bこんにちは',
+        composing: TextRange(start: 1, end: 6),
+      );
+      await tester.pump();
+      expect(keys, isEmpty);
+
+      // iOSの自動確定バグ: composingテキストの重複挿入として確定される
+      controller.value = const TextEditingValue(
+        text: '\u200Bこんにちはこんにちは',
+        selection: TextSelection.collapsed(offset: 11),
+      );
+      await tester.pump();
+
+      // 重複分は除去され、composingテキストのみ一度だけ送信される
+      expect(keys, ['こんにちは']);
+    });
+
+    testWidgets('toggling CJK mode resets the field to sentinel', (
+      tester,
+    ) async {
+      final keys = <String>[];
+      await tester.pumpWidget(
+        customHarness(directInput: true, onKeyPressed: keys.add),
+      );
+      await tester.pump();
+
+      // 通常モード（delta送信）でテキストを残す
+      await tester.enterText(directInputField(), 'ls');
+      await tester.pump();
+      expect(visibleText(tester), 'ls');
+
+      // CJKモードへ切替: 残ったテキストはクリアされる
+      await tester.pumpWidget(
+        customHarness(directInput: true, cjkMode: true, onKeyPressed: keys.add),
+      );
+      await tester.pump();
+      expect(visibleText(tester), isEmpty);
     });
   });
 

--- a/test/widgets/special_keys_bar_test.dart
+++ b/test/widgets/special_keys_bar_test.dart
@@ -670,6 +670,26 @@ void main() {
       expect(specials, contains('Enter'));
       expect(visibleText(tester), isEmpty);
     });
+
+    testWidgets('field disables autocorrect and smart punctuation', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        customHarness(directInput: true, onKeyPressed: (_) {}),
+      );
+      await tester.pump();
+
+      // パススルー入力欄のため、OSによるテキスト書き換え（".."→"‥" 等）を
+      // 許可しない（Issue: iOS自動補正による入力破壊）。
+      final field = tester.widget<TextField>(directInputField());
+      expect(field.autocorrect, isFalse);
+      expect(field.smartDashesType, SmartDashesType.disabled);
+      expect(field.smartQuotesType, SmartQuotesType.disabled);
+      // enableSuggestions は無効化しない: Androidエンジンが inputType へ
+      // TYPE_TEXT_VARIATION_VISIBLE_PASSWORD を付加し、IME変換（日本語入力）が
+      // 不可能になるため（autocorrect=false と併用しない）。
+      expect(field.enableSuggestions, isTrue);
+    });
   });
 
   group('SpecialKeysBar row auto-scroll', () {

--- a/test/widgets/special_keys_bar_test.dart
+++ b/test/widgets/special_keys_bar_test.dart
@@ -93,6 +93,7 @@ void main() {
   Widget customHarness({
     bool directInput = false,
     bool cjkMode = false,
+    bool keepKeyboardOnEnter = false,
     double width = 720,
     List<CustomKeyButton> customButtons = const [],
     List<String> row0Tokens = const <String>[],
@@ -121,6 +122,7 @@ void main() {
               onDirectInputToggle: () {},
               directInputEnabled: directInput,
               cjkMode: cjkMode,
+              keepKeyboardOnEnter: keepKeyboardOnEnter,
               hapticFeedback: false,
               customButtons: customButtons,
               rows:
@@ -673,6 +675,56 @@ void main() {
       expect(visibleText(tester), isEmpty);
     });
 
+    testWidgets('keepKeyboardOnEnter keeps focus after submit', (tester) async {
+      final specials = <String>[];
+      await tester.pumpWidget(
+        customHarness(
+          directInput: true,
+          keepKeyboardOnEnter: true,
+          onSpecialKeyPressed: specials.add,
+        ),
+      );
+      await tester.pump();
+
+      await tester.enterText(directInputField(), 'models');
+      await tester.pump();
+
+      await tester.testTextInput.receiveAction(TextInputAction.send);
+      // 同期 requestFocus() で unfocus をキャンセルする（フレームワークの
+      // 明示サポート経路: editable_text._restartConnectionIfNeeded）。
+      // pump 1回でマイクロタスクまで消化し、settle で post-frame の
+      // sentinel 再リセットも完了させる。
+      await tester.pump();
+      await tester.pumpAndSettle();
+
+      expect(specials, contains('Enter'));
+      expect(visibleText(tester), isEmpty);
+      // 送信後もフィールドはフォーカスを失わない（キーボード維持）
+      expect(
+        tester.widget<TextField>(directInputField()).focusNode!.hasFocus,
+        isTrue,
+      );
+    });
+
+    testWidgets('default (off) unfocuses after submit (regression guard)', (
+      tester,
+    ) async {
+      await tester.pumpWidget(customHarness(directInput: true));
+      await tester.pump();
+
+      await tester.enterText(directInputField(), 'models');
+      await tester.pump();
+
+      await tester.testTextInput.receiveAction(TextInputAction.send);
+      await tester.pump();
+
+      // 設定OFF（デフォルト）: 既存挙動どおりフォーカスは外れる
+      expect(
+        tester.widget<TextField>(directInputField()).focusNode!.hasFocus,
+        isFalse,
+      );
+    });
+
     testWidgets('field disables autocorrect and smart punctuation', (
       tester,
     ) async {
@@ -775,6 +827,41 @@ void main() {
       );
       await tester.pump();
       expect(visibleText(tester), isEmpty);
+    });
+
+    testWidgets('CJK mode + keepKeyboardOnEnter keeps focus after submit', (
+      tester,
+    ) async {
+      final keys = <String>[];
+      final specials = <String>[];
+      await tester.pumpWidget(
+        customHarness(
+          directInput: true,
+          cjkMode: true,
+          keepKeyboardOnEnter: true,
+          onKeyPressed: keys.add,
+          onSpecialKeyPressed: specials.add,
+        ),
+      );
+      await tester.pump();
+
+      await tester.enterText(directInputField(), 'models');
+      await tester.pump();
+      // CJKモード: 入力確定で全文送信済み・欄はクリア済み
+      expect(keys, ['models']);
+      expect(visibleText(tester), isEmpty);
+
+      await tester.testTextInput.receiveAction(TextInputAction.send);
+      await tester.pump();
+      await tester.pumpAndSettle();
+
+      // 'Enter' が1回だけ送信され、フィールドはクリア・フォーカス維持
+      expect(specials.where((k) => k == 'Enter').length, 1);
+      expect(visibleText(tester), isEmpty);
+      expect(
+        tester.widget<TextField>(directInputField()).focusNode!.hasFocus,
+        isTrue,
+      );
     });
   });
 


### PR DESCRIPTION
## Summary
- Stop iOS autocorrect from rewriting DirectInput text: the field is a passthrough to the remote terminal, so autocorrect, smart dashes, and smart quotes are now disabled (prevents ".." being replaced with the "..." ligature, which desynchronized delta sync)
- Add an iOS-only **CJK Mode** toggle (Settings > Behavior) that switches DirectInput to commit-and-clear behavior, avoiding duplicate sends when iOS CJK IMEs commit text
- Add a **Keep Keyboard Open on Enter** toggle (Settings > Behavior, all platforms, default off) that re-focuses the DirectInput field after submit so the software keyboard no longer closes on every Enter

## Changes
- `lib/widgets/special_keys_bar.dart`: disable OS text rewriting on the DirectInput field (enableSuggestions stays on — the Android engine derives `TYPE_TEXT_VARIATION_VISIBLE_PASSWORD` from it, which would break Japanese IME conversion); add CJK Mode commit-and-clear handling with iOS duplicate-insertion trimming; re-focus the field synchronously in `onSubmitted` when the keep-open setting is enabled (cancels the pending unfocus from `TextInputAction.send`; the hardware keyboard path is unaffected and `textInputAction` is unchanged)
- `lib/providers/settings_provider.dart`: new `cjkMode` and `keepKeyboardOnEnter` settings with SharedPreferences persistence (`settings_cjk_mode`, `settings_keep_keyboard_on_enter`)
- `lib/screens/settings/settings_screen.dart`: CJK Mode toggle (iOS only) and Keep Keyboard Open toggle in the Behavior section
- `lib/screens/terminal/terminal_screen.dart`: pass both settings to `SpecialKeysBar` via `select` watches inside the existing Consumer (no parent rebuilds)
- `lib/l10n/app_en.arb`, `lib/l10n/app_ja.arb`: localized strings for both toggles
- Tests: field configuration regression guard, CJK Mode commit/clear + duplicate-trim + mode-switch reset, focus retention (enabled/disabled, CJK combination), setting persistence/reload/copyWith, toggle platform visibility and interaction (Android and iOS)

## Test plan
- [x] `flutter analyze` passes with no issues
- [x] `flutter test` — full suite passes (1444 tests; 3 environment-dependent repro tests excluded, they also fail on a clean HEAD)
- [x] Installed on Android emulator (192.168.10.184) and iPad (iPad Air 11-inch M3); confirmed by the user:
  - Android: Japanese IME conversion works, `...` no longer rewritten to `‥`
  - iOS: `...` enters literally; CJK Mode toggle visible in Settings > Behavior; duplicate IME sends resolved with CJK Mode on
  - Keep Keyboard Open on Enter: toggle visible on both Android and iPad; with the setting on, Enter sends to the terminal and the software keyboard stays open; with it off, the keyboard closes as before