### PR TITLE
fix: render terminal row background from endStyle with opaque spans

### DIFF
--- a/lib/services/terminal/ansi_parser.dart
+++ b/lib/services/terminal/ansi_parser.dart
@@ -398,6 +398,15 @@ class AnsiParser {
   }
 
   /// 1セグメントを描画スタイル適用済みのTextSpanに変換
+  ///
+  /// 背景色は opaque（不透明）で常時設定する（HYP-4 opaque 化）。これは
+  /// 「途中にデフォルト区間を持ち、かつ行末まで色が埋まって末尾リセットが無い」
+  /// 行（endStyle=色 → 全幅レイヤー有色）で、途中デフォルト span が透明のまま
+  /// 下層の色を透かすのを防ぐ保険。デフォルト背景 span は
+  /// defaultBackground（= 親コンテナ背景と同一）を不透明塗りするため、
+  /// 通常描画の見た目は変わらない。inverse・実色背景も従来どおり塗られる。
+  /// [resolvePaintColors] の paintBackground 判定は行背景レイヤー
+  /// （[effectiveLineBackgroundColor]）用に維持する。
   TextSpan _segmentToTextSpan(
     AnsiSegment segment, {
     required double fontSize,
@@ -427,7 +436,7 @@ class AnsiParser {
         fontFamily,
         fontSize: fontSize,
         color: fg,
-        backgroundColor: paintBackground ? bg : null,
+        backgroundColor: bg,
         fontWeight: style.bold ? FontWeight.bold : FontWeight.normal,
         fontStyle: style.italic ? FontStyle.italic : FontStyle.normal,
         decoration: TextDecoration.combine([
@@ -517,9 +526,10 @@ class AnsiParser {
 
   /// セグメント/行スタイルから描画用の前景色・背景色と「背景を描くか」を決定する。
   ///
-  /// inverse 時は前背景を入れ替え、`inverse || 背景≠default` のときのみ背景を
-  /// 描画する。[_segmentToTextSpan]（セグメント描画）と
-  /// [effectiveLineBackgroundColor]（行背景レイヤー）の単一ソース（R3）。
+  /// inverse 時は前背景を入れ替える。`paintBackground`（`inverse || 背景≠default`）
+  /// は行背景レイヤー（[effectiveLineBackgroundColor]）の要否判定に使う単一ソース
+  /// （R3）であり、[_segmentToTextSpan] 側は opaque 化により背景色を常時設定する
+  /// （HYP-4 opaque）。
   ({Color foreground, Color background, bool paintBackground})
   resolvePaintColors(AnsiStyle style) {
     var fg = style.foreground ?? defaultForeground;
@@ -538,17 +548,39 @@ class AnsiParser {
 
   /// 行全体の有効背景色（行末まで延長・空行背景用）を返す。
   ///
-  /// 行末の空白セルは最終セグメントと同じスタイルを持つため、最終セグメント
-  /// （空行は [ParsedLine.endStyle]）から inverse 適用後の有効背景色を導出する。
+  /// tmux capture-pane は「デフォルト背景の末尾空セル」を出力せず、行が有色で
+  /// 終わる場合に合成 `\x1b[49m` を付加する（skeptic ライブ実験・EV-LOG-006）。
+  /// したがって行末セルの真のスタイルは「行内最後の SGR 適用後」= [ParsedLine.endStyle]
+  /// であり、非空行も endStyle から導出する（旧「最終セグメントと同じ」前提は FALSE）。
+  ///
+  /// 例外: 最終セグメントが**背景付きで空白で終わる**行（例: アプリが明示的に書いた
+  /// 色付きスペース列 EV-LOG-006 型）は、その空白が実在の色付きセルであり、実機の
+  /// Flutter は span 末尾の空白背景を描画しない（EV-LOG-003 before: blue x=8..158 で
+  /// 終端）ため、最終セグメント色で全幅レイヤーを残す（PR#98 の「行末まで色埋め」を
+  /// 回帰させない）。末尾空白でない最終セグメントの行（S1/S3/S4）は余白=endStyle。
+  ///
   /// デフォルト背景と等しい場合は null（背景レイヤー不要）を返す。
   Color? effectiveLineBackgroundColor(ParsedLine line) {
-    final style = line.segments.isEmpty
-        ? line.endStyle
-        : line.segments.last.style;
-    final (:foreground, :background, :paintBackground) = resolvePaintColors(
-      style,
-    );
-    return paintBackground ? background : null;
+    if (line.segments.isNotEmpty) {
+      final last = line.segments.last;
+      final lastResolved = resolvePaintColors(last.style);
+      // 最終セグメントが背景付き＆末尾空白 → 実色スペース列（EV-LOG-006 型）を最優先
+      if (lastResolved.paintBackground && _endsWithWhitespace(last.text)) {
+        return lastResolved.background;
+      }
+    }
+    final endResolved = resolvePaintColors(line.endStyle);
+    return endResolved.paintBackground ? endResolved.background : null;
+  }
+
+  /// テキストが空白文字で終わるか（全角空白・タブも含む）。
+  static bool _endsWithWhitespace(String text) {
+    if (text.isEmpty) return false;
+    final lastRun = text.codeUnits.last;
+    return lastRun == 0x20 ||
+        lastRun == 0x09 ||
+        lastRun == 0x00A0 ||
+        lastRun == 0x3000;
   }
 
   /// ParsedLineをTextSpanに変換

--- a/test/screens/terminal/ansi_text_view_bg_test.dart
+++ b/test/screens/terminal/ansi_text_view_bg_test.dart
@@ -170,9 +170,7 @@ void main() {
 
   testWidgets('S3型: 複数色＋末尾リセットはレイヤー無し・セル単位は span が担当', (tester) async {
     // W3: レイヤー無し、RED/GREEN は各セグメント span の backgroundColor で描画
-    await tester.pumpWidget(
-      buildSubject('\x1b[41mRED\x1b[42mGREEN\x1b[49m'),
-    );
+    await tester.pumpWidget(buildSubject('\x1b[41mRED\x1b[42mGREEN\x1b[49m'));
     await tester.pumpAndSettle();
 
     expect(countColoredBoxes(tester, redBackground), 0);
@@ -219,9 +217,7 @@ void main() {
 
   testWidgets('EV-LOG-006型: 実色スペース行には背景レイヤーが残る', (tester) async {
     // W7: 実スペース100個の行（PR#98 の行末色埋め機能維持の回帰防止）
-    await tester.pumpWidget(
-      buildSubject('\x1b[42mtext${' ' * 100}\x1b[0m'),
-    );
+    await tester.pumpWidget(buildSubject('\x1b[42mtext${' ' * 100}\x1b[0m'));
     await tester.pumpAndSettle();
 
     expect(countColoredBoxes(tester, greenBackground), greaterThanOrEqualTo(1));

--- a/test/screens/terminal/ansi_text_view_bg_test.dart
+++ b/test/screens/terminal/ansi_text_view_bg_test.dart
@@ -29,6 +29,10 @@ void main() {
 
   // ANSI 緑背景 (42) = standardColors[2]
   const greenBackground = Color(0xFF0DBC79);
+  // ANSI 赤背景 (41) = standardColors[1]
+  const redBackground = Color(0xFFCD3131);
+  // ANSI 青背景 (44) = standardColors[4]
+  const blueBackground = Color(0xFF2472C8);
   // デフォルト背景
   const defaultBackground = Color(0xFF1E1E1E);
 
@@ -56,8 +60,27 @@ void main() {
         .length;
   }
 
+  /// RichText の InlineSpan からテキストを持つ TextSpan を再帰的に収集する。
+  /// （opaque 化したセグメントの backgroundColor を検証するために使用）
+  List<TextSpan> collectTextSpans(InlineSpan span) {
+    if (span is! TextSpan) return const [];
+    return [
+      if (span.text != null) span,
+      ...span.children?.expand(collectTextSpans) ?? const [],
+    ];
+  }
+
+  /// ウィジェットツリー内の全 RichText からテキストを持つ TextSpan を収集する。
+  List<TextSpan> collectAllTextSpans(WidgetTester tester) {
+    return tester
+        .widgetList<RichText>(find.byType(RichText))
+        .expand((rt) => collectTextSpans(rt.text))
+        .toList();
+  }
+
   testWidgets('背景色付き行に背景レイヤーが描画される', (tester) async {
-    await tester.pumpWidget(buildSubject('\x1b[42mgreen text\x1b[0m'));
+    // W1: 末尾リセットが無い（endStyle=green）ため行レイヤーが維持される
+    await tester.pumpWidget(buildSubject('\x1b[42mgreen text'));
     await tester.pumpAndSettle();
 
     expect(countColoredBoxes(tester, greenBackground), greaterThanOrEqualTo(1));
@@ -91,6 +114,7 @@ void main() {
 
   testWidgets('背景レイヤーはIgnorePointerで包まれタップを奪わない', (tester) async {
     var tapped = false;
+    // W8: 末尾リセットが無い（endStyle=green）ため行レイヤーが維持される
     await tester.pumpWidget(
       ProviderScope(
         overrides: [
@@ -102,7 +126,7 @@ void main() {
         child: MaterialApp(
           home: Scaffold(
             body: AnsiTextView(
-              text: '\x1b[42mgreen\x1b[0m',
+              text: '\x1b[42mgreen',
               paneWidth: 80,
               paneHeight: 24,
               onTap: () => tapped = true,
@@ -134,5 +158,72 @@ void main() {
     await tester.tap(find.byType(AnsiTextView));
     await tester.pump();
     expect(tapped, isTrue);
+  });
+
+  testWidgets('S4型: 末尾リセット行には背景レイヤーが無い', (tester) async {
+    // W2: 単色＋末尾リセット → endStyle=default。余白は default（ユーザー承認仕様）
+    await tester.pumpWidget(buildSubject('\x1b[42mgreen text\x1b[0m'));
+    await tester.pumpAndSettle();
+
+    expect(countColoredBoxes(tester, greenBackground), 0);
+  });
+
+  testWidgets('S3型: 複数色＋末尾リセットはレイヤー無し・セル単位は span が担当', (tester) async {
+    // W3: レイヤー無し、RED/GREEN は各セグメント span の backgroundColor で描画
+    await tester.pumpWidget(
+      buildSubject('\x1b[41mRED\x1b[42mGREEN\x1b[49m'),
+    );
+    await tester.pumpAndSettle();
+
+    expect(countColoredBoxes(tester, redBackground), 0);
+    expect(countColoredBoxes(tester, greenBackground), 0);
+
+    final spans = collectAllTextSpans(tester);
+    final red = spans.firstWhere((s) => s.text == 'RED');
+    expect(red.style!.backgroundColor, redBackground);
+    final green = spans.firstWhere((s) => s.text == 'GREEN');
+    expect(green.style!.backgroundColor, greenBackground);
+  });
+
+  testWidgets('S1型: 途中リセット＋先頭デフォルト区間には背景レイヤーが無い', (tester) async {
+    // W4: PREFIX \x1b[44mBLUE\x1b[49m → endStyle=default → 余白は default
+    await tester.pumpWidget(buildSubject('PREFIX \x1b[44mBLUE\x1b[49m'));
+    await tester.pumpAndSettle();
+
+    expect(countColoredBoxes(tester, blueBackground), 0);
+  });
+
+  testWidgets('HYP-4型: 途中デフォルト区間は opaque で default に塗られる', (tester) async {
+    // W5: plain \x1b[44m tail → endStyle=blue のレイヤー有り。"plain " span が opaque default
+    await tester.pumpWidget(buildSubject('plain \x1b[44m tail'));
+    await tester.pumpAndSettle();
+
+    expect(countColoredBoxes(tester, blueBackground), greaterThanOrEqualTo(1));
+
+    final spans = collectAllTextSpans(tester);
+    final plain = spans.firstWhere((s) => s.text == 'plain ');
+    expect(plain.style!.backgroundColor, defaultBackground);
+  });
+
+  testWidgets('R10型: 末尾色SGRのみの行も途中 span は opaque で default', (tester) async {
+    // W6: 'text \x1b[44m' → endStyle=blue のレイヤー有り。"text " span は opaque default
+    await tester.pumpWidget(buildSubject('text \x1b[44m'));
+    await tester.pumpAndSettle();
+
+    expect(countColoredBoxes(tester, blueBackground), greaterThanOrEqualTo(1));
+
+    final spans = collectAllTextSpans(tester);
+    final text = spans.firstWhere((s) => s.text == 'text ');
+    expect(text.style!.backgroundColor, defaultBackground);
+  });
+
+  testWidgets('EV-LOG-006型: 実色スペース行には背景レイヤーが残る', (tester) async {
+    // W7: 実スペース100個の行（PR#98 の行末色埋め機能維持の回帰防止）
+    await tester.pumpWidget(
+      buildSubject('\x1b[42mtext${' ' * 100}\x1b[0m'),
+    );
+    await tester.pumpAndSettle();
+
+    expect(countColoredBoxes(tester, greenBackground), greaterThanOrEqualTo(1));
   });
 }

--- a/test/services/terminal/ansi_parser_test.dart
+++ b/test/services/terminal/ansi_parser_test.dart
@@ -208,12 +208,15 @@ void main() {
         );
       });
 
-      test('returns null for trailing default text after color (endStyle semantics)', () {
-        // 前半は赤背景、後半はリセット済み → 有効背景は default → null
-        // （旧実装前提の「最終セグメント基準」から endStyle 基準へ意味を明確化）
-        final lines = parser.parseLines('\x1b[41mRED\x1b[49m tail');
-        expect(parser.effectiveLineBackgroundColor(lines[0]), isNull);
-      });
+      test(
+        'returns null for trailing default text after color (endStyle semantics)',
+        () {
+          // 前半は赤背景、後半はリセット済み → 有効背景は default → null
+          // （旧実装前提の「最終セグメント基準」から endStyle 基準へ意味を明確化）
+          final lines = parser.parseLines('\x1b[41mRED\x1b[49m tail');
+          expect(parser.effectiveLineBackgroundColor(lines[0]), isNull);
+        },
+      );
 
       // ==== C-001: endStyle 基準 + ハイブリッド例外（fix-plan §4.1 / regression §4.1） ====
 

--- a/test/services/terminal/ansi_parser_test.dart
+++ b/test/services/terminal/ansi_parser_test.dart
@@ -181,13 +181,12 @@ void main() {
         expect(parser.effectiveLineBackgroundColor(lines[0]), isNull);
       });
 
-      test('returns segment background for colored line', () {
+      test('returns null when line ends with reset (trailing default)', () {
         // 青背景 44 = standardColors[4] = 0xFF2472C8
+        // 末尾リセット（tmux 合成 \x1b[49m）により endStyle=default のため、
+        // テキストのみ span 描画され、余白は default（S4 型・ユーザー承認仕様）
         final lines = parser.parseLines('\x1b[44mCOLORED-TEXT\x1b[49m');
-        expect(
-          parser.effectiveLineBackgroundColor(lines[0]),
-          const Color(0xFF2472C8),
-        );
+        expect(parser.effectiveLineBackgroundColor(lines[0]), isNull);
       });
 
       test('returns endStyle background for empty line with SGR only', () {
@@ -209,10 +208,106 @@ void main() {
         );
       });
 
-      test('uses last segment style for trailing style', () {
+      test('returns null for trailing default text after color (endStyle semantics)', () {
         // 前半は赤背景、後半はリセット済み → 有効背景は default → null
+        // （旧実装前提の「最終セグメント基準」から endStyle 基準へ意味を明確化）
         final lines = parser.parseLines('\x1b[41mRED\x1b[49m tail');
         expect(parser.effectiveLineBackgroundColor(lines[0]), isNull);
+      });
+
+      // ==== C-001: endStyle 基準 + ハイブリッド例外（fix-plan §4.1 / regression §4.1） ====
+
+      test('S1型: 途中で色開始＋末尾リセットは null（余白は default）', () {
+        // PREFIX-DEFAULT \x1b[44m BLUE-TAIL\x1b[49m
+        // 最終セグメント " BLUE-TAIL" は末尾非空白 → endStyle=default → null
+        final lines = parser.parseLines(
+          'PREFIX-DEFAULT \x1b[44m BLUE-TAIL\x1b[49m',
+        );
+        expect(parser.effectiveLineBackgroundColor(lines[0]), isNull);
+      });
+
+      test('S3型: 複数色＋末尾リセットは null（セル単位は span 描画が担当）', () {
+        final lines = parser.parseLines('\x1b[41mRED\x1b[42mGREEN\x1b[49m');
+        expect(parser.effectiveLineBackgroundColor(lines[0]), isNull);
+      });
+
+      test('S4型: 単色＋末尾リセットは null（ユーザー承認仕様: 余白 default）', () {
+        final lines = parser.parseLines('\x1b[42mALL-GREEN\x1b[49m');
+        expect(parser.effectiveLineBackgroundColor(lines[0]), isNull);
+      });
+
+      test('endStyle 色残り（末尾リセット無し）は行末まで色を塗る', () {
+        // P4: 末尾リセット無し → endStyle=blue → 全幅レイヤー blue
+        final lines = parser.parseLines('\x1b[44mFULL-COLOR');
+        expect(
+          parser.effectiveLineBackgroundColor(lines[0]),
+          const Color(0xFF2472C8),
+        );
+      });
+
+      test('HYP-4型: 途中デフォルト + 末尾リセット無しは endStyle=色', () {
+        // P5: 途中 "plain " は opaque span で default に塗られる
+        final lines = parser.parseLines('plain \x1b[44m tail');
+        expect(
+          parser.effectiveLineBackgroundColor(lines[0]),
+          const Color(0xFF2472C8),
+        );
+      });
+
+      test('R10型: 末尾で色SGRのみ・後続テキスト無しは endStyle=色', () {
+        // P6: 'text \x1b[44m' → endStyle=blue。「text 」span は opaque で default のまま
+        final lines = parser.parseLines('text \x1b[44m');
+        expect(
+          parser.effectiveLineBackgroundColor(lines[0]),
+          const Color(0xFF2472C8),
+        );
+      });
+
+      test('inverse＋リセットは null（余白の偽塗りが解消）', () {
+        // P7: \x1b[7mrev\x1b[27m → endStyle=default → null
+        final lines = parser.parseLines('\x1b[7mrev\x1b[27m');
+        expect(parser.effectiveLineBackgroundColor(lines[0]), isNull);
+      });
+
+      test('EV-LOG-006型: 実色スペース行（背景付き末尾空白）は最後のセグメント色', () {
+        // P8: \x1b[44mCOLORED-TEXT + 実スペース100 + \x1b[49m → 全幅レイヤー blue
+        // （PR#98 の行末色埋め機能維持。実機では span 末尾空白の背景が描画されない）
+        final lines = parser.parseLines(
+          '\x1b[44mCOLORED-TEXT${' ' * 100}\x1b[49m',
+        );
+        expect(
+          parser.effectiveLineBackgroundColor(lines[0]),
+          const Color(0xFF2472C8),
+        );
+      });
+
+      test('例外ガード: 色付き+末尾1実スペース+リセットは最後のセグメント色', () {
+        // P9: PR#98 互換ロックイン（旧実装と同一条件の部分集合）
+        final lines = parser.parseLines('\x1b[41mRED \x1b[49m');
+        expect(
+          parser.effectiveLineBackgroundColor(lines[0]),
+          const Color(0xFFCD3131),
+        );
+      });
+
+      test('例外不発: 末尾デフォルトスペースでは例外が誤発動しない', () {
+        // P10: 最後のセグメント " " はデフォルト背景 → 例外なし → endStyle=default → null
+        final lines = parser.parseLines('\x1b[42mA \x1b[49m ');
+        expect(parser.effectiveLineBackgroundColor(lines[0]), isNull);
+      });
+    });
+
+    group('toTextSpan opaque background', () {
+      test('default 背景セグメントも opaque で backgroundColor が設定される', () {
+        // opaque 化: 無色セグメントは旧挙動（null）から defaultBackground の不透明塗りに
+        final lines = parser.parseLines('plain');
+        final span = parser.lineToTextSpan(
+          lines[0],
+          fontSize: 14,
+          fontFamily: 'HackGen Console',
+        );
+        final child = span.children![0] as TextSpan;
+        expect(child.style!.backgroundColor, const Color(0xFF1E1E1E));
       });
     });
   });


### PR DESCRIPTION
## Summary
- Terminal row background was painted from `segments.last.style`, collapsing mid-line SGR background changes/resets into one full-width color. Now the row layer derives from the true end-of-line state (`endStyle`), so mid-line color changes render per cell.
- Default-background spans are now opaque (`backgroundColor = defaultBackground`), preventing the underlying row layer color from leaking through transparent spans (e.g. herdr-style trailing SGR rows where no synthetic reset is guaranteed).
- Explicit colored-space rows (e.g. `ESC[44mTEXT<100 spaces>ESC[49m`) keep the legacy full-width background layer, preserving the PR #98 behavior (Flutter does not paint trailing-space span backgrounds on device).

## Changes
- `lib/services/terminal/ansi_parser.dart`
  - `effectiveLineBackgroundColor`: use `line.endStyle` instead of `segments.last.style`; add `_endsWithWhitespace` exception that keeps the final-segment full-width layer for backgrounded rows ending in whitespace. Docstring updated with the verified tmux behavior (trailing default cells are omitted and a synthetic `ESC[49m` is appended).
  - `_segmentToTextSpan`: always set `backgroundColor` (opaque); `resolvePaintColors.paintBackground` remains the single source for the row-layer decision.
- `test/services/terminal/ansi_parser_test.dart`: expectation updated for trailing-reset rows (blue -> null); 11 new tests (S1/S3/S4 patterns, endStyle carry-over, HYP-4, R10, inverse+reset, EV-LOG-006 100-space bytes, exception guard/no-fire, opaque span check).
- `test/screens/terminal/ansi_text_view_bg_test.dart`: inputs updated to no-trailing-reset for the layer-mechanism tests; 6 new widget tests (S1/S3/S4 layer absence, HYP-4/R10 opaque spans, EV-LOG-006 layer retention).

## Test plan
- [x] `make analyze` — no issues
- [x] `flutter test --exclude-tags=repro` (CI gate) — 1461 tests passed
- [x] Emulator verification on the final tree (local AVD + remote emulator 192.168.10.184): S1 prefix leak resolved, S3 RED/GREEN cell-exact with default tail, S4 tail default (approved spec, matches real-terminal semantics), EV-LOG-006 full-width blue retained, R10 default span no leak
- [x] `make test` — 3 failures in `test/repro/repro_ssh_hostkey_fingerprint_test.dart` are pre-existing environment issues (`/tmp/bugfix-repro-key` fixture missing, reproduced on clean baseline HEAD, excluded in CI via the `repro` tag)