### PR TITLE
feat: General file upload — transfer any file from device to remote

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1469,6 +1469,43 @@
         "type": "String"
       }
     }
-  }
+  },
+  "fileUploadAction": "Upload",
+  "fileUploadSshUnavailable": "SSH is not connected",
+  "fileUploadCancelled": "Upload cancelled",
+  "fileUploadAllFailed": "Upload failed",
+  "fileUploadSuccessSingle": "Uploaded to {path}",
+  "@fileUploadSuccessSingle": {
+    "placeholders": {
+      "path": {"type": "String"}
+    }
+  },
+  "fileUploadSuccessMulti": "Uploaded {count} files to {dir}",
+  "@fileUploadSuccessMulti": {
+    "placeholders": {
+      "count": {"type": "int"},
+      "dir": {"type": "String"}
+    }
+  },
+  "fileUploadPartialFailure": "{failed} of {total} files failed to upload",
+  "@fileUploadPartialFailure": {
+    "placeholders": {
+      "failed": {"type": "int"},
+      "total": {"type": "int"}
+    }
+  },
+  "fileUploadCount": "Uploading files ({done} / {total})",
+  "@fileUploadCount": {
+    "placeholders": {
+      "done": {"type": "int"},
+      "total": {"type": "int"}
+    }
+  },
+  "fileUploadCancelAll": "Cancel all",
+  "settingsGroupFileTransfer": "File Transfer",
+  "settingsUploadConflictPolicy": "On filename conflict",
+  "settingsUploadConflictPrompt": "Ask (overwrite / rename)",
+  "settingsUploadConflictAutoRename": "Rename automatically",
+  "settingsUploadConcurrency": "Parallel uploads",
+  "settingsUploadChunkSize": "Upload chunk size (KB)"
 }
-

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -1469,6 +1469,43 @@
         "type": "String"
       }
     }
-  }
+  },
+  "fileUploadAction": "アップロード",
+  "fileUploadSshUnavailable": "SSH接続がありません",
+  "fileUploadCancelled": "アップロードをキャンセルしました",
+  "fileUploadAllFailed": "アップロードに失敗しました",
+  "fileUploadSuccessSingle": "{path} にアップロードしました",
+  "@fileUploadSuccessSingle": {
+    "placeholders": {
+      "path": {"type": "String"}
+    }
+  },
+  "fileUploadSuccessMulti": "{count} 件を {dir} にアップロードしました",
+  "@fileUploadSuccessMulti": {
+    "placeholders": {
+      "count": {"type": "int"},
+      "dir": {"type": "String"}
+    }
+  },
+  "fileUploadPartialFailure": "{total} 件中 {failed} 件が失敗しました",
+  "@fileUploadPartialFailure": {
+    "placeholders": {
+      "failed": {"type": "int"},
+      "total": {"type": "int"}
+    }
+  },
+  "fileUploadCount": "アップロード中（{done} / {total}）",
+  "@fileUploadCount": {
+    "placeholders": {
+      "done": {"type": "int"},
+      "total": {"type": "int"}
+    }
+  },
+  "fileUploadCancelAll": "すべてキャンセル",
+  "settingsGroupFileTransfer": "ファイル転送",
+  "settingsUploadConflictPolicy": "ファイル名の衝突時",
+  "settingsUploadConflictPrompt": "確認する（上書き / リネーム）",
+  "settingsUploadConflictAutoRename": "自動でリネーム",
+  "settingsUploadConcurrency": "同時アップロード数",
+  "settingsUploadChunkSize": "アップロード チャンクサイズ (KB)"
 }
-

--- a/lib/providers/file_transfer_provider.dart
+++ b/lib/providers/file_transfer_provider.dart
@@ -1,0 +1,471 @@
+import 'dart:async';
+
+import 'package:dartssh2/dartssh2.dart' show SftpClient;
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../services/sftp/sftp_service.dart';
+import '../services/sftp/transfer_progress.dart';
+import '../services/ssh/ssh_connection_state.dart';
+import 'settings_provider.dart';
+import 'ssh_provider.dart';
+
+/// ファイル転送（#41・SFTP ブラウザ画面起点）のフェーズ。
+enum FileTransferPhase {
+  /// 待機中（転送なし）
+  idle,
+
+  /// 衝突確認中（prepare 完了・UI がダイアログで解決を確認する）
+  confirming,
+
+  /// 転送中（並列・設定の同時数上限）
+  uploading,
+
+  /// 全ファイル確定（成功 / 部分失敗は items で表現）
+  completed,
+
+  /// ユーザーキャンセルにより中断
+  cancelled,
+
+  /// 準備エラー（SSH 未接続など）
+  error,
+}
+
+/// 個別ファイルの転送状態。
+enum FileTransferItemStatus { pending, uploading, done, failed, skipped }
+
+/// 衝突確認ダイアログ（基盤 showOverwriteConfirmDialog）の結果。
+enum ConflictResolution {
+  /// 未解決（UI 確認前）
+  none,
+
+  /// 上書き
+  overwrite,
+
+  /// 自動リネーム
+  rename,
+}
+
+/// 転送対象 1 ファイルの状態（イミュータブル・copyWith で更新）。
+class FileTransferItem {
+  /// ローカル側の表示名（元名・日本語保持）。
+  final String fileName;
+
+  /// 事前取得した総バイト数。
+  final int totalBytes;
+
+  /// prepare 時点でリモート送信先に同名が存在するか。
+  final bool conflict;
+
+  /// UI が確定した衝突の解決方法。
+  final ConflictResolution resolution;
+
+  /// 転送状態。
+  final FileTransferItemStatus status;
+
+  /// 最新の進捗（uploading 中）。
+  final TransferProgress? progress;
+
+  /// 確定した送信先リモートパス（成功時）。
+  final String? remotePath;
+
+  /// 失敗理由（failed 時）。
+  final Object? error;
+
+  const FileTransferItem({
+    required this.fileName,
+    required this.totalBytes,
+    this.conflict = false,
+    this.resolution = ConflictResolution.none,
+    this.status = FileTransferItemStatus.pending,
+    this.progress,
+    this.remotePath,
+    this.error,
+  });
+
+  bool get isSettled =>
+      status == FileTransferItemStatus.done ||
+      status == FileTransferItemStatus.failed ||
+      status == FileTransferItemStatus.skipped;
+
+  FileTransferItem copyWith({
+    ConflictResolution? resolution,
+    FileTransferItemStatus? status,
+    TransferProgress? progress,
+    String? remotePath,
+    Object? error,
+  }) {
+    return FileTransferItem(
+      fileName: fileName,
+      totalBytes: totalBytes,
+      conflict: conflict,
+      resolution: resolution ?? this.resolution,
+      status: status ?? this.status,
+      progress: progress ?? this.progress,
+      remotePath: remotePath ?? this.remotePath,
+      error: error ?? this.error,
+    );
+  }
+}
+
+/// ファイル転送全体の状態。
+class FileTransferState {
+  final FileTransferPhase phase;
+  final List<FileTransferItem> items;
+
+  /// 送信先ディレクトリ（SFTP ブラウザで現在閲覧中のパス）。
+  final String? remoteDir;
+
+  /// 準備エラーの種別（error 時。UI 側で l10n 化する構造化キー）。
+  final String? errorMessage;
+
+  const FileTransferState({
+    this.phase = FileTransferPhase.idle,
+    this.items = const [],
+    this.remoteDir,
+    this.errorMessage,
+  });
+
+  /// 確定済み（成功/失敗/スキップ）ファイル数。
+  int get settledCount => items.where((item) => item.isSettled).length;
+
+  /// 成功したファイル数。
+  int get doneCount =>
+      items.where((item) => item.status == FileTransferItemStatus.done).length;
+
+  /// 衝突が未解決（確認が必要）な項目のインデックス。
+  List<int> get conflictIndexes => [
+    for (var i = 0; i < items.length; i++)
+      if (items[i].conflict &&
+          items[i].resolution == ConflictResolution.none &&
+          items[i].status == FileTransferItemStatus.pending)
+        i,
+  ];
+
+  bool get hasConflicts => conflictIndexes.isNotEmpty;
+
+  FileTransferState copyWith({
+    FileTransferPhase? phase,
+    List<FileTransferItem>? items,
+    String? remoteDir,
+    String? errorMessage,
+  }) {
+    return FileTransferState(
+      phase: phase ?? this.phase,
+      items: items ?? this.items,
+      remoteDir: remoteDir ?? this.remoteDir,
+      errorMessage: errorMessage ?? this.errorMessage,
+    );
+  }
+}
+
+/// 汎用ファイル転送を管理する Notifier（#41）。
+///
+/// 既存の画像転送（ImageTransferNotifier / #29）とは独立して共存する。
+/// UI（FileBrowserScreen）は prepare → （衝突があれば基盤
+/// showOverwriteConfirmDialog で解決を setConflictResolution）→ start の順で使う。
+class FileTransferNotifier extends Notifier<FileTransferState> {
+  final _sftpService = SftpService();
+
+  /// prepare で受け取ったローカルファイル（start で消費）。
+  List<PlatformFile> _pendingFiles = [];
+
+  /// ファイル毎のキャンセルトークン（start で生成）。
+  final List<TransferCancelToken> _cancelTokens = [];
+
+  /// 全体キャンセル（cancelAll / SSH 切断で使用）。
+  TransferCancelToken? _globalToken;
+
+  StreamSubscription? _connectionSub;
+
+  @override
+  FileTransferState build() {
+    ref.onDispose(() {
+      _connectionSub?.cancel();
+      _globalToken?.cancel();
+    });
+    return const FileTransferState();
+  }
+
+  /// 選択済みファイルを準備し、送信先との衝突を検出する。
+  ///
+  /// 成功すると phase=confirming になる（conflict が無ければ UI は即 start してよい）。
+  Future<void> prepare({
+    required List<PlatformFile> files,
+    required String remoteDir,
+  }) async {
+    if (files.isEmpty) {
+      return;
+    }
+
+    final sshClient = ref.read(sshProvider.notifier).client;
+    if (sshClient == null || !sshClient.isConnected) {
+      state = state.copyWith(
+        phase: FileTransferPhase.error,
+        errorMessage: 'ssh-not-available',
+      );
+      return;
+    }
+
+    final sftp = await sshClient.openSftp();
+
+    final items = <FileTransferItem>[];
+    for (final file in files) {
+      final size = await file.length();
+      final remotePath = SftpService.safeRemotePath(remoteDir, file.name);
+      final exists = await SftpService.remoteFileExists(sftp, remotePath);
+      items.add(
+        FileTransferItem(
+          fileName: file.name,
+          totalBytes: size,
+          conflict: exists,
+        ),
+      );
+    }
+
+    _pendingFiles = List.of(files);
+    state = FileTransferState(
+      phase: FileTransferPhase.confirming,
+      items: items,
+      remoteDir: remoteDir,
+    );
+  }
+
+  /// 衝突確認ダイアログの結果を記録する（UI が呼ぶ）。
+  void setConflictResolution(int index, ConflictResolution resolution) {
+    if (index < 0 || index >= state.items.length) return;
+    final items = List<FileTransferItem>.of(state.items);
+    items[index] = items[index].copyWith(resolution: resolution);
+    state = state.copyWith(items: items);
+  }
+
+  /// 転送を開始する（並列数は設定値・1..8 に制限）。
+  Future<void> start() async {
+    if (state.phase != FileTransferPhase.confirming) return;
+
+    final sshClient = ref.read(sshProvider.notifier).client;
+    if (sshClient == null || !sshClient.isConnected) {
+      state = state.copyWith(
+        phase: FileTransferPhase.error,
+        errorMessage: 'ssh-not-available',
+      );
+      return;
+    }
+    final sftp = await sshClient.openSftp();
+
+    final settings = ref.read(settingsProvider);
+    final remoteDir = state.remoteDir!;
+    final files = List.of(_pendingFiles);
+    final initialItems = List<FileTransferItem>.of(state.items);
+
+    // 最終ファイル名の確定:
+    // - 衝突なし → 元名のまま
+    // - 衝突 + overwrite → 元名（truncate 上書き）
+    // - 衝突 + rename / 設定 autoRename → generateUniqueName
+    // - 衝突 + none（prompt のまま未確認で start）→ 安全側のスキップ扱い
+    // ※ バッチ内の重複名は後続を自動リネームして誤上書きを防ぐ
+    final claimedNames = <String>{};
+    final finalNames = <String>[];
+    var items = List<FileTransferItem>.of(initialItems);
+    for (var i = 0; i < items.length; i++) {
+      final item = items[i];
+      var name = item.fileName;
+      var status = FileTransferItemStatus.pending;
+      if (item.conflict) {
+        switch (item.resolution) {
+          case ConflictResolution.overwrite:
+            name = item.fileName;
+          case ConflictResolution.rename:
+            name = SftpService.generateUniqueName(item.fileName);
+          case ConflictResolution.none:
+            if (settings.uploadConflictPolicy ==
+                TransferConflictPolicy.autoRename) {
+              name = SftpService.generateUniqueName(item.fileName);
+            } else {
+              // 確認を経ずに開始された衝突は安全側（スキップ）に倒す
+              status = FileTransferItemStatus.skipped;
+            }
+        }
+      }
+      while (claimedNames.contains(name) &&
+          status == FileTransferItemStatus.pending) {
+        name = SftpService.generateUniqueName(name);
+      }
+      claimedNames.add(name);
+      finalNames.add(name);
+      if (status != items[i].status) {
+        items[i] = items[i].copyWith(status: status);
+      }
+    }
+
+    _globalToken = TransferCancelToken();
+    _cancelTokens
+      ..clear()
+      ..addAll(List.generate(items.length, (_) => TransferCancelToken()));
+
+    state = state.copyWith(phase: FileTransferPhase.uploading, items: items);
+
+    // SSH 切断監視（image_transfer / file_browser と同じパターン）。
+    _connectionSub?.cancel();
+    _connectionSub = sshClient.connectionStateStream.listen((connState) {
+      if (connState == SshConnectionState.disconnected ||
+          connState == SshConnectionState.error) {
+        if (state.phase == FileTransferPhase.uploading) {
+          _globalToken?.cancel();
+        }
+      }
+    });
+
+    try {
+      final queue = <int>[
+        for (var i = 0; i < items.length; i++)
+          if (items[i].status == FileTransferItemStatus.pending) i,
+      ];
+      final concurrency = settings.uploadConcurrency.clamp(1, 8);
+      final workerCount = concurrency > queue.length
+          ? queue.length
+          : concurrency;
+
+      Future<void> worker() async {
+        while (queue.isNotEmpty) {
+          if (_globalToken?.isCancelled ?? false) return;
+          final index = queue.removeAt(0);
+          await _uploadOne(
+            sftp: sftp,
+            remoteDir: remoteDir,
+            finalName: finalNames[index],
+            file: files[index],
+            totalBytes: initialItems[index].totalBytes,
+            index: index,
+            cancelToken: _cancelTokens[index],
+            globalToken: _globalToken!,
+            chunkSize: settings.uploadChunkKb * 1024,
+          );
+        }
+      }
+
+      await Future.wait(List.generate(workerCount, (_) => worker()));
+    } finally {
+      _connectionSub?.cancel();
+      _connectionSub = null;
+    }
+
+    // 全体確定（未完の項目はスキップ扱い。全体キャンセル時は cancelled）。
+    items = List.of(state.items);
+    for (var i = 0; i < items.length; i++) {
+      if (items[i].status == FileTransferItemStatus.pending ||
+          items[i].status == FileTransferItemStatus.uploading) {
+        items[i] = items[i].copyWith(status: FileTransferItemStatus.skipped);
+      }
+    }
+    final cancelled = _globalToken?.isCancelled ?? false;
+    state = state.copyWith(
+      phase: cancelled
+          ? FileTransferPhase.cancelled
+          : FileTransferPhase.completed,
+      items: items,
+    );
+  }
+
+  Future<void> _uploadOne({
+    required SftpClient sftp,
+    required String remoteDir,
+    required String finalName,
+    required PlatformFile file,
+    required int totalBytes,
+    required int index,
+    required TransferCancelToken cancelToken,
+    required TransferCancelToken globalToken,
+    required int chunkSize,
+  }) async {
+    _updateItem(
+      index,
+      (item) => item.copyWith(status: FileTransferItemStatus.uploading),
+    );
+    try {
+      final result = await _sftpService.uploadStream(
+        sftp: sftp,
+        remoteDir: remoteDir,
+        filename: finalName,
+        source: file.readAsByteStream(),
+        totalBytes: totalBytes,
+        chunkSize: chunkSize,
+        cancelToken: _CombinedCancelToken(globalToken, cancelToken),
+        onProgress: (progress) =>
+            _updateItem(index, (item) => item.copyWith(progress: progress)),
+      );
+      _updateItem(
+        index,
+        (item) => item.copyWith(
+          status: FileTransferItemStatus.done,
+          remotePath: result.remotePath,
+        ),
+      );
+    } on TransferCancelledException {
+      _updateItem(
+        index,
+        (item) => item.copyWith(status: FileTransferItemStatus.skipped),
+      );
+    } catch (e) {
+      _updateItem(
+        index,
+        (item) =>
+            item.copyWith(status: FileTransferItemStatus.failed, error: e),
+      );
+    }
+  }
+
+  void _updateItem(
+    int index,
+    FileTransferItem Function(FileTransferItem) transform,
+  ) {
+    if (index < 0 || index >= state.items.length) return;
+    final items = List<FileTransferItem>.of(state.items);
+    items[index] = transform(items[index]);
+    state = state.copyWith(items: items);
+  }
+
+  /// 全ファイルの転送をキャンセルする（部分ファイルはサービス側で削除）。
+  void cancelAll() {
+    _globalToken?.cancel();
+    for (final token in _cancelTokens) {
+      token.cancel();
+    }
+  }
+
+  /// 指定ファイルのみキャンセルする。
+  void cancelFile(int index) {
+    if (index < 0 || index >= _cancelTokens.length) return;
+    _cancelTokens[index].cancel();
+  }
+
+  /// 状態をリセットする（完了/キャンセル/エラー後）。
+  void reset() {
+    _globalToken?.cancel();
+    _connectionSub?.cancel();
+    _connectionSub = null;
+    _pendingFiles = [];
+    _cancelTokens.clear();
+    state = const FileTransferState();
+  }
+}
+
+/// 全体キャンセルとファイル個別キャンセルのいずれかで中止する複合トークン。
+class _CombinedCancelToken extends TransferCancelToken {
+  final TransferCancelToken global;
+  final TransferCancelToken individual;
+
+  _CombinedCancelToken(this.global, this.individual);
+
+  @override
+  bool get isCancelled => global.isCancelled || individual.isCancelled;
+
+  @override
+  void cancel() => individual.cancel();
+}
+
+/// ファイル転送プロバイダー。
+final fileTransferProvider =
+    NotifierProvider<FileTransferNotifier, FileTransferState>(
+      FileTransferNotifier.new,
+    );

--- a/lib/providers/settings_provider.dart
+++ b/lib/providers/settings_provider.dart
@@ -7,6 +7,25 @@ import 'package:flutter_displaymode/flutter_displaymode.dart';
 import '../services/settings_migration.dart';
 import '../l10n/l10n_lookup.dart';
 
+/// アップロード時のファイル名衝突ポリシー（#41）。
+/// - [prompt]: 既定。衝突時にモーダルで上書き/リネーム/キャンセルを確認
+/// - [autoRename]: 確認なしで自動リネーム（generateUniqueName）
+enum TransferConflictPolicy {
+  prompt,
+  autoRename;
+
+  /// SharedPreferences 永続化値。
+  String get persistedValue =>
+      this == TransferConflictPolicy.autoRename ? 'autoRename' : 'prompt';
+
+  /// 永続化値からの復元（不正値は既定の prompt にフォールバック）。
+  static TransferConflictPolicy fromPersisted(String? value) {
+    return value == 'autoRename'
+        ? TransferConflictPolicy.autoRename
+        : TransferConflictPolicy.prompt;
+  }
+}
+
 /// アプリ設定
 class AppSettings {
   final bool darkMode;
@@ -93,6 +112,16 @@ class AppSettings {
   final bool imageAutoEnter;
   final bool imageBracketedPaste;
 
+  // --- ファイル転送設定（#41） ---
+  /// アップロード時のファイル名衝突ポリシー
+  final TransferConflictPolicy uploadConflictPolicy;
+
+  /// 同時アップロード並列数
+  final int uploadConcurrency;
+
+  /// アップロード書き込みチャンクサイズ（KB）
+  final int uploadChunkKb;
+
   const AppSettings({
     this.darkMode = true,
     this.fontSize = 14.0,
@@ -133,6 +162,9 @@ class AppSettings {
     this.imagePathFormat = '{path}',
     this.imageAutoEnter = false,
     this.imageBracketedPaste = false,
+    this.uploadConflictPolicy = TransferConflictPolicy.prompt,
+    this.uploadConcurrency = 2,
+    this.uploadChunkKb = 256,
   });
 
   bool get isAutoFit => adjustMode == 'autoFit';
@@ -178,6 +210,9 @@ class AppSettings {
     String? imagePathFormat,
     bool? imageAutoEnter,
     bool? imageBracketedPaste,
+    TransferConflictPolicy? uploadConflictPolicy,
+    int? uploadConcurrency,
+    int? uploadChunkKb,
   }) {
     return AppSettings(
       darkMode: darkMode ?? this.darkMode,
@@ -218,6 +253,9 @@ class AppSettings {
       imagePathFormat: imagePathFormat ?? this.imagePathFormat,
       imageAutoEnter: imageAutoEnter ?? this.imageAutoEnter,
       imageBracketedPaste: imageBracketedPaste ?? this.imageBracketedPaste,
+      uploadConflictPolicy: uploadConflictPolicy ?? this.uploadConflictPolicy,
+      uploadConcurrency: uploadConcurrency ?? this.uploadConcurrency,
+      uploadChunkKb: uploadChunkKb ?? this.uploadChunkKb,
     );
   }
 }
@@ -267,6 +305,10 @@ class SettingsNotifier extends Notifier<AppSettings> {
   static const String _keyOverlayArrowKey = 'settings_key_overlay_arrow';
   static const String _keyOverlayShortcutKey = 'settings_key_overlay_shortcut';
   static const String _keyOverlayPositionKey = 'settings_key_overlay_position';
+  static const String _uploadConflictPolicyKey =
+      'settings_upload_conflict_policy';
+  static const String _uploadConcurrencyKey = 'settings_upload_concurrency';
+  static const String _uploadChunkKbKey = 'settings_upload_chunk_kb';
 
   @override
   AppSettings build() {
@@ -324,6 +366,11 @@ class SettingsNotifier extends Notifier<AppSettings> {
       imagePathFormat: prefs.getString(_imagePathFormatKey) ?? '{path}',
       imageAutoEnter: prefs.getBool(_imageAutoEnterKey) ?? false,
       imageBracketedPaste: prefs.getBool(_imageBracketedPasteKey) ?? false,
+      uploadConflictPolicy: TransferConflictPolicy.fromPersisted(
+        prefs.getString(_uploadConflictPolicyKey),
+      ),
+      uploadConcurrency: prefs.getInt(_uploadConcurrencyKey) ?? 2,
+      uploadChunkKb: prefs.getInt(_uploadChunkKbKey) ?? 256,
     );
 
     // 言語設定を l10n キャッシュへ反映（BuildContext を持たない層用）。
@@ -627,6 +674,27 @@ class SettingsNotifier extends Notifier<AppSettings> {
   Future<void> setImageBracketedPaste(bool value) async {
     state = state.copyWith(imageBracketedPaste: value);
     await _saveSetting(_imageBracketedPasteKey, value);
+  }
+
+  // --- ファイル転送設定（#41）のsetter ---
+  /// ファイル名衝突ポリシーを設定
+  Future<void> setUploadConflictPolicy(TransferConflictPolicy value) async {
+    state = state.copyWith(uploadConflictPolicy: value);
+    await _saveSetting(_uploadConflictPolicyKey, value.persistedValue);
+  }
+
+  /// 同時アップロード並列数を設定（1〜8 に制限）
+  Future<void> setUploadConcurrency(int value) async {
+    final clamped = value.clamp(1, 8);
+    state = state.copyWith(uploadConcurrency: clamped);
+    await _saveSetting(_uploadConcurrencyKey, clamped);
+  }
+
+  /// アップロード書き込みチャンクサイズ（KB）を設定（16〜8192 に制限）
+  Future<void> setUploadChunkKb(int value) async {
+    final clamped = value.clamp(16, 8192);
+    state = state.copyWith(uploadChunkKb: clamped);
+    await _saveSetting(_uploadChunkKbKey, clamped);
   }
 
   /// リロード

--- a/lib/screens/file_browser/file_browser_screen.dart
+++ b/lib/screens/file_browser/file_browser_screen.dart
@@ -1,13 +1,19 @@
 // ignore_for_file: use_build_context_synchronously
 
+import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:google_fonts/google_fonts.dart';
 
-import '../../providers/file_browser_provider.dart';
 import '../../l10n/l10n_ext.dart';
+import '../../providers/file_browser_provider.dart';
+import '../../providers/file_transfer_provider.dart';
 import '../../services/sftp/file_entry.dart';
+import '../../services/sftp/overwrite_choice.dart';
+import '../../services/sftp/transfer_progress.dart';
 import '../../theme/design_colors.dart';
+import '../../widgets/dialogs/overwrite_confirm_dialog.dart';
+import '../../widgets/file_transfer/transfer_progress_row.dart';
 import 'widgets/file_action_menu.dart';
 import 'widgets/file_list_tile.dart';
 import 'widgets/path_bar.dart';
@@ -38,6 +44,7 @@ class _FileBrowserScreenState extends ConsumerState<FileBrowserScreen> {
   @override
   Widget build(BuildContext context) {
     final state = ref.watch(fileBrowserProvider);
+    final transferState = ref.watch(fileTransferProvider);
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final colorScheme = Theme.of(context).colorScheme;
 
@@ -59,6 +66,10 @@ class _FileBrowserScreenState extends ConsumerState<FileBrowserScreen> {
                 },
               ),
             ),
+            if (transferState.phase == FileTransferPhase.uploading)
+              SliverToBoxAdapter(
+                child: _buildTransferPanel(context, transferState),
+              ),
             _buildBody(context, state, isDark),
           ],
         ),
@@ -76,6 +87,9 @@ class _FileBrowserScreenState extends ConsumerState<FileBrowserScreen> {
     bool isDark,
     ColorScheme colorScheme,
   ) {
+    final transferState = ref.watch(fileTransferProvider);
+    final transferInProgress =
+        transferState.phase == FileTransferPhase.uploading;
     final dirName = state.currentPath == '/'
         ? '/'
         : state.currentPath.split('/').where((s) => s.isNotEmpty).lastOrNull ??
@@ -94,6 +108,14 @@ class _FileBrowserScreenState extends ConsumerState<FileBrowserScreen> {
         ),
       ),
       actions: [
+        // アップロード（#41・転送中は無効化）
+        IconButton(
+          icon: const Icon(Icons.upload_file, size: 22),
+          onPressed: transferInProgress
+              ? null
+              : () => _handleUpload(context, state.currentPath),
+          tooltip: context.l10n.fileUploadAction,
+        ),
         // 隠しファイルトグル
         IconButton(
           icon: Icon(
@@ -159,6 +181,195 @@ class _FileBrowserScreenState extends ConsumerState<FileBrowserScreen> {
           ],
         ),
       ],
+    );
+  }
+
+  /// アップロード導線（#41）: file_picker 複数選択 → 衝突確認 → 並列転送。
+  Future<void> _handleUpload(BuildContext context, String remoteDir) async {
+    final l10n = context.l10n;
+    List<PlatformFile> files;
+    try {
+      files = await FilePicker.pickFiles(type: FileType.any);
+    } catch (_) {
+      files = [];
+    }
+    if (!mounted || files.isEmpty) return;
+
+    final notifier = ref.read(fileTransferProvider.notifier);
+    await notifier.prepare(files: files, remoteDir: remoteDir);
+    if (!mounted) return;
+
+    var transferState = ref.read(fileTransferProvider);
+    if (transferState.phase == FileTransferPhase.error) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(l10n.fileUploadSshUnavailable),
+          backgroundColor: DesignColors.error,
+          behavior: SnackBarBehavior.floating,
+        ),
+      );
+      notifier.reset();
+      return;
+    }
+
+    // 衝突確認（基盤 showOverwriteConfirmDialog・single モード）。
+    // dismiss(null) と cancel はどちらも全体中止（基盤契約 C-8）。
+    while (ref.read(fileTransferProvider).hasConflicts) {
+      final index = ref.read(fileTransferProvider).conflictIndexes.first;
+      final item = ref.read(fileTransferProvider).items[index];
+      final result = await showOverwriteConfirmDialog(
+        context,
+        fileName: item.fileName,
+        mode: OverwriteDialogMode.single,
+      );
+      if (!mounted) return;
+      if (result == null || result.choice == OverwriteChoice.cancel) {
+        notifier.reset();
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(l10n.fileUploadCancelled),
+            behavior: SnackBarBehavior.floating,
+          ),
+        );
+        return;
+      }
+      notifier.setConflictResolution(
+        index,
+        result.choice == OverwriteChoice.overwrite
+            ? ConflictResolution.overwrite
+            : ConflictResolution.rename,
+      );
+    }
+
+    await notifier.start();
+    if (!mounted) return;
+    transferState = ref.read(fileTransferProvider);
+
+    // 結果フィードバック（アップロード先パス付き）
+    final doneItems = transferState.items
+        .where((item) => item.status == FileTransferItemStatus.done)
+        .toList();
+    final failedCount = transferState.items
+        .where((item) => item.status == FileTransferItemStatus.failed)
+        .length;
+    if (transferState.phase == FileTransferPhase.cancelled) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(l10n.fileUploadCancelled),
+          behavior: SnackBarBehavior.floating,
+        ),
+      );
+    } else if (doneItems.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(l10n.fileUploadAllFailed),
+          backgroundColor: DesignColors.error,
+          behavior: SnackBarBehavior.floating,
+        ),
+      );
+    } else if (failedCount > 0) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+            l10n.fileUploadPartialFailure(
+              failedCount,
+              transferState.items.length,
+            ),
+          ),
+          backgroundColor: DesignColors.error,
+          behavior: SnackBarBehavior.floating,
+        ),
+      );
+    } else if (doneItems.length == 1) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+            l10n.fileUploadSuccessSingle(doneItems.first.remotePath ?? ''),
+          ),
+          backgroundColor: DesignColors.success,
+          behavior: SnackBarBehavior.floating,
+        ),
+      );
+    } else {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+            l10n.fileUploadSuccessMulti(doneItems.length, remoteDir),
+          ),
+          backgroundColor: DesignColors.success,
+          behavior: SnackBarBehavior.floating,
+        ),
+      );
+    }
+
+    if (doneItems.isNotEmpty) {
+      // アップロード済みファイルを一覧へ反映
+      await ref.read(fileBrowserProvider.notifier).refresh();
+    }
+  }
+
+  /// 転送中パネル（基盤 TransferProgressRow × アクティブ行 + 全体カウンタ）。
+  Widget _buildTransferPanel(
+    BuildContext context,
+    FileTransferState transferState,
+  ) {
+    final l10n = context.l10n;
+    final activeIndexes = [
+      for (var i = 0; i < transferState.items.length; i++)
+        if (transferState.items[i].status == FileTransferItemStatus.uploading)
+          i,
+    ];
+
+    return Material(
+      elevation: 2,
+      color: Theme.of(context).colorScheme.surfaceContainerHighest,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 8, 8, 0),
+            child: Row(
+              children: [
+                const SizedBox(
+                  width: 18,
+                  height: 18,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    l10n.fileUploadCount(
+                      transferState.settledCount,
+                      transferState.items.length,
+                    ),
+                    style: Theme.of(context).textTheme.labelLarge,
+                  ),
+                ),
+                TextButton.icon(
+                  onPressed: () =>
+                      ref.read(fileTransferProvider.notifier).cancelAll(),
+                  icon: const Icon(Icons.close, size: 16),
+                  label: Text(l10n.fileUploadCancelAll),
+                ),
+              ],
+            ),
+          ),
+          for (final index in activeIndexes)
+            TransferProgressRow(
+              key: ValueKey('transfer-row-$index'),
+              progress:
+                  transferState.items[index].progress ??
+                  TransferProgress(
+                    doneBytes: 0,
+                    totalBytes: transferState.items[index].totalBytes,
+                  ),
+              label: transferState.items[index].fileName,
+              onCancel: () =>
+                  ref.read(fileTransferProvider.notifier).cancelFile(index),
+            ),
+          const SizedBox(height: 4),
+        ],
+      ),
     );
   }
 

--- a/lib/screens/settings/pickers/conflict_policy_picker.dart
+++ b/lib/screens/settings/pickers/conflict_policy_picker.dart
@@ -1,0 +1,43 @@
+// ignore_for_file: deprecated_member_use
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../l10n/l10n_ext.dart';
+import '../../../providers/settings_provider.dart';
+
+/// ファイル名衝突ポリシー（確認 / 自動リネーム）選択ダイアログ（#41）。
+///
+/// `output_format_picker.dart` と同じ SimpleDialog + RadioListTile パターン。
+Future<void> showConflictPolicyPicker(
+  BuildContext context,
+  WidgetRef ref,
+  TransferConflictPolicy current,
+) async {
+  final l10n = context.l10n;
+  showDialog(
+    context: context,
+    builder: (ctx) => SimpleDialog(
+      title: Text(l10n.settingsUploadConflictPolicy),
+      children: [
+        for (final policy in TransferConflictPolicy.values)
+          RadioListTile<TransferConflictPolicy>(
+            title: Text(switch (policy) {
+              TransferConflictPolicy.prompt =>
+                l10n.settingsUploadConflictPrompt,
+              TransferConflictPolicy.autoRename =>
+                l10n.settingsUploadConflictAutoRename,
+            }),
+            value: policy,
+            groupValue: current,
+            onChanged: (v) {
+              if (v != null) {
+                ref.read(settingsProvider.notifier).setUploadConflictPolicy(v);
+              }
+              Navigator.pop(ctx);
+            },
+          ),
+      ],
+    ),
+  );
+}

--- a/lib/screens/settings/sections/connection_section.dart
+++ b/lib/screens/settings/sections/connection_section.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../l10n/l10n_ext.dart';
 import '../../../providers/settings_provider.dart';
 import '../pickers/clear_host_keys_confirmation.dart';
+import '../pickers/conflict_policy_picker.dart';
 import '../pickers/output_format_picker.dart';
 import '../pickers/resize_preset_picker.dart';
 import '../pickers/slider_dialog.dart';
@@ -128,6 +129,48 @@ class ConnectionSection extends ConsumerWidget {
               ref.read(settingsProvider.notifier).setImageBracketedPaste(v),
         ),
         const Divider(),
+        SettingsSectionHeader(title: l10n.settingsGroupFileTransfer),
+        ListTile(
+          leading: const Icon(Icons.rule),
+          title: Text(l10n.settingsUploadConflictPolicy),
+          subtitle: Text(switch (settings.uploadConflictPolicy) {
+            TransferConflictPolicy.prompt => l10n.settingsUploadConflictPrompt,
+            TransferConflictPolicy.autoRename =>
+              l10n.settingsUploadConflictAutoRename,
+          }),
+          onTap: () => showConflictPolicyPicker(
+            context,
+            ref,
+            settings.uploadConflictPolicy,
+          ),
+        ),
+        ListTile(
+          leading: const Icon(Icons.call_split),
+          title: Text(l10n.settingsUploadConcurrency),
+          subtitle: Text('${settings.uploadConcurrency}'),
+          onTap: () => showNumberInputDialog(
+            context,
+            ref,
+            title: l10n.settingsUploadConcurrency,
+            currentValue: settings.uploadConcurrency,
+            onSave: (v) =>
+                ref.read(settingsProvider.notifier).setUploadConcurrency(v),
+          ),
+        ),
+        ListTile(
+          leading: const Icon(Icons.memory),
+          title: Text(l10n.settingsUploadChunkSize),
+          subtitle: Text('${settings.uploadChunkKb} KB'),
+          onTap: () => showNumberInputDialog(
+            context,
+            ref,
+            title: l10n.settingsUploadChunkSize,
+            currentValue: settings.uploadChunkKb,
+            onSave: (v) =>
+                ref.read(settingsProvider.notifier).setUploadChunkKb(v),
+          ),
+        ),
+        const Divider(),
         ListTile(
           leading: const Icon(Icons.key_off),
           title: Text(l10n.settingsClearHostKeys),
@@ -228,10 +271,39 @@ final List<SettingsSearchItem> connectionSearchDescriptors = [
     groupLabel: (l10n) => l10n.settingsGroupImageTransfer,
     icon: Icons.paste,
   ),
-  // --- フラット（1項目グループ回避・A2） ---
+  // --- ファイル転送（File Transfer・#41） ---
   SettingsSearchItem(
     category: SettingsCategory.connection,
     orderInCategory: 9,
+    id: 'uploadConflictPolicy',
+    title: (l10n) => l10n.settingsUploadConflictPolicy,
+    valueLabels: [
+      (l10n) => l10n.settingsUploadConflictPrompt,
+      (l10n) => l10n.settingsUploadConflictAutoRename,
+    ],
+    groupLabel: (l10n) => l10n.settingsGroupFileTransfer,
+    icon: Icons.rule,
+  ),
+  SettingsSearchItem(
+    category: SettingsCategory.connection,
+    orderInCategory: 10,
+    id: 'uploadConcurrency',
+    title: (l10n) => l10n.settingsUploadConcurrency,
+    groupLabel: (l10n) => l10n.settingsGroupFileTransfer,
+    icon: Icons.call_split,
+  ),
+  SettingsSearchItem(
+    category: SettingsCategory.connection,
+    orderInCategory: 11,
+    id: 'uploadChunkSize',
+    title: (l10n) => l10n.settingsUploadChunkSize,
+    groupLabel: (l10n) => l10n.settingsGroupFileTransfer,
+    icon: Icons.memory,
+  ),
+  // --- フラット（1項目グループ回避・A2） ---
+  SettingsSearchItem(
+    category: SettingsCategory.connection,
+    orderInCategory: 12,
     id: 'clearHostKeys',
     title: (l10n) => l10n.settingsClearHostKeys,
     description: (l10n) => l10n.settingsClearHostKeysDescription,

--- a/lib/services/sftp/sftp_service.dart
+++ b/lib/services/sftp/sftp_service.dart
@@ -1,7 +1,11 @@
+import 'dart:async';
 import 'dart:typed_data';
 
 import 'package:dartssh2/dartssh2.dart';
+import 'package:path/path.dart' as p;
 import 'package:uuid/uuid.dart';
+
+import 'transfer_progress.dart';
 
 /// SFTPアップロード結果
 class SftpUploadResult {
@@ -19,9 +23,18 @@ class SftpService {
   static const _uuid = Uuid();
   static final _safeCharsRegex = RegExp(r'[^a-zA-Z0-9._-]');
 
+  /// [uploadStream] の既定チャンクサイズ（書き込み要求の粒度）。
+  ///
+  /// dartssh2 の SftpFileWriter は内部で 16KB パケットに再分割するため、
+  /// この値は進捗通知の粒度とバッファ量のバランスを決める。
+  static const int defaultChunkSize = 256 * 1024;
+
   /// ファイル名をサニタイズ（安全な文字のみ許可）
   ///
   /// [a-zA-Z0-9._-] 以外の文字は `_` に置換する。
+  ///
+  /// ※ #41 の汎用アップロード（[uploadStream]）では日本語名を保持するため
+  /// この関数を使わず [safeRemotePath] でパス構造のみを防御する。
   static String sanitizeFilename(String raw) {
     if (raw.isEmpty) return 'unnamed';
     return raw.replaceAll(_safeCharsRegex, '_');
@@ -31,14 +44,56 @@ class SftpService {
   ///
   /// 例: img_20260403_143025_a3f2.png
   static String generateFilename(String prefix, String extension) {
-    final now = DateTime.now();
-    final timestamp =
-        '${now.year}${_pad(now.month)}${_pad(now.day)}_${_pad(now.hour)}${_pad(now.minute)}${_pad(now.second)}';
+    final timestamp = _timestamp();
     final shortUuid = _uuid.v4().substring(0, 4);
     final sanitizedExt = extension.startsWith('.')
         ? extension.substring(1)
         : extension;
     return '${sanitizeFilename(prefix)}${timestamp}_$shortUuid.$sanitizedExt';
+  }
+
+  /// 元のファイル名ベースでユニークファイル名を生成（#41 リネーム選択用）。
+  ///
+  /// 元名（日本語等の多バイト名を含む）の拡張子を保持し、
+  /// `名前_YYYYMMDD_HHMMSS_uuid4.拡張子` 形式で衝突を回避する。
+  /// 例: report.pdf -> report_20260403_143025_a3f2.pdf
+  static String generateUniqueName(String originalName) {
+    final base = p.basename(originalName);
+    final dotIndex = base.lastIndexOf('.');
+    final hasExtension = dotIndex > 0 && dotIndex < base.length - 1;
+    final stem = hasExtension ? base.substring(0, dotIndex) : base;
+    final extension = hasExtension ? base.substring(dotIndex) : '';
+    final separator = stem.isEmpty || stem.endsWith('_') || stem.endsWith('-')
+        ? ''
+        : '_';
+    final timestamp = _timestamp();
+    final shortUuid = _uuid.v4().substring(0, 4);
+    return '$stem$separator${timestamp}_$shortUuid$extension';
+  }
+
+  /// リモートディレクトリとファイル名を安全に連結する（パストラバーサル防御）。
+  ///
+  /// - ファイル名は [p.basename] でパス構造（`/`・`..`）を除去する
+  /// - ディレクトリは [p.normalize] で正規化する
+  /// - 日本語等の多バイトファイル名はそのまま保持される（🤝#3）
+  static String safeRemotePath(String remoteDir, String filename) {
+    final dir = p.normalize(remoteDir.isEmpty ? '.' : remoteDir);
+    return p.join(dir, p.basename(filename));
+  }
+
+  /// リモートパスにファイル/ディレクトリが存在するか（衝突検出用）。
+  ///
+  /// 存在する場合 true、SftpStatusError（No such file 等）の場合 false。
+  static Future<bool> remoteFileExists(
+    SftpClient sftp,
+    String remotePath,
+  ) async {
+    try {
+      await sftp.stat(remotePath);
+      return true;
+    } on SftpStatusError {
+      return false;
+    }
   }
 
   /// リモートディレクトリの存在確認・作成
@@ -50,26 +105,56 @@ class SftpService {
     }
   }
 
-  /// ファイルアップロード
+  /// バイト全体をアップロード（既存API・#29 画像フロー互換）。
   ///
-  /// [sftp] SFTPクライアント
-  /// [remoteDir] リモートディレクトリパス（末尾/なし可）
-  /// [filename] ファイル名
-  /// [bytes] アップロードするバイトデータ
-  /// [onProgress] 進捗コールバック (0.0 ~ 1.0)
+  /// 内部は [uploadStream] への移譲。進捗コールバックは従来どおり
+  /// 0.0〜1.0 の double。
   Future<SftpUploadResult> upload({
     required SftpClient sftp,
     required String remoteDir,
     required String filename,
     required Uint8List bytes,
     void Function(double progress)? onProgress,
-  }) async {
-    final dir = remoteDir.endsWith('/')
-        ? remoteDir.substring(0, remoteDir.length - 1)
-        : remoteDir;
-    final remotePath = '$dir/$filename';
+  }) {
+    return uploadStream(
+      sftp: sftp,
+      remoteDir: remoteDir,
+      filename: filename,
+      source: Stream.value(bytes),
+      totalBytes: bytes.length,
+      onProgress: onProgress == null
+          ? null
+          : (progress) => onProgress(progress.fraction ?? 1.0),
+    );
+  }
 
-    await ensureDirectory(sftp, dir);
+  /// ストリーム入力の汎用アップロード（#41）。
+  ///
+  /// - [source]: ローカルファイルの読み込みストリーム（例: XFile.openRead()）。
+  ///   全量メモリ展開せず、[chunkSize] 単位に遅延分割して書き込む（OOM 回避）。
+  /// - [totalBytes]: 事前取得した総バイト数。0 以下は「サイズ未知」扱い
+  ///   （進捗は速度のみ表示）。
+  /// - [cancelToken]: キャンセル要求。検知時に `SftpFileWriter.abort()` で
+  ///   書き込みを即時中断し、部分ファイルを削除して
+  ///   [TransferCancelledException] を投げる。
+  /// - [onProgress]: 進捗通知。[progressInterval] 間引き＋
+  ///   [TransferSpeedEma] による速度付き（終了時は必ず最終値を通知）。
+  ///
+  /// 失敗時（キャンセル・エラー共通）は部分ファイルを削除して rethrow する。
+  Future<SftpUploadResult> uploadStream({
+    required SftpClient sftp,
+    required String remoteDir,
+    required String filename,
+    required Stream<Uint8List> source,
+    required int totalBytes,
+    int chunkSize = defaultChunkSize,
+    TransferCancelToken? cancelToken,
+    void Function(TransferProgress progress)? onProgress,
+    Duration progressInterval = const Duration(milliseconds: 100),
+  }) async {
+    final effectiveChunkSize = chunkSize <= 0 ? defaultChunkSize : chunkSize;
+    final remotePath = safeRemotePath(remoteDir, filename);
+    await ensureDirectory(sftp, p.dirname(remotePath));
 
     SftpFile? file;
     try {
@@ -81,31 +166,104 @@ class SftpService {
             SftpFileOpenMode.truncate,
       );
 
-      final totalBytes = bytes.length;
-      var written = 0;
+      final speedEma = TransferSpeedEma();
+      final stopwatch = Stopwatch()..start();
+      // 初回は必ず通知するため、前回通知時刻を十分過去に初期化する。
+      var lastNotifyElapsed = -progressInterval.inMilliseconds;
+      final effectiveTotal = totalBytes > 0 ? totalBytes : 0;
 
-      // チャンク分割でストリーム書き込み（進捗追跡用）
-      const chunkSize = 32 * 1024; // 32KB
-      final chunks = <Uint8List>[];
-      for (var offset = 0; offset < totalBytes; offset += chunkSize) {
-        final end = (offset + chunkSize > totalBytes)
-            ? totalBytes
-            : offset + chunkSize;
-        chunks.add(bytes.sublist(offset, end));
+      void handleProgress(int ackedBytes) {
+        if (onProgress == null) return;
+        final elapsed = stopwatch.elapsedMilliseconds;
+        if (elapsed - lastNotifyElapsed < progressInterval.inMilliseconds &&
+            ackedBytes < effectiveTotal) {
+          return;
+        }
+        lastNotifyElapsed = elapsed;
+        onProgress(
+          TransferProgress.fromBytes(
+            ackedBytes,
+            totalBytes: effectiveTotal,
+            bytesPerSec: speedEma.update(ackedBytes),
+          ),
+        );
       }
 
-      final stream = Stream.fromIterable(chunks).map((chunk) {
-        written += chunk.length;
-        onProgress?.call(totalBytes > 0 ? written / totalBytes : 1.0);
-        return chunk;
+      // ストリーム内で例外を投げると dartssh2 側 subscribe で未ハンドルに
+      // なるため、キャンセル/ソースエラーはシグナルで外へ伝える。
+      final cancelSignal = Completer<void>();
+      final errorSignal = Completer<Object>();
+      Object? sourceError;
+
+      final chunked = _chunkedUploadStream(
+        source: source,
+        chunkSize: effectiveChunkSize,
+        cancelToken: cancelToken,
+        onCancelled: () {
+          if (!cancelSignal.isCompleted) cancelSignal.complete();
+        },
+        onError: (error) {
+          sourceError = error;
+          if (!errorSignal.isCompleted) errorSignal.complete(error);
+        },
+      );
+
+      final writer = file.write(chunked, onProgress: handleProgress);
+
+      final outcome = Completer<_UploadOutcome>();
+      writer.done.then(
+        (_) {
+          if (!outcome.isCompleted) outcome.complete(_UploadOutcome.done);
+        },
+        onError: (Object error) {
+          sourceError = error;
+          if (!outcome.isCompleted) {
+            outcome.complete(_UploadOutcome.sourceError);
+          }
+        },
+      );
+      cancelSignal.future.then((_) {
+        if (!outcome.isCompleted) outcome.complete(_UploadOutcome.cancelled);
+      });
+      errorSignal.future.then((_) {
+        if (!outcome.isCompleted) outcome.complete(_UploadOutcome.sourceError);
       });
 
-      final writer = file.write(stream);
-      await writer.done;
-
-      return SftpUploadResult(remotePath: remotePath, bytesWritten: totalBytes);
-    } catch (e) {
-      // 部分ファイルのクリーンアップ試行
+      switch (await outcome.future) {
+        case _UploadOutcome.cancelled:
+          // 書き込みを即時中断する（done 完了後の二重 complete は無視）。
+          try {
+            await writer.abort();
+          } catch (_) {
+            // already completed
+          }
+          throw const TransferCancelledException();
+        case _UploadOutcome.sourceError:
+          throw sourceError!;
+        case _UploadOutcome.done:
+          if (cancelToken?.isCancelled ?? false) {
+            // ストリーム終端とキャンセルが競合した場合もキャンセル扱い
+            throw const TransferCancelledException();
+          }
+          if (onProgress != null) {
+            // 最終進捗（100%）は間引きせず必ず通知する。
+            onProgress(
+              TransferProgress.fromBytes(
+                writer.progress,
+                totalBytes: effectiveTotal > 0
+                    ? effectiveTotal
+                    : writer.progress,
+                bytesPerSec: speedEma.update(writer.progress),
+              ),
+            );
+          }
+          return SftpUploadResult(
+            remotePath: remotePath,
+            bytesWritten: writer.progress,
+          );
+      }
+    } catch (_) {
+      // 部分ファイルのクリーンアップ試行（キャンセル・エラー共通）
       try {
         await sftp.remove(remotePath);
       } catch (_) {
@@ -117,5 +275,54 @@ class SftpService {
     }
   }
 
+  /// 読み込みストリームを [chunkSize] 単位に再構成するジェネレータ。
+  ///
+  /// - 各データ到着時に [cancelToken] を検査し、キャンセルされていれば
+  ///   ストリームを閉じて [onCancelled] を呼ぶ（中断自体は abort で行う）
+  /// - ソースのエラーは再送出せず [onError] へ渡す
+  /// - async* の yield は購読側（SftpFileWriter）の pause/resume に追従する
+  ///   ため、バックプレッシャーがソースまで伝達される
+  Stream<Uint8List> _chunkedUploadStream({
+    required Stream<Uint8List> source,
+    required int chunkSize,
+    required TransferCancelToken? cancelToken,
+    required void Function() onCancelled,
+    required void Function(Object error) onError,
+  }) async* {
+    final buffer = BytesBuilder(copy: false);
+    try {
+      await for (final data in source) {
+        if (cancelToken?.isCancelled ?? false) {
+          onCancelled();
+          return;
+        }
+        buffer.add(data);
+        while (buffer.length >= chunkSize) {
+          final joined = buffer.takeBytes();
+          buffer.add(joined.sublist(chunkSize));
+          yield Uint8List.sublistView(joined, 0, chunkSize);
+        }
+      }
+      if (cancelToken?.isCancelled ?? false) {
+        onCancelled();
+        return;
+      }
+      if (buffer.isNotEmpty) {
+        yield buffer.takeBytes();
+      }
+    } catch (error) {
+      onError(error);
+    }
+  }
+
+  static String _timestamp() {
+    final now = DateTime.now();
+    return '${now.year}${_pad(now.month)}${_pad(now.day)}_'
+        '${_pad(now.hour)}${_pad(now.minute)}${_pad(now.second)}';
+  }
+
   static String _pad(int value) => value.toString().padLeft(2, '0');
 }
+
+/// [SftpService.uploadStream] の内部終了状態。
+enum _UploadOutcome { done, cancelled, sourceError }

--- a/lib/theme/app_theme.dart
+++ b/lib/theme/app_theme.dart
@@ -43,6 +43,11 @@ class AppTheme {
       onPrimaryContainer: DesignColors.primary,
       secondary: DesignColors.primary,
       onSecondary: Colors.black,
+      // 未設定だと SDK が secondary（＝primary）を代用し、M3 の track 色
+      // （secondaryContainer）と indicator（primary）が同色になって
+      // LinearProgressIndicator の進捗が視認できなくなるため明示設定する。
+      secondaryContainer: DesignColors.primary.withValues(alpha: 0.2),
+      onSecondaryContainer: DesignColors.primary,
       surface: DesignColors.surfaceDark,
       onSurface: DesignColors.textPrimary,
       error: DesignColors.error,
@@ -257,6 +262,11 @@ class AppTheme {
       onPrimaryContainer: DesignColors.primaryDark,
       secondary: DesignColors.primary,
       onSecondary: Colors.white,
+      // 未設定だと SDK が secondary（＝primary）を代用し、M3 の track 色
+      // （secondaryContainer）と indicator（primary）が同色になって
+      // LinearProgressIndicator の進捗が視認できなくなるため明示設定する。
+      secondaryContainer: DesignColors.primary.withValues(alpha: 0.1),
+      onSecondaryContainer: DesignColors.primaryDark,
       surface: DesignColors.surfaceLight,
       onSurface: DesignColors.textPrimaryLight,
       error: DesignColors.error,

--- a/test/helpers/fake_sftp_client.dart
+++ b/test/helpers/fake_sftp_client.dart
@@ -21,6 +21,9 @@ class FakeSftpClient implements SftpClient {
   /// `remove()` が呼ばれたファイルパス（部分削除の検証用）。
   final List<String> removeCalls = [];
 
+  /// `open()` が返した [FakeSftpFile]（書き込み内容の検証用・#41）。
+  final List<FakeSftpFile> openedFiles = [];
+
   FakeSftpClient({
     this.entriesByPath = const {},
     this.contentsByPath = const {},
@@ -84,7 +87,9 @@ class FakeSftpClient implements SftpClient {
     String path, {
     SftpFileOpenMode mode = SftpFileOpenMode.read,
   }) async {
-    return FakeSftpFile(this, contentsByPath[path] ?? Uint8List(0));
+    final file = FakeSftpFile(this, contentsByPath[path] ?? Uint8List(0));
+    openedFiles.add(file);
+    return file;
   }
 
   @override

--- a/test/providers/file_transfer_provider_test.dart
+++ b/test/providers/file_transfer_provider_test.dart
@@ -1,0 +1,433 @@
+import 'dart:async';
+
+import 'package:dartssh2/dartssh2.dart'
+    show SftpName, SftpFileAttrs, SftpFileMode;
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_muxpod/providers/file_transfer_provider.dart';
+import 'package:flutter_muxpod/providers/settings_provider.dart';
+import 'package:flutter_muxpod/providers/ssh_provider.dart';
+// XFile は cross_file の正規クラス（file_picker 経由では再エクポートされないため、
+// 直接依存のある image_picker 経由で参照する）。
+import 'package:image_picker/image_picker.dart' show XFile;
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../helpers/fake_sftp_client.dart';
+import '../helpers/fake_ssh_client.dart';
+import '../helpers/fake_ssh_notifier.dart';
+
+/// テスト用の [PlatformFile] 実装（内容をメモリで保持）。
+base class FakePlatformFile extends PlatformFile {
+  @override
+  final String name;
+
+  @override
+  final Uri uri;
+
+  final Uint8List content;
+
+  FakePlatformFile(this.name, {List<int>? content, Uri? uri})
+    : content = Uint8List.fromList(content ?? const []),
+      uri = uri ?? Uri.file('/local/$name');
+
+  @override
+  XFile get xFile => XFile.fromData(content, name: name);
+
+  @override
+  Future<int> length() async => content.length;
+
+  @override
+  Future<Uint8List> readAsBytes() async => content;
+
+  @override
+  Stream<Uint8List> readAsByteStream() => Stream.value(content);
+}
+
+/// 読み込みストリームを外部制御する [PlatformFile]（キャンセル試験用）。
+base class ControlledPlatformFile extends FakePlatformFile {
+  final StreamController<Uint8List> controller = StreamController();
+
+  ControlledPlatformFile(super.name, {super.content});
+
+  @override
+  Stream<Uint8List> readAsByteStream() => controller.stream;
+}
+
+/// 読み込みが必ず失敗する [PlatformFile]。
+base class ThrowingPlatformFile extends FakePlatformFile {
+  ThrowingPlatformFile(super.name);
+
+  @override
+  Stream<Uint8List> readAsByteStream() =>
+      Stream.error(StateError('local read failure'));
+}
+
+/// 非同期イベントを確実に進める。
+Future<void> pumpEvents([int times = 8]) async {
+  for (var i = 0; i < times; i++) {
+    await Future<void>.delayed(Duration.zero);
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform, (_) async => null);
+  });
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform, null);
+  });
+
+  ProviderContainer makeContainer(FakeSshClient sshClient) {
+    final container = ProviderContainer(
+      overrides: [
+        sshProvider.overrideWith(() => FakeSshNotifier(client: sshClient)),
+      ],
+    );
+    addTearDown(container.dispose);
+    return container;
+  }
+
+  group('FileTransferNotifier', () {
+    test('初期状態は idle', () {
+      final container = makeContainer(FakeSshClient());
+      final state = container.read(fileTransferProvider);
+      expect(state.phase, FileTransferPhase.idle);
+      expect(state.items, isEmpty);
+    });
+
+    test('prepare: 衝突なしで confirming になる', () async {
+      final ssh = FakeSshClient();
+      final container = makeContainer(ssh);
+
+      await container
+          .read(fileTransferProvider.notifier)
+          .prepare(
+            files: [FakePlatformFile('a.txt', content: List.filled(10, 1))],
+            remoteDir: '/remote',
+          );
+
+      final state = container.read(fileTransferProvider);
+      expect(state.phase, FileTransferPhase.confirming);
+      expect(state.remoteDir, '/remote');
+      expect(state.items, hasLength(1));
+      expect(state.items.first.fileName, 'a.txt');
+      expect(state.items.first.totalBytes, 10);
+      expect(state.items.first.conflict, isFalse);
+      expect(state.hasConflicts, isFalse);
+    });
+
+    test('prepare: リモート既存ファイルを衝突として検出する', () async {
+      final ssh = FakeSshClient();
+      ssh.sftpClient = FakeSftpClient(
+        entriesByPath: {
+          '/remote/a.txt': [SftpNameFactory.file('a.txt')],
+        },
+      );
+      final container = makeContainer(ssh);
+
+      await container
+          .read(fileTransferProvider.notifier)
+          .prepare(files: [FakePlatformFile('a.txt')], remoteDir: '/remote');
+
+      final state = container.read(fileTransferProvider);
+      expect(state.items.first.conflict, isTrue);
+      expect(state.hasConflicts, isTrue);
+      expect(state.conflictIndexes, [0]);
+    });
+
+    test('prepare: SSH 未接続では error になる', () async {
+      final container = ProviderContainer(
+        overrides: [sshProvider.overrideWith(() => FakeSshNotifier())],
+      );
+      addTearDown(container.dispose);
+
+      await container
+          .read(fileTransferProvider.notifier)
+          .prepare(files: [FakePlatformFile('a.txt')], remoteDir: '/remote');
+
+      final state = container.read(fileTransferProvider);
+      expect(state.phase, FileTransferPhase.error);
+      expect(state.errorMessage, 'ssh-not-available');
+    });
+
+    test('prepare: 空リストでは状態を変えない', () async {
+      final container = makeContainer(FakeSshClient());
+
+      await container
+          .read(fileTransferProvider.notifier)
+          .prepare(files: [], remoteDir: '/remote');
+
+      expect(
+        container.read(fileTransferProvider).phase,
+        FileTransferPhase.idle,
+      );
+    });
+
+    test('start: 単一ファイルを転送して completed になる', () async {
+      final ssh = FakeSshClient();
+      final container = makeContainer(ssh);
+
+      await container
+          .read(fileTransferProvider.notifier)
+          .prepare(
+            files: [FakePlatformFile('a.bin', content: List.filled(300, 7))],
+            remoteDir: '/remote',
+          );
+      await container.read(fileTransferProvider.notifier).start();
+
+      final state = container.read(fileTransferProvider);
+      expect(state.phase, FileTransferPhase.completed);
+      expect(state.items.first.status, FileTransferItemStatus.done);
+      expect(state.items.first.remotePath, '/remote/a.bin');
+      expect(ssh.sftpClient.openedFiles.single.content.length, 300);
+      expect(state.doneCount, 1);
+    });
+
+    test('start: 衝突 + overwrite は元名で上書き転送する', () async {
+      final ssh = FakeSshClient();
+      ssh.sftpClient = FakeSftpClient(
+        entriesByPath: {
+          '/remote/a.txt': [SftpNameFactory.file('a.txt')],
+        },
+      );
+      final container = makeContainer(ssh);
+
+      await container
+          .read(fileTransferProvider.notifier)
+          .prepare(files: [FakePlatformFile('a.txt')], remoteDir: '/remote');
+      container
+          .read(fileTransferProvider.notifier)
+          .setConflictResolution(0, ConflictResolution.overwrite);
+      await container.read(fileTransferProvider.notifier).start();
+
+      final state = container.read(fileTransferProvider);
+      expect(state.items.first.status, FileTransferItemStatus.done);
+      expect(state.items.first.remotePath, '/remote/a.txt');
+    });
+
+    test('start: 衝突 + rename はユニーク名で転送する', () async {
+      final ssh = FakeSshClient();
+      ssh.sftpClient = FakeSftpClient(
+        entriesByPath: {
+          '/remote/a.txt': [SftpNameFactory.file('a.txt')],
+        },
+      );
+      final container = makeContainer(ssh);
+
+      await container
+          .read(fileTransferProvider.notifier)
+          .prepare(files: [FakePlatformFile('a.txt')], remoteDir: '/remote');
+      container
+          .read(fileTransferProvider.notifier)
+          .setConflictResolution(0, ConflictResolution.rename);
+      await container.read(fileTransferProvider.notifier).start();
+
+      final state = container.read(fileTransferProvider);
+      expect(state.items.first.status, FileTransferItemStatus.done);
+      expect(
+        state.items.first.remotePath,
+        matches(RegExp(r'^/remote/a_\d{8}_\d{6}_[a-f0-9]{4}\.txt$')),
+      );
+    });
+
+    test('start: 衝突未解決（prompt 既定）はそのファイルをスキップする', () async {
+      final ssh = FakeSshClient();
+      ssh.sftpClient = FakeSftpClient(
+        entriesByPath: {
+          '/remote/a.txt': [SftpNameFactory.file('a.txt')],
+        },
+      );
+      final container = makeContainer(ssh);
+
+      await container
+          .read(fileTransferProvider.notifier)
+          .prepare(
+            files: [FakePlatformFile('a.txt'), FakePlatformFile('b.txt')],
+            remoteDir: '/remote',
+          );
+      await container.read(fileTransferProvider.notifier).start();
+
+      final state = container.read(fileTransferProvider);
+      expect(state.phase, FileTransferPhase.completed);
+      expect(state.items[0].status, FileTransferItemStatus.skipped);
+      expect(state.items[1].status, FileTransferItemStatus.done);
+    });
+
+    test('start: autoRename 設定では衝突を確認なしでリネームする', () async {
+      final ssh = FakeSshClient();
+      ssh.sftpClient = FakeSftpClient(
+        entriesByPath: {
+          '/remote/a.txt': [SftpNameFactory.file('a.txt')],
+        },
+      );
+      final container = makeContainer(ssh);
+
+      await container
+          .read(settingsProvider.notifier)
+          .setUploadConflictPolicy(TransferConflictPolicy.autoRename);
+
+      await container
+          .read(fileTransferProvider.notifier)
+          .prepare(files: [FakePlatformFile('a.txt')], remoteDir: '/remote');
+      await container.read(fileTransferProvider.notifier).start();
+
+      final state = container.read(fileTransferProvider);
+      expect(state.items.first.status, FileTransferItemStatus.done);
+      expect(state.items.first.remotePath, isNot('/remote/a.txt'));
+      expect(
+        state.items.first.remotePath,
+        matches(RegExp(r'^/remote/a_\d{8}_\d{6}_[a-f0-9]{4}\.txt$')),
+      );
+    });
+
+    test('start: 複数ファイル（並列数2）を全て転送する', () async {
+      final ssh = FakeSshClient();
+      final container = makeContainer(ssh);
+
+      await container
+          .read(fileTransferProvider.notifier)
+          .prepare(
+            files: [
+              FakePlatformFile('a.bin', content: List.filled(50, 1)),
+              FakePlatformFile('b.bin', content: List.filled(60, 2)),
+              FakePlatformFile('c.bin', content: List.filled(70, 3)),
+            ],
+            remoteDir: '/remote',
+          );
+      await container.read(fileTransferProvider.notifier).start();
+
+      final state = container.read(fileTransferProvider);
+      expect(state.phase, FileTransferPhase.completed);
+      expect(state.doneCount, 3);
+      expect(ssh.sftpClient.openedFiles, hasLength(3));
+    });
+
+    test('start: バッチ内の重複名は後続を自動リネームする', () async {
+      final ssh = FakeSshClient();
+      final container = makeContainer(ssh);
+
+      await container
+          .read(fileTransferProvider.notifier)
+          .prepare(
+            files: [FakePlatformFile('dup.txt'), FakePlatformFile('dup.txt')],
+            remoteDir: '/remote',
+          );
+      await container.read(fileTransferProvider.notifier).start();
+
+      final state = container.read(fileTransferProvider);
+      expect(state.doneCount, 2);
+      expect(state.items[0].remotePath, '/remote/dup.txt');
+      expect(state.items[1].remotePath, isNot('/remote/dup.txt'));
+    });
+
+    test('start: ソースエラーはそのファイルのみ failed にする', () async {
+      final ssh = FakeSshClient();
+      final container = makeContainer(ssh);
+
+      await container
+          .read(fileTransferProvider.notifier)
+          .prepare(
+            files: [
+              ThrowingPlatformFile('bad.txt'),
+              FakePlatformFile('ok.txt'),
+            ],
+            remoteDir: '/remote',
+          );
+      await container.read(fileTransferProvider.notifier).start();
+
+      final state = container.read(fileTransferProvider);
+      expect(state.phase, FileTransferPhase.completed);
+      expect(state.items[0].status, FileTransferItemStatus.failed);
+      expect(state.items[0].error, isStateError);
+      expect(state.items[1].status, FileTransferItemStatus.done);
+    });
+
+    test('cancelFile: 指定ファイルのみキャンセル（skipped）する', () async {
+      final ssh = FakeSshClient();
+      final container = makeContainer(ssh);
+      final controlled = ControlledPlatformFile('big.bin');
+
+      await container
+          .read(fileTransferProvider.notifier)
+          .prepare(
+            files: [controlled, FakePlatformFile('ok.txt')],
+            remoteDir: '/remote',
+          );
+      final startFuture = container.read(fileTransferProvider.notifier).start();
+      await pumpEvents();
+
+      // 制御側ストリームの初回チャンク到着後にキャンセル要求 → 次チャンクで中断
+      controlled.controller.add(Uint8List.fromList(List.filled(10, 1)));
+      await pumpEvents();
+      container.read(fileTransferProvider.notifier).cancelFile(0);
+      controlled.controller.add(Uint8List.fromList(List.filled(100, 2)));
+      await pumpEvents();
+      await controlled.controller.close();
+      await startFuture;
+
+      final state = container.read(fileTransferProvider);
+      expect(state.phase, FileTransferPhase.completed);
+      expect(state.items[0].status, FileTransferItemStatus.skipped);
+      expect(state.items[1].status, FileTransferItemStatus.done);
+      // キャンセルされたファイルの部分ファイルは削除される
+      expect(ssh.sftpClient.removeCalls, contains('/remote/big.bin'));
+    });
+
+    test('cancelAll: 転送全体をキャンセルする', () async {
+      final ssh = FakeSshClient();
+      final container = makeContainer(ssh);
+      final controlled = ControlledPlatformFile('big.bin');
+
+      await container
+          .read(fileTransferProvider.notifier)
+          .prepare(files: [controlled], remoteDir: '/remote');
+      final startFuture = container.read(fileTransferProvider.notifier).start();
+      await pumpEvents();
+
+      controlled.controller.add(Uint8List.fromList(List.filled(10, 1)));
+      await pumpEvents();
+      container.read(fileTransferProvider.notifier).cancelAll();
+      controlled.controller.add(Uint8List.fromList(List.filled(100, 2)));
+      await pumpEvents();
+      await controlled.controller.close();
+      await startFuture;
+
+      final state = container.read(fileTransferProvider);
+      expect(state.phase, FileTransferPhase.cancelled);
+      expect(state.items.first.status, FileTransferItemStatus.skipped);
+      expect(ssh.sftpClient.removeCalls, contains('/remote/big.bin'));
+    });
+
+    test('reset: 状態を idle に戻す', () async {
+      final ssh = FakeSshClient();
+      final container = makeContainer(ssh);
+
+      await container
+          .read(fileTransferProvider.notifier)
+          .prepare(files: [FakePlatformFile('a.txt')], remoteDir: '/remote');
+      await container.read(fileTransferProvider.notifier).start();
+      container.read(fileTransferProvider.notifier).reset();
+
+      final state = container.read(fileTransferProvider);
+      expect(state.phase, FileTransferPhase.idle);
+      expect(state.items, isEmpty);
+    });
+  });
+}
+
+/// テスト用 [SftpName] ファクトリ。
+class SftpNameFactory {
+  static SftpName file(String name) => SftpName(
+    filename: name,
+    longname: '-rw-r--r--',
+    attr: SftpFileAttrs(mode: SftpFileMode.value(0x81A4)),
+  );
+}

--- a/test/providers/settings_search_provider_test.dart
+++ b/test/providers/settings_search_provider_test.dart
@@ -118,19 +118,19 @@ void main() {
       final systemIndex = container.read(settingsSearchIndexProvider);
       expect(
         systemIndex.items.length,
-        36,
+        39,
       ); // Display10+Behavior13+Connection10+About3
       expect(systemIndex.current, isNotNull);
       expect(systemIndex.other, isNotNull);
 
       await setLanguage('ja');
       final jaIndex = container.read(settingsSearchIndexProvider);
-      expect(jaIndex.items.length, 36);
+      expect(jaIndex.items.length, 39);
       expect(jaIndex.other, isNotNull); // en 側も並置
 
       await setLanguage('en');
       final enIndex = container.read(settingsSearchIndexProvider);
-      expect(enIndex.items.length, 36);
+      expect(enIndex.items.length, 39);
       expect(enIndex.other, isNotNull); // ja 側も並置
     });
   });
@@ -252,11 +252,11 @@ void main() {
     });
   });
 
-  group('検索対象の完全性（全36項目）', () {
-    test('36項目すべてが descriptor に存在しカテゴリと order が一意', () {
+  group('検索対象の完全性（全39項目）', () {
+    test('39項目すべてが descriptor に存在しカテゴリと order が一意', () {
       final index = container.read(settingsSearchIndexProvider);
       final ids = index.items.map((e) => e.id).toList();
-      expect(ids.toSet().length, 36);
+      expect(ids.toSet().length, 39);
       // カテゴリ内 order が一意（0..n-1 の重複なし）
       for (final category in SettingsCategory.values) {
         final perCategory =
@@ -279,7 +279,7 @@ void main() {
         index.items
             .where((e) => e.category == SettingsCategory.connection)
             .length,
-        10,
+        13,
       );
       expect(
         index.items.where((e) => e.category == SettingsCategory.about).length,

--- a/test/screens/file_browser/file_browser_upload_test.dart
+++ b/test/screens/file_browser/file_browser_upload_test.dart
@@ -1,0 +1,239 @@
+import 'dart:async';
+
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_muxpod/l10n/app_localizations.dart';
+import 'package:flutter_muxpod/providers/ssh_provider.dart';
+import 'package:flutter_muxpod/providers/tmux_provider.dart';
+import 'package:flutter_muxpod/screens/file_browser/file_browser_screen.dart';
+import 'package:image_picker/image_picker.dart' show XFile;
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../helpers/fake_sftp_client.dart';
+import '../../helpers/fake_ssh_client.dart';
+import '../../helpers/fake_ssh_notifier.dart';
+import '../../helpers/fake_tmux_notifier.dart';
+
+/// テスト用の [PlatformFile] 実装。
+base class FakePlatformFile extends PlatformFile {
+  @override
+  final String name;
+
+  @override
+  final Uri uri;
+
+  final Uint8List content;
+
+  FakePlatformFile(this.name, {List<int>? content})
+    : content = Uint8List.fromList(content ?? const []),
+      uri = Uri.file('/local/$name');
+
+  @override
+  XFile get xFile => XFile.fromData(content, name: name);
+
+  @override
+  Future<int> length() async => content.length;
+
+  @override
+  Future<Uint8List> readAsBytes() async => content;
+
+  @override
+  Stream<Uint8List> readAsByteStream() => Stream.value(content);
+}
+
+/// 読み込みストリームを外部制御する [PlatformFile]。
+base class ControlledPlatformFile extends FakePlatformFile {
+  final StreamController<Uint8List> controller = StreamController();
+
+  ControlledPlatformFile(super.name);
+
+  @override
+  Stream<Uint8List> readAsByteStream() => controller.stream;
+}
+
+/// pickFiles が固定リストを返す fake プラットフォーム。
+class FakeFilePickerPlatform extends FilePickerPlatform {
+  List<PlatformFile> filesToReturn = [];
+
+  @override
+  Future<List<PlatformFile>> pickFiles({
+    String? dialogTitle,
+    String? initialDirectory,
+    FileType type = FileType.any,
+    List<String>? allowedExtensions,
+    Function(FilePickerStatus)? onFileLoading,
+    int compressionQuality = 0,
+    bool allowMultiple = true,
+    bool withData = false,
+    bool withReadStream = false,
+    bool lockParentWindow = false,
+    bool readSequential = false,
+    bool cancelUploadOnWindowBlur = true,
+    Object? androidSafOptions,
+    AndroidOptions androidOptions = const AndroidOptions(),
+    WindowsOptions windowsOptions = const WindowsOptions(),
+    LinuxOptions linuxOptions = const LinuxOptions(),
+    WebOptions webOptions = const WebOptions(),
+  }) async {
+    return filesToReturn;
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late FakeFilePickerPlatform picker;
+  late FakeSshClient ssh;
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform, (_) async => null);
+    picker = FakeFilePickerPlatform();
+    FilePickerPlatform.instance = picker;
+    ssh = FakeSshClient();
+  });
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform, null);
+  });
+
+  Future<void> pumpScreen(WidgetTester tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          sshProvider.overrideWith(() => FakeSshNotifier(client: ssh)),
+          tmuxProvider.overrideWith(
+            () => FakeTmuxNotifier(initialState: const TmuxState()),
+          ),
+        ],
+        child: MaterialApp(
+          locale: const Locale('ja'),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: const FileBrowserScreen(connectionId: 'c1'),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('アップロードボタンが表示される', (tester) async {
+    await pumpScreen(tester);
+    expect(find.byTooltip('アップロード'), findsOneWidget);
+  });
+
+  testWidgets('衝突なし: 選択→転送→成功SnackBarにリモートパスが出る', (tester) async {
+    await pumpScreen(tester);
+    picker.filesToReturn = [
+      FakePlatformFile('a.txt', content: [1, 2, 3]),
+    ];
+
+    await tester.tap(find.byTooltip('アップロード'));
+    await tester.pumpAndSettle();
+
+    // 初期ディレクトリはホーム（FakeSshClient の SFTP fake のホーム）
+    expect(find.text('/home/user/a.txt にアップロードしました'), findsOneWidget);
+    expect(ssh.sftpClient.openedFiles, hasLength(1));
+    expect(ssh.sftpClient.openedFiles.single.content, [1, 2, 3]);
+    expect(ssh.sftpClient.removeCalls, isEmpty);
+  });
+
+  testWidgets('衝突あり: 上書き確認ダイアログ→上書きで元名転送', (tester) async {
+    ssh.sftpClient = FakeSftpClient(entriesByPath: {'/home/user/a.txt': []});
+    await pumpScreen(tester);
+    picker.filesToReturn = [
+      FakePlatformFile('a.txt', content: [9]),
+    ];
+
+    await tester.tap(find.byTooltip('アップロード'));
+    await tester.pumpAndSettle();
+
+    // 基盤の上書き確認ダイアログ（single モード）
+    expect(find.text('ファイルが既に存在します'), findsOneWidget);
+    expect(find.text('上書き'), findsOneWidget);
+    expect(find.text('リネーム'), findsOneWidget);
+    expect(find.text('キャンセル'), findsOneWidget);
+
+    await tester.tap(find.text('上書き'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('/home/user/a.txt にアップロードしました'), findsOneWidget);
+    expect(ssh.sftpClient.openedFiles, hasLength(1));
+  });
+
+  testWidgets('衝突あり: リネームでユニーク名転送', (tester) async {
+    ssh.sftpClient = FakeSftpClient(entriesByPath: {'/home/user/a.txt': []});
+    await pumpScreen(tester);
+    picker.filesToReturn = [
+      FakePlatformFile('a.txt', content: [9]),
+    ];
+
+    await tester.tap(find.byTooltip('アップロード'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('リネーム'));
+    await tester.pumpAndSettle();
+
+    // ユニーク名（a_YYYYMMDD_HHMMSS_xxxx.txt）で転送される
+    final snackBarText = tester
+        .widget<SnackBar>(find.byType(SnackBar))
+        .content
+        .toString();
+    expect(
+      RegExp(
+        r'a_\d{8}_\d{6}_[a-f0-9]{4}\.txt にアップロードしました',
+      ).hasMatch(snackBarText),
+      isTrue,
+      reason: 'SnackBar: $snackBarText',
+    );
+    expect(ssh.sftpClient.openedFiles, hasLength(1));
+  });
+
+  testWidgets('衝突あり: キャンセルで中止し転送しない', (tester) async {
+    ssh.sftpClient = FakeSftpClient(entriesByPath: {'/home/user/a.txt': []});
+    await pumpScreen(tester);
+    picker.filesToReturn = [
+      FakePlatformFile('a.txt', content: [9]),
+    ];
+
+    await tester.tap(find.byTooltip('アップロード'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('キャンセル'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('アップロードをキャンセルしました'), findsOneWidget);
+    expect(ssh.sftpClient.openedFiles, isEmpty);
+  });
+
+  testWidgets('転送中: 進捗パネルとキャンセルボタンが表示される', (tester) async {
+    await pumpScreen(tester);
+    final controlled = ControlledPlatformFile('big.bin');
+    picker.filesToReturn = [controlled];
+
+    await tester.tap(find.byTooltip('アップロード'));
+    // 進捗パネルの CircularProgressIndicator は無限アニメーションのため
+    // pumpAndSettle ではなく pump で進める。
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+    await tester.pump(const Duration(milliseconds: 100));
+
+    // 転送を保留した状態でパネル・キャンセル導線が表示される
+    expect(find.text('すべてキャンセル'), findsOneWidget);
+    expect(find.text('big.bin'), findsOneWidget);
+
+    // 保留していたストリームを完結させると通常転送として終了する
+    // （キャンセル伝播の非同期フロー自体は provider テストで検証済み）
+    controlled.controller.add(Uint8List.fromList(List.filled(10, 1)));
+    await controlled.controller.close();
+    await tester.pumpAndSettle();
+
+    expect(ssh.sftpClient.openedFiles.single.content, hasLength(10));
+    expect(find.text('/home/user/big.bin にアップロードしました'), findsOneWidget);
+    // 完了後はパネルが消える
+    expect(find.text('すべてキャンセル'), findsNothing);
+  });
+}

--- a/test/services/sftp/sftp_service_test.dart
+++ b/test/services/sftp/sftp_service_test.dart
@@ -1,5 +1,18 @@
+import 'dart:async';
+import 'dart:typed_data';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_muxpod/services/sftp/sftp_service.dart';
+import 'package:flutter_muxpod/services/sftp/transfer_progress.dart';
+
+import '../../helpers/fake_sftp_client.dart';
+
+/// 非同期イベント（StreamController → SftpFileWriter）を確実に進める。
+Future<void> pumpEvents([int times = 8]) async {
+  for (var i = 0; i < times; i++) {
+    await Future<void>.delayed(Duration.zero);
+  }
+}
 
 void main() {
   group('SftpService', () {
@@ -73,6 +86,319 @@ void main() {
         final result = SftpService.generateFilename('my file', 'txt');
         expect(result, startsWith('my_file'));
         expect(result, endsWith('.txt'));
+      });
+    });
+
+    group('generateUniqueName（#41）', () {
+      test('元名ベース・拡張子保持のユニーク名が生成される', () {
+        final result = SftpService.generateUniqueName('report.pdf');
+        expect(
+          result,
+          matches(RegExp(r'^report_\d{8}_\d{6}_[a-f0-9]{4}\.pdf$')),
+        );
+      });
+
+      test('日本語の元名が保持される', () {
+        final result = SftpService.generateUniqueName('ファイル.txt');
+        expect(result, startsWith('ファイル_'));
+        expect(result, endsWith('.txt'));
+      });
+
+      test('拡張子なしのファイル名も処理される', () {
+        final result = SftpService.generateUniqueName('README');
+        expect(result, matches(RegExp(r'^README_\d{8}_\d{6}_[a-f0-9]{4}$')));
+      });
+
+      test('パス区切りを含む名前はベース名のみ使われる', () {
+        final result = SftpService.generateUniqueName('/local/dir/画像.png');
+        expect(result, startsWith('画像_'));
+        expect(result, endsWith('.png'));
+      });
+
+      test('生成される名前は一意である', () {
+        final results = <String>{
+          for (var i = 0; i < 10; i++) SftpService.generateUniqueName('a.txt'),
+        };
+        expect(results.length, greaterThan(1));
+      });
+    });
+
+    group('safeRemotePath（#41）', () {
+      test('ディレクトリとファイル名を連結する', () {
+        expect(
+          SftpService.safeRemotePath('/tmp/muxpod', 'a.txt'),
+          '/tmp/muxpod/a.txt',
+        );
+      });
+
+      test('末尾スラッシュ付きディレクトリも正しく連結する', () {
+        expect(
+          SftpService.safeRemotePath('/tmp/muxpod/', 'a.txt'),
+          '/tmp/muxpod/a.txt',
+        );
+      });
+
+      test('パストラバーサル（../）は basename で除去される', () {
+        expect(
+          SftpService.safeRemotePath('/remote', '../../../etc/passwd'),
+          '/remote/passwd',
+        );
+      });
+
+      test('絶対パス形式のファイル名もベース名のみ使われる', () {
+        expect(
+          SftpService.safeRemotePath('/remote', '/etc/shadow'),
+          '/remote/shadow',
+        );
+      });
+
+      test('日本語ファイル名はそのまま保持される', () {
+        expect(
+          SftpService.safeRemotePath('/remote', 'ファイル.png'),
+          '/remote/ファイル.png',
+        );
+      });
+
+      test('ルートディレクトリへの連結も機能する', () {
+        expect(SftpService.safeRemotePath('/', 'a.txt'), '/a.txt');
+      });
+    });
+
+    group('remoteFileExists（#41）', () {
+      test('存在するパスは true', () async {
+        final fake = FakeSftpClient();
+        expect(await SftpService.remoteFileExists(fake, '/'), isTrue);
+      });
+
+      test('存在しないパスは false（SftpStatusError を捕捉）', () async {
+        final fake = FakeSftpClient();
+        expect(
+          await SftpService.remoteFileExists(fake, '/remote/none.txt'),
+          isFalse,
+        );
+      });
+    });
+
+    group('uploadStream（#41）', () {
+      late SftpService service;
+      late FakeSftpClient fake;
+
+      setUp(() {
+        service = SftpService();
+        fake = FakeSftpClient();
+      });
+
+      Uint8List bytes(int length, {int fill = 0x41}) =>
+          Uint8List.fromList(List.filled(length, fill));
+
+      test('全チャンクを書き込み結果を返す', () async {
+        final result = await service.uploadStream(
+          sftp: fake,
+          remoteDir: '/remote',
+          filename: 'a.bin',
+          source: Stream.value(bytes(300)),
+          totalBytes: 300,
+          chunkSize: 100,
+        );
+
+        expect(result.remotePath, '/remote/a.bin');
+        expect(result.bytesWritten, 300);
+        expect(fake.openedFiles.single.content.length, 300);
+        // 成功時は部分削除が行われない
+        expect(fake.removeCalls, isEmpty);
+      });
+
+      test('進捗（間引きなし）は doneBytes が増加し最終値が総量に一致する', () async {
+        final progressList = <TransferProgress>[];
+        final result = await service.uploadStream(
+          sftp: fake,
+          remoteDir: '/remote',
+          filename: 'a.bin',
+          source: Stream.value(bytes(300)),
+          totalBytes: 300,
+          chunkSize: 100,
+          progressInterval: Duration.zero,
+          onProgress: progressList.add,
+        );
+
+        expect(result.bytesWritten, 300);
+        // 16KB 分割された acked 进捗が複数回通知される
+        expect(progressList.length, greaterThan(1));
+        var previous = 0;
+        for (final p in progressList) {
+          expect(p.doneBytes, greaterThanOrEqualTo(previous));
+          expect(p.totalBytes, 300);
+          previous = p.doneBytes;
+        }
+        expect(progressList.last.doneBytes, 300);
+      });
+
+      test('既定の間引き（100ms）では高速転送時に通知が抑制される', () async {
+        final progressList = <TransferProgress>[];
+        await service.uploadStream(
+          sftp: fake,
+          remoteDir: '/remote',
+          filename: 'a.bin',
+          source: Stream.value(bytes(300)),
+          totalBytes: 300,
+          chunkSize: 100,
+          onProgress: progressList.add,
+        );
+
+        // 初回＋最終（強制通知）のみ。中間 16KB 通知は間引きで抑制される。
+        expect(progressList.length, lessThanOrEqualTo(3));
+        expect(progressList.first.doneBytes, greaterThan(0));
+        expect(progressList.last.doneBytes, 300);
+        expect(progressList.last.bytesPerSec, greaterThanOrEqualTo(0));
+      });
+
+      test('サイズ未知（totalBytes=0）でも転送は完了する', () async {
+        final result = await service.uploadStream(
+          sftp: fake,
+          remoteDir: '/remote',
+          filename: 'a.bin',
+          source: Stream.value(bytes(50)),
+          totalBytes: 0,
+          chunkSize: 100,
+        );
+
+        expect(result.bytesWritten, 50);
+      });
+
+      test('空ファイル（空ストリーム）を処理する', () async {
+        final result = await service.uploadStream(
+          sftp: fake,
+          remoteDir: '/remote',
+          filename: 'empty.bin',
+          source: const Stream.empty(),
+          totalBytes: 0,
+          chunkSize: 100,
+        );
+
+        expect(result.bytesWritten, 0);
+        expect(result.remotePath, '/remote/empty.bin');
+        expect(fake.removeCalls, isEmpty);
+      });
+
+      test('転送途中のキャンセルは部分ファイルを削除し例外を投げる', () async {
+        final controller = StreamController<Uint8List>();
+        final token = TransferCancelToken();
+
+        final future = service.uploadStream(
+          sftp: fake,
+          remoteDir: '/remote',
+          filename: 'a.bin',
+          source: controller.stream,
+          totalBytes: 300,
+          chunkSize: 100,
+          cancelToken: token,
+        );
+        final expectation = expectLater(
+          future,
+          throwsA(isA<TransferCancelledException>()),
+        );
+
+        await pumpEvents();
+        controller.add(bytes(60));
+        await pumpEvents();
+        token.cancel();
+        controller.add(bytes(240));
+        await pumpEvents();
+        await controller.close();
+
+        await expectation;
+        expect(fake.removeCalls, contains('/remote/a.bin'));
+      });
+
+      test('ソースストリームのエラーは rethrow され部分ファイルを削除する', () async {
+        final controller = StreamController<Uint8List>();
+        final future = service.uploadStream(
+          sftp: fake,
+          remoteDir: '/remote',
+          filename: 'a.bin',
+          source: controller.stream,
+          totalBytes: 300,
+          chunkSize: 100,
+        );
+        final expectation = expectLater(future, throwsStateError);
+
+        await pumpEvents();
+        controller.add(bytes(50));
+        controller.addError(StateError('local read failure'));
+        await controller.close();
+        await pumpEvents();
+
+        await expectation;
+        expect(fake.removeCalls, contains('/remote/a.bin'));
+      });
+
+      test('日本語ファイル名はサニタイズされず保持される', () async {
+        final result = await service.uploadStream(
+          sftp: fake,
+          remoteDir: '/remote',
+          filename: 'ファイル.png',
+          source: Stream.value(bytes(10)),
+          totalBytes: 10,
+          chunkSize: 100,
+        );
+
+        expect(result.remotePath, '/remote/ファイル.png');
+      });
+
+      test('ファイル名のパストラバーサルは basename で防御される', () async {
+        final result = await service.uploadStream(
+          sftp: fake,
+          remoteDir: '/remote',
+          filename: '../../etc/passwd',
+          source: Stream.value(bytes(10)),
+          totalBytes: 10,
+          chunkSize: 100,
+        );
+
+        expect(result.remotePath, '/remote/passwd');
+      });
+
+      test('SftpClient は close されない（close 禁止契約）', () async {
+        await service.uploadStream(
+          sftp: fake,
+          remoteDir: '/remote',
+          filename: 'a.bin',
+          source: Stream.value(bytes(10)),
+          totalBytes: 10,
+          chunkSize: 100,
+        );
+
+        expect(fake.closeCalls, 0);
+      });
+    });
+
+    group('upload（既存API・uploadStream 移譲）', () {
+      late SftpService service;
+      late FakeSftpClient fake;
+
+      setUp(() {
+        service = SftpService();
+        fake = FakeSftpClient();
+      });
+
+      test('バイト全体をアップロードし進捗は 0.0〜1.0 で通知される', () async {
+        final progressList = <double>[];
+        final result = await service.upload(
+          sftp: fake,
+          remoteDir: '/tmp/muxpod',
+          filename: 'img_20260403_143025_a3f2.png',
+          bytes: Uint8List.fromList(List.filled(300, 1)),
+          onProgress: progressList.add,
+        );
+
+        expect(result.remotePath, '/tmp/muxpod/img_20260403_143025_a3f2.png');
+        expect(result.bytesWritten, 300);
+        expect(fake.openedFiles.single.content.length, 300);
+        expect(progressList, isNotEmpty);
+        expect(progressList.last, 1.0);
+        for (final p in progressList) {
+          expect(p, inInclusiveRange(0.0, 1.0));
+        }
       });
     });
   });

--- a/test/theme/app_theme_test.dart
+++ b/test/theme/app_theme_test.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_muxpod/theme/app_theme.dart';
+import 'package:flutter_muxpod/theme/design_colors.dart';
+
+/// テーマのカラースキーム回帰テスト。
+///
+/// 背景: secondaryContainer を未設定のまま ColorScheme.dark/light を作ると、
+/// SDK は `secondaryContainer => _secondaryContainer ?? secondary` で
+/// secondary（＝本アプリでは primary と同色）を代用する。
+/// M3 の LinearProgressIndicator は track 色に secondaryContainer を使うため、
+/// 結果として track（未進行）と indicator（進行）が同色になり、
+/// 転送進捗が視認できなくなる（Issue #41 の検証で発見）。
+void main() {
+  test('dark: secondaryContainer は primary と別トーン（track が視認できる）', () {
+    final scheme = AppTheme.dark.colorScheme;
+
+    expect(scheme.secondary, DesignColors.primary);
+    expect(
+      scheme.secondaryContainer,
+      isNot(DesignColors.primary),
+      reason:
+          'secondaryContainer が primary と同色だと LinearProgressIndicator '
+          'の track と indicator が区別できず進捗が見えない',
+    );
+    // 半透明で primary 由来の色であること
+    expect((scheme.secondaryContainer.a * 255).round(), lessThan(255));
+  });
+
+  test('light: secondaryContainer は primary と別トーン（track が視認できる）', () {
+    final scheme = AppTheme.light.colorScheme;
+
+    expect(scheme.secondary, DesignColors.primary);
+    expect(
+      scheme.secondaryContainer,
+      isNot(DesignColors.primary),
+      reason:
+          'secondaryContainer が primary と同色だと LinearProgressIndicator '
+          'の track と indicator が区別できず進捗が見えない',
+    );
+    expect((scheme.secondaryContainer.a * 255).round(), lessThan(255));
+  });
+
+  testWidgets('LinearProgressIndicator の track 色が indicator と同色にならない', (
+    tester,
+  ) async {
+    // value=0.3 のバーを AppTheme.dark で描画し、track（未進行部分）の色が
+    // indicator（primary）と異なることをカスタムペイント結果ではなく
+    // テーマ経由で検証する（描画色は painter 内部で決定されるため、
+    // ここではテーマ保証を確認する）。
+    await tester.pumpWidget(
+      MaterialApp(theme: AppTheme.dark, home: const Scaffold()),
+    );
+    final scheme = Theme.of(tester.element(find.byType(Scaffold))).colorScheme;
+    expect(scheme.secondaryContainer, isNot(scheme.primary));
+  });
+}


### PR DESCRIPTION
Closes #41

## Summary

- Implements general file upload (#41) entry-pointed from the **SFTP file browser screen**, reusing shared foundation components (PR #104) and coexisting with the existing image transfer flow (#29). Terminal-related items (path injection) are out of scope per the agreed plan.
- `SftpService.uploadStream`: stream-based chunked upload (memory-safe for large files), 100ms-throttled progress with EMA speed, immediate cancellation via `TransferCancelToken` + `SftpFileWriter.abort()` with partial-file cleanup, and traversal-safe remote path joining that preserves multi-byte (Japanese) filenames.
- `FileTransferProvider`: state machine (idle → confirming → uploading → completed/cancelled/error) with **parallel uploads (1..8, configurable)**, per-file and global cancel tokens, SSH disconnect monitoring, and conflict resolution (overwrite / rename / skip-safe default with `TransferConflictPolicy`).
- `FileBrowserScreen`: upload button in the app bar (browsing stays available during transfers), multi-file selection via file_picker, conflict confirmation with the shared `showOverwriteConfirmDialog` (single mode; dismiss = abort), progress panel built on the shared `TransferProgressRow` with per-file cancel and overall i/N counter, and success/failure feedback via SnackBar including the uploaded remote path.
- Settings: "File Transfer" group in the Connection category (conflict policy picker, parallel uploads, chunk size in KB) with search support; l10n keys for en/ja.

## Changes

| Area | Files | Purpose |
|---|---|---|
| Service | `lib/services/sftp/sftp_service.dart` | `uploadStream` + `safeRemotePath` / `generateUniqueName` / `remoteFileExists`; existing `upload(bytes)` delegates for compatibility |
| Provider | `lib/providers/file_transfer_provider.dart` (new), `lib/providers/settings_provider.dart` | Transfer state machine + `TransferConflictPolicy` and upload settings persistence |
| UI | `lib/screens/file_browser/file_browser_screen.dart`, `lib/screens/settings/sections/connection_section.dart`, `lib/screens/settings/pickers/conflict_policy_picker.dart` (new) | Upload entry, conflict flow, progress panel, settings group |
| l10n | `lib/l10n/app_en.arb`, `app_ja.arb` | `fileUpload*` / `settingsUpload*` keys |
| Tests | `test/services/sftp/sftp_service_test.dart` (+29), `test/providers/file_transfer_provider_test.dart` (+16, new), `test/screens/file_browser/file_browser_upload_test.dart` (+6, new), `test/helpers/fake_sftp_client.dart`, `test/providers/settings_search_provider_test.dart` | Unit / provider / widget coverage incl. cancel, throttle, Japanese filenames, traversal defense, conflict flows |

## Test plan

- [x] `make analyze` — No issues found (HEAD `ae3da44`)
- [x] `flutter test --exclude-tags=repro` — +1591 all passed (same condition as CI)
- [x] `dart format --set-exit-if-changed --output=none lib test` — 0 changed
- [x] Manual verification on Android emulator (API 35) against a real SSH server, evidence attached as a PR comment (upload success SnackBar with remote path, filename conflict dialog with overwrite/rename, batch upload of 2 files with Japanese filename preserved and unique auto-rename, progress panel with bytes/speed/cancel, File Transfer settings group; remote file hashes verified against local originals)
- `test/repro/*` tests are excluded by CI tag (they require a local sshd fixture key and fail identically on `main`)

## Notes

- Cancellation uses `SftpFileWriter.abort()` from dartssh2 2.22.5 for immediate write interruption.
- Defaults (parallel uploads = 2, chunk size = 256 KB) are intended to be tuned after real-device measurements.
- Implementation plan (Rev.2) and implementation report are linked in the project knowledge base.