### PR TITLE
fix(tmux): use printable field/record delimiters (session list is empty on tmux 3.7)

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1222,6 +1222,7 @@
       }
     }
   },
+  "connTmuxOutputUnparsable": "tmux output could not be parsed (no delimiters found)",
   "connTmuxCommandFailed": "tmux command failed (exit code: {code})",
   "@connTmuxCommandFailed": {
     "placeholders": {

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -1222,6 +1222,7 @@
       }
     }
   },
+  "connTmuxOutputUnparsable": "tmux の出力を解析できませんでした（区切り文字が見つかりません）",
   "connTmuxCommandFailed": "tmux コマンドが失敗しました（終了コード: {code}）",
   "@connTmuxCommandFailed": {
     "placeholders": {

--- a/lib/providers/tmux_provider.dart
+++ b/lib/providers/tmux_provider.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../services/tmux/tmux_delimiters.dart';
 import '../services/tmux/tmux_facade.dart';
 import '../services/tmux/tmux_models.dart';
 
@@ -125,9 +126,9 @@ class TmuxNotifier extends Notifier<TmuxState> {
   // inventory: PROV-TMUX-016
   // inventory: LEGACY-0173
   /// セッション一覧を解析して更新
-  void parseAndUpdateSessions(String output) {
+  void parseAndUpdateSessions(String output, TmuxDelimiters delimiters) {
     try {
-      final sessions = tmuxFacade.parseSessions(output);
+      final sessions = tmuxFacade.parseSessions(output, delimiters);
       state = state.copyWith(sessions: sessions, error: null);
     } catch (e) {
       state = state.copyWith(error: e.toString());
@@ -137,9 +138,9 @@ class TmuxNotifier extends Notifier<TmuxState> {
   // inventory: PROV-TMUX-017
   // inventory: LEGACY-0174
   /// フルツリーを解析して更新
-  void parseAndUpdateFullTree(String output) {
+  void parseAndUpdateFullTree(String output, TmuxDelimiters delimiters) {
     try {
-      final sessions = tmuxFacade.parseFullTree(output);
+      final sessions = tmuxFacade.parseFullTree(output, delimiters);
       state = state.copyWith(sessions: sessions, error: null);
     } catch (e) {
       state = state.copyWith(error: e.toString());

--- a/lib/screens/terminal/terminal_screen.dart
+++ b/lib/screens/terminal/terminal_screen.dart
@@ -47,6 +47,7 @@ import '../../services/tmux/tmux_pane_content_reader.dart';
 import '../../services/terminal/font_calculator.dart';
 import '../../services/terminal/adaptive_polling.dart';
 import '../../services/tmux/tmux_command_builder.dart';
+import '../../services/tmux/tmux_contract.dart';
 import '../../services/tmux/tmux_facade.dart';
 import '../../services/tmux/tmux_models.dart';
 import '../../services/tmux/tmux_to_domain.dart';
@@ -5932,11 +5933,16 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       // セッション消滅確認（最後のウィンドウの最後のペインだった場合）
       if (isLastPane && isLastWindow) {
         var sessions = <TmuxSession>[];
+        var listed = true;
         try {
           sessions = await tmuxFacade.listSessions(sshClient.tmuxExecutor);
+        } on TmuxOutputParseException {
+          // 出力を読めなかっただけで、セッションが消えた証拠ではない。
+          // サーバ消滅は素の TmuxCommandException で下の catch に落ちる。
+          listed = false;
         } catch (_) {}
         if (!mounted || _isDisposed) return;
-        if (sessions.isEmpty) {
+        if (listed && sessions.isEmpty) {
           // inventory: TERM-DIALOG-012
           await _disconnect();
           return;
@@ -6358,10 +6364,14 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
 
       // セッション消滅判定: list-sessionsで直接確認
       var sessions = <TmuxSession>[];
+      var listed = true;
       try {
         sessions = await tmuxFacade.listSessions(sshClient.tmuxExecutor);
+      } on TmuxOutputParseException {
+        // 出力を読めなかっただけで、セッションが消えた証拠ではない。
+        listed = false;
       } catch (_) {}
-      if (sessions.isEmpty) {
+      if (listed && sessions.isEmpty) {
         debugPrint(
           '[Terminal] Last window closed, session terminated. Disconnecting...',
         );

--- a/lib/services/tmux/tmux_command_builder.dart
+++ b/lib/services/tmux/tmux_command_builder.dart
@@ -5,6 +5,7 @@ library;
 import 'dart:convert';
 import 'dart:math';
 
+import 'tmux_delimiters.dart';
 import 'tmux_executable_resolver.dart';
 
 // inventory: TMUX-CMD-000
@@ -14,18 +15,13 @@ import 'tmux_executable_resolver.dart';
 /// TmuxParserと対応するフォーマット文字列を使用。
 class TmuxCommands {
   // inventory: TMUX-CMD-001
-  /// Field delimiter. Printable on purpose: tmux 3.7 rewrites every
-  /// non-printable byte in `-F` output to `_`, so a control character here
-  /// arrives indistinguishable from the next one and parsing yields nothing.
-  static const String fieldDelimiter = '@@F@@';
-
-  /// Record delimiter, appended after each record so a newline inside a field
-  /// cannot split it. Printable for the same reason as [fieldDelimiter].
-  static const String recordDelimiter = '@@R@@';
-
-  /// 旧区切り文字（後方互換）。
-  @Deprecated('Use fieldDelimiter')
-  static const String delimiter = fieldDelimiter;
+  /// Renders the `-F` argument of a list command from [fields].
+  ///
+  /// The delimiters are supplied per call ([TmuxDelimiters.random]) rather
+  /// than fixed, so no session, window or pane name can contain one: see
+  /// [TmuxDelimiters] for why they must also stay printable.
+  static String _listFormat(List<String> fields, TmuxDelimiters delimiters) =>
+      '${fields.join(delimiters.field)}${delimiters.record}';
 
   // ===== セッション =====
 
@@ -33,14 +29,15 @@ class TmuxCommands {
   /// セッション一覧を取得するコマンド（詳細版）
   ///
   /// 出力フォーマット: `session_name\tsession_created\tsession_attached\tsession_windows\tsession_id`
-  static String listSessions() {
-    return 'tmux list-sessions -F "'
-        '#{session_name}$fieldDelimiter'
-        '#{session_created}$fieldDelimiter'
-        '#{session_attached}$fieldDelimiter'
-        '#{session_windows}$fieldDelimiter'
-        '#{session_id}$recordDelimiter'
-        '"';
+  static String listSessions(TmuxDelimiters delimiters) {
+    const fields = [
+      '#{session_name}',
+      '#{session_created}',
+      '#{session_attached}',
+      '#{session_windows}',
+      '#{session_id}',
+    ];
+    return 'tmux list-sessions -F "${_listFormat(fields, delimiters)}"';
   }
 
   // inventory: TMUX-CMD-003
@@ -93,15 +90,16 @@ class TmuxCommands {
   /// ウィンドウ一覧を取得するコマンド（詳細版）
   ///
   /// 出力フォーマット: `window_index\twindow_id\twindow_name\twindow_active\twindow_panes\twindow_flags`
-  static String listWindows(String sessionName) {
-    return 'tmux list-windows -t ${_escapeArg(sessionName)} -F "'
-        '#{window_index}$fieldDelimiter'
-        '#{window_id}$fieldDelimiter'
-        '#{window_name}$fieldDelimiter'
-        '#{window_active}$fieldDelimiter'
-        '#{window_panes}$fieldDelimiter'
-        '#{window_flags}$recordDelimiter'
-        '"';
+  static String listWindows(String sessionName, TmuxDelimiters delimiters) {
+    const fields = [
+      '#{window_index}',
+      '#{window_id}',
+      '#{window_name}',
+      '#{window_active}',
+      '#{window_panes}',
+      '#{window_flags}',
+    ];
+    return 'tmux list-windows -t ${_escapeArg(sessionName)} -F "${_listFormat(fields, delimiters)}"';
   }
 
   // inventory: TMUX-CMD-009
@@ -162,18 +160,24 @@ class TmuxCommands {
   /// ペイン一覧を取得するコマンド（詳細版）
   ///
   /// 出力フォーマット: `pane_index\tpane_id\tpane_active\tpane_current_command\tpane_title\tpane_width\tpane_height\tcursor_x\tcursor_y`
-  static String listPanes(String sessionName, int windowIndex) {
-    return 'tmux list-panes -t ${_escapeArg(sessionName)}:$windowIndex -F "'
-        '#{pane_index}$fieldDelimiter'
-        '#{pane_id}$fieldDelimiter'
-        '#{pane_active}$fieldDelimiter'
-        '#{pane_current_command}$fieldDelimiter'
-        '#{pane_title}$fieldDelimiter'
-        '#{pane_width}$fieldDelimiter'
-        '#{pane_height}$fieldDelimiter'
-        '#{cursor_x}$fieldDelimiter'
-        '#{cursor_y}$recordDelimiter'
-        '"';
+  static String listPanes(
+    String sessionName,
+    int windowIndex,
+    TmuxDelimiters delimiters,
+  ) {
+    const fields = [
+      '#{pane_index}',
+      '#{pane_id}',
+      '#{pane_active}',
+      '#{pane_current_command}',
+      '#{pane_title}',
+      '#{pane_width}',
+      '#{pane_height}',
+      '#{cursor_x}',
+      '#{cursor_y}',
+    ];
+    return 'tmux list-panes -t ${_escapeArg(sessionName)}:$windowIndex '
+        '-F "${_listFormat(fields, delimiters)}"';
   }
 
   // inventory: TMUX-CMD-015
@@ -189,28 +193,29 @@ class TmuxCommands {
   /// 全ペインを取得するコマンド（セッションツリー構築用）
   ///
   /// 出力フォーマット: 完全なツリー情報（window_flags含む）
-  static String listAllPanes() {
-    return 'tmux list-panes -a -F "'
-        '#{session_name}$fieldDelimiter'
-        '#{session_id}$fieldDelimiter'
-        '#{window_index}$fieldDelimiter'
-        '#{window_id}$fieldDelimiter'
-        '#{window_name}$fieldDelimiter'
-        '#{window_active}$fieldDelimiter'
-        '#{pane_index}$fieldDelimiter'
-        '#{pane_id}$fieldDelimiter'
-        '#{pane_active}$fieldDelimiter'
-        '#{pane_width}$fieldDelimiter'
-        '#{pane_height}$fieldDelimiter'
-        '#{pane_left}$fieldDelimiter'
-        '#{pane_top}$fieldDelimiter'
-        '#{pane_title}$fieldDelimiter'
-        '#{pane_current_command}$fieldDelimiter'
-        '#{cursor_x}$fieldDelimiter'
-        '#{cursor_y}$fieldDelimiter'
-        '#{pane_current_path}$fieldDelimiter'
-        '#{window_flags}$recordDelimiter'
-        '"';
+  static String listAllPanes(TmuxDelimiters delimiters) {
+    const fields = [
+      '#{session_name}',
+      '#{session_id}',
+      '#{window_index}',
+      '#{window_id}',
+      '#{window_name}',
+      '#{window_active}',
+      '#{pane_index}',
+      '#{pane_id}',
+      '#{pane_active}',
+      '#{pane_width}',
+      '#{pane_height}',
+      '#{pane_left}',
+      '#{pane_top}',
+      '#{pane_title}',
+      '#{pane_current_command}',
+      '#{cursor_x}',
+      '#{cursor_y}',
+      '#{pane_current_path}',
+      '#{window_flags}',
+    ];
+    return 'tmux list-panes -a -F "${_listFormat(fields, delimiters)}"';
   }
 
   // inventory: TMUX-CMD-017

--- a/lib/services/tmux/tmux_command_builder.dart
+++ b/lib/services/tmux/tmux_command_builder.dart
@@ -14,13 +14,14 @@ import 'tmux_executable_resolver.dart';
 /// TmuxParserと対応するフォーマット文字列を使用。
 class TmuxCommands {
   // inventory: TMUX-CMD-001
-  /// フィールド区切り文字（US: 0x1f）。
-  /// ユーザーが入力可能な `|` やタブより出現確率が極めて低い制御文字を使う。
-  static const String fieldDelimiter = '\x1f';
+  /// Field delimiter. Printable on purpose: tmux 3.7 rewrites every
+  /// non-printable byte in `-F` output to `_`, so a control character here
+  /// arrives indistinguishable from the next one and parsing yields nothing.
+  static const String fieldDelimiter = '@@F@@';
 
-  /// レコード区切り文字（RS: 0x1e）。
-  /// tmux の各レコード末尾に追加し、フィールド内改行を含んでも崩れないようにする。
-  static const String recordDelimiter = '\x1e';
+  /// Record delimiter, appended after each record so a newline inside a field
+  /// cannot split it. Printable for the same reason as [fieldDelimiter].
+  static const String recordDelimiter = '@@R@@';
 
   /// 旧区切り文字（後方互換）。
   @Deprecated('Use fieldDelimiter')

--- a/lib/services/tmux/tmux_contract.dart
+++ b/lib/services/tmux/tmux_contract.dart
@@ -10,6 +10,7 @@ import 'dart:async';
 import '../connection_error.dart';
 import 'tmux_command_builder.dart';
 import 'tmux_command_executor.dart';
+import 'tmux_delimiters.dart';
 import 'tmux_models.dart';
 import 'tmux_version.dart';
 
@@ -24,12 +25,26 @@ class TmuxCommandException extends SshConnectionError {
   TmuxCommandException(super.message, [super.cause]);
 }
 
+// inventory: TMUX-CONTRACT-EXC-003
+/// tmux は成功したが、その出力を 1 レコードも解析できなかったときの例外。
+///
+/// 区切り文字が往路で失われた出力（UTF-8 でないクライアントに tmux が返す
+/// `_` 置換など）は、終了コード 0 のまま空リストに解析され、「セッションが
+/// 無い」と区別が付かない。既存の `on TmuxCommandException` でも捕捉できる
+/// よう、失敗系の例外を継承する。
+class TmuxOutputParseException extends TmuxCommandException {
+  // inventory: TMUX-CONTRACT-EXC-004
+  TmuxOutputParseException(super.message, [super.cause]);
+}
+
 // inventory: TMUX-CONTRACT-001
 abstract interface class TmuxContract {
   // inventory: TMUX-CONTRACT-PARSE-001
-  List<TmuxSession> parseSessions(String output);
+  /// [delimiters] は [output] を生成したコマンドに渡したものを指定する。
+  /// 呼び出しごとに生成されるため、既定値は置かない。
+  List<TmuxSession> parseSessions(String output, TmuxDelimiters delimiters);
   // inventory: TMUX-CONTRACT-PARSE-002
-  List<TmuxSession> parseFullTree(String output);
+  List<TmuxSession> parseFullTree(String output, TmuxDelimiters delimiters);
   // inventory: TMUX-CONTRACT-PARSE-003
   TmuxPaneContent parsePaneContent(
     String output, {

--- a/lib/services/tmux/tmux_delimiters.dart
+++ b/lib/services/tmux/tmux_delimiters.dart
@@ -1,0 +1,63 @@
+// inventory: TMUX-DELIM-000
+/// tmux `-F` 出力の区切り文字ペア
+library;
+
+import 'dart:math';
+
+// inventory: TMUX-DELIM-001
+/// The field/record delimiter pair used for one `tmux -F` round trip.
+///
+/// Both delimiters are printable. tmux hands `-F` output to a client that is
+/// not in UTF-8 mode through `utf8_sanitize()`, which rewrites every byte
+/// outside `0x20..0x7e` to `_` — 0x1f, 0x1e and TAB all arrive as the same
+/// character, indistinguishable from content. A tmux client is in UTF-8 mode
+/// only when `$TMUX`, `LC_ALL`, `LC_CTYPE` or `LANG` says so, and an SSH
+/// command channel carries none of those, so MuxPod always lands in the
+/// sanitizing path.
+///
+/// The pair is minted per invocation ([TmuxDelimiters.random]) rather than
+/// fixed: tmux accepts any printable string in a session, window or pane name,
+/// so a constant delimiter — however unlikely — can be typed by a user and
+/// shift the fields of a record. A delimiter that did not exist when the name
+/// was set cannot be.
+class TmuxDelimiters {
+  /// Separates the fields inside one record.
+  final String field;
+
+  /// Terminates each record, so a newline inside a field cannot split it.
+  final String record;
+
+  const TmuxDelimiters({required this.field, required this.record});
+
+  // inventory: TMUX-DELIM-002
+  /// Mints a fresh pair, unguessable to whoever named the sessions.
+  factory TmuxDelimiters.random() {
+    final id = _randomId();
+    return TmuxDelimiters(field: '@F$id@', record: '@R$id@');
+  }
+
+  // inventory: TMUX-DELIM-003
+  /// Field delimiter (US, 0x1f) MuxPod used to ask tmux for.
+  static const String legacyField = '\x1f';
+
+  /// Record delimiter (RS, 0x1e) MuxPod used to ask tmux for.
+  static const String legacyRecord = '\x1e';
+
+  // inventory: TMUX-DELIM-004
+  /// The pair MuxPod used to ask tmux for.
+  ///
+  /// Parse side only — never build a command with it. Output produced by an
+  /// older MuxPod, and the fixtures modelled on it, still has to parse.
+  static const TmuxDelimiters legacy = TmuxDelimiters(
+    field: legacyField,
+    record: legacyRecord,
+  );
+
+  /// 16 hex characters (64 bits) from a cryptographic source, like the
+  /// pollPane section marker.
+  static String _randomId() {
+    final rng = Random.secure();
+    final bytes = List<int>.generate(8, (_) => rng.nextInt(256));
+    return bytes.map((b) => b.toRadixString(16).padLeft(2, '0')).join();
+  }
+}

--- a/lib/services/tmux/tmux_facade.dart
+++ b/lib/services/tmux/tmux_facade.dart
@@ -13,6 +13,7 @@ import '../command/command_request.dart';
 import 'tmux_command_builder.dart';
 import 'tmux_command_executor.dart';
 import 'tmux_contract.dart';
+import 'tmux_delimiters.dart';
 import 'tmux_models.dart';
 import 'tmux_parser_adapter.dart';
 import 'tmux_version.dart';
@@ -47,11 +48,11 @@ class TmuxFacade implements TmuxContract {
   }
 
   @override
-  List<TmuxSession> parseSessions(String output) =>
-      TmuxParser.parseSessions(output);
+  List<TmuxSession> parseSessions(String output, TmuxDelimiters delimiters) =>
+      TmuxParser.parseSessions(output, delimiters: delimiters);
   @override
-  List<TmuxSession> parseFullTree(String output) =>
-      TmuxParser.parseFullTree(output);
+  List<TmuxSession> parseFullTree(String output, TmuxDelimiters delimiters) =>
+      TmuxParser.parseFullTree(output, delimiters: delimiters);
   @override
   TmuxPaneContent parsePaneContent(
     String output, {
@@ -90,14 +91,28 @@ class TmuxFacade implements TmuxContract {
 
   @override
   Future<List<TmuxSession>> listSessions(TmuxCommandExecutor executor) async {
-    final output = await _execChecked(executor, TmuxCommands.listSessions());
-    return TmuxParser.parseSessions(output);
+    final delimiters = TmuxDelimiters.random();
+    final output = await _execChecked(
+      executor,
+      TmuxCommands.listSessions(delimiters),
+    );
+    return _requireRecords(
+      output,
+      TmuxParser.parseSessions(output, delimiters: delimiters),
+    );
   }
 
   @override
   Future<List<TmuxSession>> listAllPanes(TmuxCommandExecutor executor) async {
-    final output = await _execChecked(executor, TmuxCommands.listAllPanes());
-    return TmuxParser.parseFullTree(output);
+    final delimiters = TmuxDelimiters.random();
+    final output = await _execChecked(
+      executor,
+      TmuxCommands.listAllPanes(delimiters),
+    );
+    return _requireRecords(
+      output,
+      TmuxParser.parseFullTree(output, delimiters: delimiters),
+    );
   }
 
   @override
@@ -154,11 +169,15 @@ class TmuxFacade implements TmuxContract {
     TmuxCommandExecutor executor,
     String sessionName,
   ) async {
+    final delimiters = TmuxDelimiters.random();
     final output = await _execChecked(
       executor,
-      TmuxCommands.listWindows(sessionName),
+      TmuxCommands.listWindows(sessionName, delimiters),
     );
-    return TmuxParser.parseWindows(output);
+    return _requireRecords(
+      output,
+      TmuxParser.parseWindows(output, delimiters: delimiters),
+    );
   }
 
   @override
@@ -223,11 +242,15 @@ class TmuxFacade implements TmuxContract {
     String sessionName,
     int windowIndex,
   ) async {
+    final delimiters = TmuxDelimiters.random();
     final output = await _execChecked(
       executor,
-      TmuxCommands.listPanes(sessionName, windowIndex),
+      TmuxCommands.listPanes(sessionName, windowIndex, delimiters),
     );
-    return TmuxParser.parsePanes(output);
+    return _requireRecords(
+      output,
+      TmuxParser.parsePanes(output, delimiters: delimiters),
+    );
   }
 
   @override
@@ -574,6 +597,19 @@ class TmuxFacade implements TmuxContract {
     List<String> targets,
   ) async {
     await executor.restoreWindowsNoWait(targets);
+  }
+
+  /// tmux が出力を返したのに 1 レコードも解析できなかった場合は投げる。
+  ///
+  /// 区切り文字が往路で失われた出力は終了コード 0 のまま空リストになり、
+  /// 「セッションが無い」と見分けが付かないため、成功として返さない。
+  List<T> _requireRecords<T>(String output, List<T> records) {
+    if (records.isEmpty && TmuxParser.hasRecordContent(output)) {
+      throw TmuxOutputParseException(
+        (_l10n ?? lookupL10n()).connTmuxOutputUnparsable,
+      );
+    }
+    return records;
   }
 
   // inventory: TMUX-FACADE-CHECK-001

--- a/lib/services/tmux/tmux_parser_adapter.dart
+++ b/lib/services/tmux/tmux_parser_adapter.dart
@@ -12,10 +12,10 @@ import 'tmux_models.dart';
 class TmuxParser {
   // inventory: TMUX-PARSER-001
   /// デフォルトのフィールド区切り文字（US: 0x1f）。
-  static const String defaultFieldDelimiter = '\x1f';
+  static const String defaultFieldDelimiter = '@@F@@';
 
   /// デフォルトのレコード区切り文字（RS: 0x1e）。
-  static const String defaultRecordDelimiter = '\x1e';
+  static const String defaultRecordDelimiter = '@@R@@';
 
   /// 旧区切り文字（後方互換）。
   @Deprecated('Use defaultFieldDelimiter')
@@ -478,17 +478,24 @@ class TmuxParser {
   }
 
   // inventory: TMUX-PARSER-020
-  /// tmux の `-F` 出力で、制御文字がリテラル表記に化けた場合に制御文字へ戻す。
+  /// Normalises every delimiter spelling tmux may emit into the current ones.
   ///
-  /// tmux は `-F` フォーマット内の制御文字（0x1f / 0x1e）を、SSH シェル経由で
-  /// `\037` / `\036`（8 進数表記）や `\x1f` / `\x1e`（16 進数表記）のリテラル
-  /// 文字列として出力することがある。このヘルパーで各リテラル表記を元の
-  /// 制御文字に正規化してから分割できるようにする。
+  /// Delimiters are printable (`@@F@@` / `@@R@@`) because tmux 3.7 replaces
+  /// EVERY non-printable byte in `-F` output with `_` — 0x1f, 0x1e, 0x01 and
+  /// even TAB all come back as the same character. Control-character
+  /// delimiters are therefore unrecoverable there: the parser sees one field,
+  /// returns null per line, and the session list silently comes back empty.
   ///
-  /// tmux のセッション名・ウィンドウ名は ASCII 制御文字を受け付けないため、
-  /// リテラル表記が名前の中に現れて誤変換される実害はない。
+  /// Older tmux passes 0x1f/0x1e through, and some shells render them as the
+  /// literal text `\037` / `\x1f`, so all three spellings are accepted.
   static String normalizeDelimiters(String output) {
     return output
+        // tmux >= 3.7 rewrites every non-printable byte in -F output to '_',
+        // so control-character delimiters never survive; these two lines keep
+        // output from older tmux, which passes 0x1f/0x1e through untouched,
+        // parseable by the same code path.
+        .replaceAll('\x1f', defaultFieldDelimiter)
+        .replaceAll('\x1e', defaultRecordDelimiter)
         .replaceAll(r'\x1f', defaultFieldDelimiter)
         .replaceAll(r'\x1e', defaultRecordDelimiter)
         .replaceAll(r'\037', defaultFieldDelimiter)

--- a/lib/services/tmux/tmux_parser_adapter.dart
+++ b/lib/services/tmux/tmux_parser_adapter.dart
@@ -2,6 +2,7 @@
 /// tmux コマンド出力パーサー（アダプター）
 library;
 
+import 'tmux_delimiters.dart';
 import 'tmux_models.dart';
 
 // inventory: TMUX-PARSER-000
@@ -11,15 +12,12 @@ import 'tmux_models.dart';
 /// フォーマット文字列に対応したパーサーを提供。
 class TmuxParser {
   // inventory: TMUX-PARSER-001
-  /// デフォルトのフィールド区切り文字（US: 0x1f）。
-  static const String defaultFieldDelimiter = '@@F@@';
-
-  /// デフォルトのレコード区切り文字（RS: 0x1e）。
-  static const String defaultRecordDelimiter = '@@R@@';
-
-  /// 旧区切り文字（後方互換）。
-  @Deprecated('Use defaultFieldDelimiter')
-  static const String defaultDelimiter = defaultFieldDelimiter;
+  /// Delimiters assumed for output that did not come from [TmuxCommands].
+  ///
+  /// Everything the app itself asks tmux for is parsed with the pair minted
+  /// for that call; this default only covers output of unknown provenance,
+  /// which historically used the control characters.
+  static const TmuxDelimiters defaultDelimiters = TmuxDelimiters.legacy;
 
   // ===== セッション =====
 
@@ -29,21 +27,20 @@ class TmuxParser {
   /// 対応フォーマット: `#{session_name}\t#{session_created}\t#{session_attached}\t#{session_windows}\t#{session_id}`
   static List<TmuxSession> parseSessions(
     String output, {
-    String fieldDelimiter = defaultFieldDelimiter,
-    String recordDelimiter = defaultRecordDelimiter,
+    TmuxDelimiters delimiters = defaultDelimiters,
   }) {
     if (!isServerRunning(output)) {
       return [];
     }
-    output = normalizeDelimiters(output);
+    output = normalizeDelimiters(output, delimiters);
 
     final sessions = <TmuxSession>[];
 
-    for (final record in output.split(recordDelimiter)) {
+    for (final record in output.split(delimiters.record)) {
       final trimmed = record.trim();
       if (trimmed.isEmpty) continue;
 
-      final session = parseSessionLine(trimmed, delimiter: fieldDelimiter);
+      final session = parseSessionLine(trimmed, delimiter: delimiters.field);
       if (session != null) {
         sessions.add(session);
       }
@@ -56,7 +53,7 @@ class TmuxParser {
   /// 単一のセッション行をパース
   static TmuxSession? parseSessionLine(
     String line, {
-    String delimiter = defaultFieldDelimiter,
+    String delimiter = TmuxDelimiters.legacyField,
   }) {
     final parts = line.split(delimiter);
     // 区切り文字が含まれない行はtmux出力ではない（シェルエラー等）
@@ -110,17 +107,16 @@ class TmuxParser {
   /// 対応フォーマット: `#{window_index}\t#{window_id}\t#{window_name}\t#{window_active}\t#{window_panes}\t#{window_flags}`
   static List<TmuxWindow> parseWindows(
     String output, {
-    String fieldDelimiter = defaultFieldDelimiter,
-    String recordDelimiter = defaultRecordDelimiter,
+    TmuxDelimiters delimiters = defaultDelimiters,
   }) {
-    output = normalizeDelimiters(output);
+    output = normalizeDelimiters(output, delimiters);
     final windows = <TmuxWindow>[];
 
-    for (final record in output.split(recordDelimiter)) {
+    for (final record in output.split(delimiters.record)) {
       final trimmed = record.trim();
       if (trimmed.isEmpty) continue;
 
-      final window = parseWindowLine(trimmed, delimiter: fieldDelimiter);
+      final window = parseWindowLine(trimmed, delimiter: delimiters.field);
       if (window != null) {
         windows.add(window);
       }
@@ -133,7 +129,7 @@ class TmuxParser {
   /// 単一のウィンドウ行をパース
   static TmuxWindow? parseWindowLine(
     String line, {
-    String delimiter = defaultFieldDelimiter,
+    String delimiter = TmuxDelimiters.legacyField,
   }) {
     final parts = line.split(delimiter);
     if (parts.isEmpty) return null;
@@ -186,17 +182,16 @@ class TmuxParser {
   /// 対応フォーマット: `#{pane_index}\t#{pane_id}\t#{pane_active}\t#{pane_current_command}\t#{pane_title}\t#{pane_width}\t#{pane_height}\t#{cursor_x}\t#{cursor_y}`
   static List<TmuxPane> parsePanes(
     String output, {
-    String fieldDelimiter = defaultFieldDelimiter,
-    String recordDelimiter = defaultRecordDelimiter,
+    TmuxDelimiters delimiters = defaultDelimiters,
   }) {
-    output = normalizeDelimiters(output);
+    output = normalizeDelimiters(output, delimiters);
     final panes = <TmuxPane>[];
 
-    for (final record in output.split(recordDelimiter)) {
+    for (final record in output.split(delimiters.record)) {
       final trimmed = record.trim();
       if (trimmed.isEmpty) continue;
 
-      final pane = parsePaneLine(trimmed, delimiter: fieldDelimiter);
+      final pane = parsePaneLine(trimmed, delimiter: delimiters.field);
       if (pane != null) {
         panes.add(pane);
       }
@@ -209,7 +204,7 @@ class TmuxParser {
   /// 単一のペイン行をパース
   static TmuxPane? parsePaneLine(
     String line, {
-    String delimiter = defaultFieldDelimiter,
+    String delimiter = TmuxDelimiters.legacyField,
   }) {
     final parts = line.split(delimiter);
     if (parts.length < 2) return null;
@@ -303,22 +298,21 @@ class TmuxParser {
   /// `tmux list-panes -a -F "..."`の出力から完全なツリーを構築
   static List<TmuxSession> parseFullTree(
     String output, {
-    String fieldDelimiter = defaultFieldDelimiter,
-    String recordDelimiter = defaultRecordDelimiter,
+    TmuxDelimiters delimiters = defaultDelimiters,
   }) {
     if (!isServerRunning(output)) {
       return [];
     }
-    output = normalizeDelimiters(output);
+    output = normalizeDelimiters(output, delimiters);
 
     final sessionsMap = <String, TmuxSession>{};
     final windowsMap = <String, Map<int, TmuxWindow>>{};
 
-    for (final record in output.split(recordDelimiter)) {
+    for (final record in output.split(delimiters.record)) {
       final trimmed = record.trim();
       if (trimmed.isEmpty) continue;
 
-      final parts = trimmed.split(fieldDelimiter);
+      final parts = trimmed.split(delimiters.field);
       if (parts.length < 10) continue;
 
       // フォーマット: session_name, session_id, window_index, window_id, window_name, window_active,
@@ -478,29 +472,35 @@ class TmuxParser {
   }
 
   // inventory: TMUX-PARSER-020
-  /// Normalises every delimiter spelling tmux may emit into the current ones.
+  /// Rewrites every spelling of the legacy delimiters into [delimiters].
   ///
-  /// Delimiters are printable (`@@F@@` / `@@R@@`) because tmux 3.7 replaces
-  /// EVERY non-printable byte in `-F` output with `_` — 0x1f, 0x1e, 0x01 and
-  /// even TAB all come back as the same character. Control-character
-  /// delimiters are therefore unrecoverable there: the parser sees one field,
-  /// returns null per line, and the session list silently comes back empty.
+  /// MuxPod used to ask tmux for 0x1f/0x1e, and that output reached the app in
+  /// three shapes: the raw bytes, and — because tmux <= 3.5a ran command
+  /// output through `strvis` — the literal text `\037` / `\x1f`. Records in
+  /// any of those shapes still have to parse, so they are folded onto the pair
+  /// the current call is using.
   ///
-  /// Older tmux passes 0x1f/0x1e through, and some shells render them as the
-  /// literal text `\037` / `\x1f`, so all three spellings are accepted.
-  static String normalizeDelimiters(String output) {
+  /// The delimiters MuxPod asks for today are printable and minted per call
+  /// (see [TmuxDelimiters]), so nothing here touches them.
+  static String normalizeDelimiters(String output, TmuxDelimiters delimiters) {
     return output
-        // tmux >= 3.7 rewrites every non-printable byte in -F output to '_',
-        // so control-character delimiters never survive; these two lines keep
-        // output from older tmux, which passes 0x1f/0x1e through untouched,
-        // parseable by the same code path.
-        .replaceAll('\x1f', defaultFieldDelimiter)
-        .replaceAll('\x1e', defaultRecordDelimiter)
-        .replaceAll(r'\x1f', defaultFieldDelimiter)
-        .replaceAll(r'\x1e', defaultRecordDelimiter)
-        .replaceAll(r'\037', defaultFieldDelimiter)
-        .replaceAll(r'\036', defaultRecordDelimiter);
+        .replaceAll(TmuxDelimiters.legacyField, delimiters.field)
+        .replaceAll(TmuxDelimiters.legacyRecord, delimiters.record)
+        .replaceAll(r'\x1f', delimiters.field)
+        .replaceAll(r'\x1e', delimiters.record)
+        .replaceAll(r'\037', delimiters.field)
+        .replaceAll(r'\036', delimiters.record);
   }
+
+  // inventory: TMUX-PARSER-022
+  /// Whether [output] carried something the record parsers were meant to turn
+  /// into at least one record.
+  ///
+  /// An empty parse result over output that answers `true` here means the
+  /// delimiters did not survive the trip — a failure that used to reach the UI
+  /// as "no sessions" with exit code 0.
+  static bool hasRecordContent(String output) =>
+      output.trim().isNotEmpty && isServerRunning(output);
 
   // inventory: TMUX-PARSER-021
   /// エラーメッセージを抽出

--- a/test/fixtures/tmux/tmux_parser_fixtures.dart
+++ b/test/fixtures/tmux/tmux_parser_fixtures.dart
@@ -2,8 +2,8 @@
 
 /// tmux コマンド出力の fixture
 ///
-/// 区切り文字は TmuxCommands.fieldDelimiter（US: 0x1f）と
-/// TmuxCommands.recordDelimiter（RS: 0x1e）を使用
+/// Delimiters come from TmuxParser's constants, never hard-coded bytes: they
+/// are printable because tmux 3.7 rewrites non-printable bytes in -F output.
 library;
 
 import 'package:flutter_muxpod/services/tmux/tmux_parser_adapter.dart';

--- a/test/fixtures/tmux/tmux_parser_fixtures.dart
+++ b/test/fixtures/tmux/tmux_parser_fixtures.dart
@@ -2,14 +2,16 @@
 
 /// tmux コマンド出力の fixture
 ///
-/// Delimiters come from TmuxParser's constants, never hard-coded bytes: they
-/// are printable because tmux 3.7 rewrites non-printable bytes in -F output.
+/// Written with the legacy 0x1f/0x1e pair on purpose: output recorded from a
+/// MuxPod that still asked tmux for the control characters has to keep
+/// parsing, whatever delimiters the current call minted. The live shape —
+/// printable, per-invocation — is covered in tmux_facade_test.dart.
 library;
 
-import 'package:flutter_muxpod/services/tmux/tmux_parser_adapter.dart';
+import 'package:flutter_muxpod/services/tmux/tmux_delimiters.dart';
 
-const _fs = TmuxParser.defaultFieldDelimiter;
-const _rs = TmuxParser.defaultRecordDelimiter;
+const _fs = TmuxDelimiters.legacyField;
+const _rs = TmuxDelimiters.legacyRecord;
 
 // セッション一覧（詳細版）
 const kSessionOutput =

--- a/test/providers/tmux_provider_test.dart
+++ b/test/providers/tmux_provider_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_muxpod/services/tmux/tmux_delimiters.dart';
 import 'package:flutter_muxpod/providers/tmux_provider.dart';
 import 'package:flutter_muxpod/services/tmux/tmux_models.dart';
 import 'package:flutter_muxpod/services/tmux/tmux_parser_adapter.dart';
@@ -34,14 +35,14 @@ void main() {
 
     test('parseAndUpdateSessions parses raw output', () {
       final notifier = container.read(tmuxProvider.notifier);
-      notifier.parseAndUpdateSessions(kSessionOutput);
+      notifier.parseAndUpdateSessions(kSessionOutput, TmuxDelimiters.legacy);
       expect(container.read(tmuxProvider).sessions, hasLength(2));
       expect(container.read(tmuxProvider).sessions[0].name, 'mysession');
     });
 
     test('parseAndUpdateFullTree parses full tree', () {
       final notifier = container.read(tmuxProvider.notifier);
-      notifier.parseAndUpdateFullTree(kFullTreeOutput);
+      notifier.parseAndUpdateFullTree(kFullTreeOutput, TmuxDelimiters.legacy);
       final state = container.read(tmuxProvider);
       expect(state.sessions, hasLength(2));
       expect(state.sessions[0].windows, hasLength(1));
@@ -49,7 +50,7 @@ void main() {
 
     test('setActiveSession selects active window and pane', () {
       final notifier = container.read(tmuxProvider.notifier);
-      notifier.parseAndUpdateFullTree(kFullTreeOutput);
+      notifier.parseAndUpdateFullTree(kFullTreeOutput, TmuxDelimiters.legacy);
       notifier.setActiveSession('mysession');
       final state = container.read(tmuxProvider);
       expect(state.activeSessionName, 'mysession');
@@ -59,7 +60,7 @@ void main() {
 
     test('setActiveSession on unknown session clears active pane', () {
       final notifier = container.read(tmuxProvider.notifier);
-      notifier.parseAndUpdateFullTree(kFullTreeOutput);
+      notifier.parseAndUpdateFullTree(kFullTreeOutput, TmuxDelimiters.legacy);
       notifier.setActiveSession('missing');
       final state = container.read(tmuxProvider);
       expect(state.activeSessionName, 'missing');
@@ -69,7 +70,7 @@ void main() {
 
     test('setActiveWindow updates active pane', () {
       final notifier = container.read(tmuxProvider.notifier);
-      notifier.parseAndUpdateFullTree(kFullTreeOutput);
+      notifier.parseAndUpdateFullTree(kFullTreeOutput, TmuxDelimiters.legacy);
       notifier.setActiveSession('mysession');
       notifier.setActiveWindow(0);
       final state = container.read(tmuxProvider);
@@ -79,7 +80,7 @@ void main() {
 
     test('setActiveWindow clears pane selection when the window is absent', () {
       final notifier = container.read(tmuxProvider.notifier);
-      notifier.parseAndUpdateFullTree(kFullTreeOutput);
+      notifier.parseAndUpdateFullTree(kFullTreeOutput, TmuxDelimiters.legacy);
       notifier.setActiveSession('mysession');
 
       notifier.setActiveWindow(99);
@@ -100,7 +101,7 @@ void main() {
 
     test('setActivePane by id updates index', () {
       final notifier = container.read(tmuxProvider.notifier);
-      notifier.parseAndUpdateFullTree(kFullTreeOutput);
+      notifier.parseAndUpdateFullTree(kFullTreeOutput, TmuxDelimiters.legacy);
       notifier.setActiveSession('mysession');
       notifier.setActivePane('%1');
       final state = container.read(tmuxProvider);
@@ -112,7 +113,7 @@ void main() {
       'setActivePane retains the last index when the pane id is no longer present',
       () {
         final notifier = container.read(tmuxProvider.notifier);
-        notifier.parseAndUpdateFullTree(kFullTreeOutput);
+        notifier.parseAndUpdateFullTree(kFullTreeOutput, TmuxDelimiters.legacy);
         notifier.setActiveSession('mysession');
 
         notifier.setActivePane('%missing');
@@ -125,7 +126,7 @@ void main() {
 
     test('updateCursorPosition updates active pane cursor', () {
       final notifier = container.read(tmuxProvider.notifier);
-      notifier.parseAndUpdateFullTree(kFullTreeOutput);
+      notifier.parseAndUpdateFullTree(kFullTreeOutput, TmuxDelimiters.legacy);
       notifier.setActiveSession('mysession');
       notifier.updateCursorPosition('%0', 12, 34);
       final pane = container.read(tmuxProvider).activePane;
@@ -137,7 +138,7 @@ void main() {
       'updateCursorPosition ignores inactive pane and unchanged coordinates',
       () {
         final notifier = container.read(tmuxProvider.notifier);
-        notifier.parseAndUpdateFullTree(kFullTreeOutput);
+        notifier.parseAndUpdateFullTree(kFullTreeOutput, TmuxDelimiters.legacy);
         notifier.setActiveSession('mysession');
         final before = container.read(tmuxProvider);
 
@@ -151,7 +152,7 @@ void main() {
 
     test('currentTarget returns pane id', () {
       final notifier = container.read(tmuxProvider.notifier);
-      notifier.parseAndUpdateFullTree(kFullTreeOutput);
+      notifier.parseAndUpdateFullTree(kFullTreeOutput, TmuxDelimiters.legacy);
       notifier.setActiveSession('mysession');
       expect(notifier.currentTarget, '%0');
     });
@@ -173,7 +174,7 @@ void main() {
 
     test('clear resets state', () {
       final notifier = container.read(tmuxProvider.notifier);
-      notifier.parseAndUpdateFullTree(kFullTreeOutput);
+      notifier.parseAndUpdateFullTree(kFullTreeOutput, TmuxDelimiters.legacy);
       notifier.setActiveSession('mysession');
       notifier.clear();
       final state = container.read(tmuxProvider);

--- a/test/screens/terminal/terminal_screen_remaining_contracts_test.dart
+++ b/test/screens/terminal/terminal_screen_remaining_contracts_test.dart
@@ -2,7 +2,7 @@ import 'dart:convert';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter_muxpod/services/tmux/tmux_parser_adapter.dart';
+import 'package:flutter_muxpod/services/tmux/tmux_delimiters.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_muxpod/providers/image_transfer_provider.dart';
 import 'package:flutter_muxpod/providers/settings_provider.dart';
@@ -177,7 +177,7 @@ void main() {
     testWidgets('TERM-DIALOG-012 last pane termination disconnects', (
       tester,
     ) async {
-      const rs = TmuxParser.defaultRecordDelimiter;
+      const rs = TmuxDelimiters.legacyRecord;
       final onePaneTree = '${kFullTreeOutput.split(rs).first}$rs';
       await TerminalTestScaffold.pumpTerminalScreen(
         tester,
@@ -195,6 +195,37 @@ void main() {
       await tester.pumpAndSettle();
       expect(notifier.client, isNull);
     });
+
+    testWidgets(
+      'TERM-DIALOG-012 an unreadable session list does not disconnect',
+      (tester) async {
+        // What tmux answers a non-UTF-8 client when the delimiters are control
+        // characters: every one of them rewritten to '_', exit code 0. That is
+        // not evidence the session died, so the terminal must stay up.
+        const rs = TmuxDelimiters.legacyRecord;
+        final onePaneTree = '${kFullTreeOutput.split(rs).first}$rs';
+        await TerminalTestScaffold.pumpTerminalScreen(
+          tester,
+          execOutputs: {
+            'list-panes -a': onePaneTree,
+            'list-sessions': 'claude/monoroll_\$0\n',
+          },
+        );
+        final container = ProviderScope.containerOf(
+          tester.element(find.byType(TerminalScreen)),
+        );
+        final notifier =
+            container.read(sshProvider.notifier) as FakeSshNotifier;
+        await tester.tap(find.text('Pane 0'));
+        await tester.pumpAndSettle();
+        await tester.longPress(find.text('bash').last);
+        await tester.pumpAndSettle();
+        await tester.tap(find.text('Close'));
+        await tester.pumpAndSettle();
+
+        expect(notifier.client, isNotNull);
+      },
+    );
 
     testWidgets('TERM-FILE-003 completed upload injects bracketed path', (
       tester,

--- a/test/screens/terminal/terminal_screen_remaining_contracts_test.dart
+++ b/test/screens/terminal/terminal_screen_remaining_contracts_test.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_muxpod/services/tmux/tmux_parser_adapter.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_muxpod/providers/image_transfer_provider.dart';
 import 'package:flutter_muxpod/providers/settings_provider.dart';
@@ -176,7 +177,8 @@ void main() {
     testWidgets('TERM-DIALOG-012 last pane termination disconnects', (
       tester,
     ) async {
-      final onePaneTree = '${kFullTreeOutput.split('\x1e').first}\x1e';
+      const rs = TmuxParser.defaultRecordDelimiter;
+      final onePaneTree = '${kFullTreeOutput.split(rs).first}$rs';
       await TerminalTestScaffold.pumpTerminalScreen(
         tester,
         execOutputs: {'list-panes -a': onePaneTree, 'list-sessions': ''},

--- a/test/services/tmux/tmux_commands_test.dart
+++ b/test/services/tmux/tmux_commands_test.dart
@@ -4,14 +4,18 @@ import 'dart:convert';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_muxpod/services/tmux/tmux_command_builder.dart';
+import 'package:flutter_muxpod/services/tmux/tmux_parser_adapter.dart';
 
 void main() {
   group('TmuxCommands', () {
     test(
-      'TMUX-CMD-001: deprecated delimiter remains the US field delimiter',
+      'TMUX-CMD-001: deprecated delimiter tracks the field delimiter',
       () {
-        expect(TmuxCommands.delimiter, String.fromCharCode(0x1f));
         expect(TmuxCommands.delimiter, TmuxCommands.fieldDelimiter);
+        // The builder and the parser must agree, or every record parses to a
+        // single field and the session list comes back empty with no error.
+        expect(TmuxCommands.fieldDelimiter, TmuxParser.defaultFieldDelimiter);
+        expect(TmuxCommands.recordDelimiter, TmuxParser.defaultRecordDelimiter);
       },
     );
 

--- a/test/services/tmux/tmux_commands_test.dart
+++ b/test/services/tmux/tmux_commands_test.dart
@@ -8,16 +8,13 @@ import 'package:flutter_muxpod/services/tmux/tmux_parser_adapter.dart';
 
 void main() {
   group('TmuxCommands', () {
-    test(
-      'TMUX-CMD-001: deprecated delimiter tracks the field delimiter',
-      () {
-        expect(TmuxCommands.delimiter, TmuxCommands.fieldDelimiter);
-        // The builder and the parser must agree, or every record parses to a
-        // single field and the session list comes back empty with no error.
-        expect(TmuxCommands.fieldDelimiter, TmuxParser.defaultFieldDelimiter);
-        expect(TmuxCommands.recordDelimiter, TmuxParser.defaultRecordDelimiter);
-      },
-    );
+    test('TMUX-CMD-001: deprecated delimiter tracks the field delimiter', () {
+      expect(TmuxCommands.delimiter, TmuxCommands.fieldDelimiter);
+      // The builder and the parser must agree, or every record parses to a
+      // single field and the session list comes back empty with no error.
+      expect(TmuxCommands.fieldDelimiter, TmuxParser.defaultFieldDelimiter);
+      expect(TmuxCommands.recordDelimiter, TmuxParser.defaultRecordDelimiter);
+    });
 
     group('killPane', () {
       test('generates correct kill-pane command for standard pane ID', () {

--- a/test/services/tmux/tmux_commands_test.dart
+++ b/test/services/tmux/tmux_commands_test.dart
@@ -4,17 +4,35 @@ import 'dart:convert';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_muxpod/services/tmux/tmux_command_builder.dart';
-import 'package:flutter_muxpod/services/tmux/tmux_parser_adapter.dart';
+import 'package:flutter_muxpod/services/tmux/tmux_delimiters.dart';
 
 void main() {
   group('TmuxCommands', () {
-    test('TMUX-CMD-001: deprecated delimiter tracks the field delimiter', () {
-      expect(TmuxCommands.delimiter, TmuxCommands.fieldDelimiter);
-      // The builder and the parser must agree, or every record parses to a
-      // single field and the session list comes back empty with no error.
-      expect(TmuxCommands.fieldDelimiter, TmuxParser.defaultFieldDelimiter);
-      expect(TmuxCommands.recordDelimiter, TmuxParser.defaultRecordDelimiter);
-    });
+    test(
+      'TMUX-CMD-001: every -F command carries the delimiters it was handed',
+      () {
+        final delimiters = TmuxDelimiters.random();
+        final commands = [
+          TmuxCommands.listSessions(delimiters),
+          TmuxCommands.listWindows('main', delimiters),
+          TmuxCommands.listPanes('main', 0, delimiters),
+          TmuxCommands.listAllPanes(delimiters),
+        ];
+
+        for (final command in commands) {
+          expect(command, contains(delimiters.field));
+          expect(command, contains(delimiters.record));
+          // A control character never survives the round trip: tmux rewrites
+          // it to '_' for a non-UTF-8 client and the parser then sees a single
+          // field per record.
+          expect(
+            command.codeUnits.every((c) => c >= 0x20 && c != 0x7f),
+            isTrue,
+            reason: 'command must stay free of control characters: $command',
+          );
+        }
+      },
+    );
 
     group('killPane', () {
       test('generates correct kill-pane command for standard pane ID', () {
@@ -473,10 +491,11 @@ void main() {
 
   group('listSessions', () {
     test('generates detailed list-sessions command', () {
-      final fs = TmuxCommands.fieldDelimiter;
-      final rs = TmuxCommands.recordDelimiter;
+      final d = TmuxDelimiters.random();
+      final fs = d.field;
+      final rs = d.record;
       expect(
-        TmuxCommands.listSessions(),
+        TmuxCommands.listSessions(d),
         'tmux list-sessions -F "'
         '#{session_name}$fs'
         '#{session_created}$fs'
@@ -559,10 +578,11 @@ void main() {
 
   group('listWindows', () {
     test('generates detailed list-windows command', () {
-      final fs = TmuxCommands.fieldDelimiter;
-      final rs = TmuxCommands.recordDelimiter;
+      final d = TmuxDelimiters.random();
+      final fs = d.field;
+      final rs = d.record;
       expect(
-        TmuxCommands.listWindows('main'),
+        TmuxCommands.listWindows('main', d),
         'tmux list-windows -t main -F "'
         '#{window_index}$fs'
         '#{window_id}$fs'
@@ -575,10 +595,11 @@ void main() {
     });
 
     test('escapes session name', () {
-      final fs = TmuxCommands.fieldDelimiter;
-      final rs = TmuxCommands.recordDelimiter;
+      final d = TmuxDelimiters.random();
+      final fs = d.field;
+      final rs = d.record;
       expect(
-        TmuxCommands.listWindows('my session'),
+        TmuxCommands.listWindows('my session', d),
         'tmux list-windows -t "my session" -F "'
         '#{window_index}$fs'
         '#{window_id}$fs'
@@ -638,10 +659,11 @@ void main() {
 
   group('listPanes', () {
     test('generates detailed list-panes command', () {
-      final fs = TmuxCommands.fieldDelimiter;
-      final rs = TmuxCommands.recordDelimiter;
+      final d = TmuxDelimiters.random();
+      final fs = d.field;
+      final rs = d.record;
       expect(
-        TmuxCommands.listPanes('main', 0),
+        TmuxCommands.listPanes('main', 0, d),
         'tmux list-panes -t main:0 -F "'
         '#{pane_index}$fs'
         '#{pane_id}$fs'
@@ -668,10 +690,11 @@ void main() {
 
   group('listAllPanes', () {
     test('generates list-panes -a command for full tree', () {
-      final fs = TmuxCommands.fieldDelimiter;
-      final rs = TmuxCommands.recordDelimiter;
+      final d = TmuxDelimiters.random();
+      final fs = d.field;
+      final rs = d.record;
       expect(
-        TmuxCommands.listAllPanes(),
+        TmuxCommands.listAllPanes(d),
         'tmux list-panes -a -F "'
         '#{session_name}$fs'
         '#{session_id}$fs'

--- a/test/services/tmux/tmux_delimiters_test.dart
+++ b/test/services/tmux/tmux_delimiters_test.dart
@@ -1,0 +1,62 @@
+import 'package:flutter_muxpod/services/tmux/tmux_delimiters.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('TmuxDelimiters', () {
+    test('TMUX-DELIM-001: a minted pair is printable ASCII', () {
+      // tmux rewrites every non-printable byte of `-F` output to '_' when the
+      // client is not in UTF-8 mode, which makes a control-character delimiter
+      // indistinguishable from the content around it.
+      for (var i = 0; i < 32; i++) {
+        final delimiters = TmuxDelimiters.random();
+        for (final delimiter in [delimiters.field, delimiters.record]) {
+          expect(
+            delimiter.codeUnits.every((c) => c > 0x20 && c < 0x7f),
+            isTrue,
+            reason: 'delimiter must be printable ASCII: $delimiter',
+          );
+        }
+      }
+    });
+
+    test('TMUX-DELIM-002: field and record delimiters are distinct', () {
+      final delimiters = TmuxDelimiters.random();
+      expect(delimiters.field, isNot(delimiters.record));
+    });
+
+    test('TMUX-DELIM-003: every call mints a fresh pair', () {
+      // The whole point of minting per invocation: a delimiter nobody can type
+      // into a session name, because it did not exist when the name was set.
+      final seen = <String>{};
+      for (var i = 0; i < 64; i++) {
+        final delimiters = TmuxDelimiters.random();
+        expect(
+          seen.add(delimiters.field),
+          isTrue,
+          reason: 'field delimiter repeated: ${delimiters.field}',
+        );
+        expect(
+          seen.add(delimiters.record),
+          isTrue,
+          reason: 'record delimiter repeated: ${delimiters.record}',
+        );
+      }
+    });
+
+    test(
+      'TMUX-DELIM-004: a minted pair carries at least 64 bits of entropy',
+      () {
+        final delimiters = TmuxDelimiters.random();
+        expect(RegExp(r'[0-9a-f]{16}').hasMatch(delimiters.field), isTrue);
+        expect(RegExp(r'[0-9a-f]{16}').hasMatch(delimiters.record), isTrue);
+      },
+    );
+
+    test('TMUX-DELIM-005: the legacy pair is the historical US/RS pair', () {
+      // Parse-side only: output from a MuxPod that still asked tmux for
+      // 0x1f/0x1e must keep parsing.
+      expect(TmuxDelimiters.legacy.field, '\x1f');
+      expect(TmuxDelimiters.legacy.record, '\x1e');
+    });
+  });
+}

--- a/test/services/tmux/tmux_facade_test.dart
+++ b/test/services/tmux/tmux_facade_test.dart
@@ -1,6 +1,8 @@
 import 'package:flutter_muxpod/services/command/command_request.dart';
 import 'package:flutter_muxpod/services/command/command_result.dart';
 import 'package:flutter_muxpod/services/tmux/tmux_command_executor.dart';
+import 'package:flutter_muxpod/services/tmux/tmux_contract.dart';
+import 'package:flutter_muxpod/services/tmux/tmux_delimiters.dart';
 import 'package:flutter_muxpod/services/tmux/tmux_facade.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -48,6 +50,61 @@ class _FakeExecutor implements TmuxCommandExecutor {
   Future<void> restoreWindowsNoWait(List<String> targets) async {
     restoreCalls.add(List<String>.of(targets));
   }
+}
+
+/// A tmux that answers in exactly the `-F` format it was handed, so a round
+/// trip is exercised with the delimiters the facade minted for that call —
+/// which no test can know in advance.
+class _FormatEchoExecutor implements TmuxCommandExecutor {
+  /// Field values per record, in the order the format asks for them.
+  final List<List<String>> records;
+  final List<String> commands = [];
+
+  _FormatEchoExecutor(this.records);
+
+  @override
+  bool get isConnected => true;
+
+  @override
+  String? get tmuxPath => null;
+
+  @override
+  Future<CommandResult> execute(CommandRequest request) async {
+    commands.add(request.command);
+    final format = RegExp(
+      r'-F "([^"]*)"',
+    ).firstMatch(request.command)?.group(1);
+    final out = StringBuffer();
+    if (format != null) {
+      for (final values in records) {
+        var i = 0;
+        out.write(
+          format.replaceAllMapped(RegExp(r'#\{\w+\}'), (_) => values[i++]),
+        );
+        // tmux ends every -F record with a newline.
+        out.write('\n');
+      }
+    }
+    return CommandResult(
+      stdout: out.toString(),
+      stderr: '',
+      exitCode: 0,
+      outputSeparation: CommandOutputSeparation.separated,
+      actualTransport: CommandTransport.ephemeral,
+    );
+  }
+
+  @override
+  void write(String data) {}
+
+  @override
+  Future<void> sendKeysCommand(String command) async {}
+
+  @override
+  Future<void> setWindowRestoreTrap(List<String> windowTargets) async {}
+
+  @override
+  Future<void> restoreWindowsNoWait(List<String> targets) async {}
 }
 
 void main() {
@@ -106,5 +163,84 @@ void main() {
         expect(executor.commands, isEmpty);
       },
     );
+  });
+
+  group('TmuxFacade delimiters', () {
+    test(
+      'listSessions round-trips the delimiters minted for that call',
+      () async {
+        // The builder and the parser agree on a pair nobody else has seen; if
+        // they ever drift, every record parses to a single field and the list
+        // comes back empty with no error at all.
+        final executor = _FormatEchoExecutor([
+          ['mysession', '1735689600', '1', '3', r'$0'],
+          ['other', '1735689700', '0', '1', r'$1'],
+        ]);
+
+        final sessions = await tmuxFacade.listSessions(executor);
+
+        expect(sessions.map((s) => s.name), ['mysession', 'other']);
+        expect(sessions.first.windowCount, 3);
+        expect(sessions.first.attached, isTrue);
+      },
+    );
+
+    test('a session named after a delimiter is not a delimiter', () async {
+      // tmux takes these strings in a session name, so a fixed delimiter can
+      // be typed into one and shift the fields of the record around it.
+      final foreign = TmuxDelimiters.random();
+      final name = '@@F@@${foreign.field}@@R@@';
+      final executor = _FormatEchoExecutor([
+        [name, '1735689600', '1', '3', r'$0'],
+      ]);
+
+      final sessions = await tmuxFacade.listSessions(executor);
+
+      expect(sessions.single.name, name);
+      expect(sessions.single.windowCount, 3);
+    });
+
+    test('listAllPanes round-trips the minted delimiters', () async {
+      final executor = _FormatEchoExecutor([
+        [
+          'mysession', r'$0', '0', '@0', 'shell', '1', //
+          '0', '%0', '1', '80', '24', '0', '0', //
+          'title', 'bash', '5', '10', '/home/user', '-',
+        ],
+      ]);
+
+      final sessions = await tmuxFacade.listAllPanes(executor);
+
+      expect(sessions.single.name, 'mysession');
+      expect(sessions.single.windows.single.panes.single.id, '%0');
+    });
+
+    test('mangled output is reported, not served as an empty list', () async {
+      // What tmux answers a non-UTF-8 client when the delimiters are control
+      // characters: every one of them rewritten to '_', exit code 0, empty
+      // stderr. Before, that reached the UI as "no tmux sessions found".
+      final executor = _FakeExecutor({
+        'list-sessions': 'claude/monoroll_\$0\n',
+      });
+
+      await expectLater(
+        tmuxFacade.listSessions(executor),
+        throwsA(isA<TmuxOutputParseException>()),
+      );
+    });
+
+    test('nothing to parse is an empty list, not a failure', () async {
+      final executor = _FakeExecutor({'list-sessions': ''});
+
+      expect(await tmuxFacade.listSessions(executor), isEmpty);
+    });
+
+    test('a dead tmux server is an empty list, not a failure', () async {
+      final executor = _FakeExecutor({
+        'list-sessions': 'no server running on /tmp/tmux-1000/default\n',
+      });
+
+      expect(await tmuxFacade.listSessions(executor), isEmpty);
+    });
   });
 }

--- a/test/services/tmux/tmux_parser_test.dart
+++ b/test/services/tmux/tmux_parser_test.dart
@@ -2,35 +2,60 @@
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_muxpod/services/tmux/tmux_command_builder.dart';
+import 'package:flutter_muxpod/services/tmux/tmux_delimiters.dart';
 import 'package:flutter_muxpod/services/tmux/tmux_models.dart';
 import 'package:flutter_muxpod/services/tmux/tmux_parser_adapter.dart';
 
 import '../../fixtures/tmux/tmux_parser_fixtures.dart';
 
-const _fs = TmuxParser.defaultFieldDelimiter;
-const _rs = TmuxParser.defaultRecordDelimiter;
+const _fs = TmuxDelimiters.legacyField;
+const _rs = TmuxDelimiters.legacyRecord;
 
 void main() {
   group('TmuxParser', () {
+    test('TMUX-PARSER-001: records written with the legacy pair parse under a '
+        'freshly minted one', () {
+      // Output from a MuxPod that still asked tmux for 0x1f/0x1e, and every
+      // fixture modelled on it, has to keep parsing.
+      final sessions = TmuxParser.parseSessions(
+        kSessionOutput,
+        delimiters: TmuxDelimiters.random(),
+      );
+
+      expect(sessions.map((s) => s.name), ['mysession', 'other']);
+      expect(sessions.first.windowCount, 3);
+    });
+
     test(
-      'TMUX-PARSER-001: deprecated defaultDelimiter tracks the field delimiter',
+      'TMUX-PARSER-001: the literal octal spelling of the legacy pair parses '
+      'under a freshly minted one',
       () {
-        expect(TmuxParser.defaultDelimiter, TmuxParser.defaultFieldDelimiter);
-        // Must stay printable: tmux 3.7 rewrites every non-printable byte in
-        // -F output to '_', which silently collapses the fields into one.
-        for (final d in [
-          TmuxParser.defaultFieldDelimiter,
-          TmuxParser.defaultRecordDelimiter,
-        ]) {
-          expect(d, isNotEmpty);
-          expect(
-            d.codeUnits.every((c) => c >= 0x20 && c != 0x7f),
-            isTrue,
-            reason: 'delimiter must contain no control characters: $d',
-          );
-        }
+        // tmux <= 3.5a escapes the control bytes on the way out, so the
+        // delimiter reaches the app as the four characters \037.
+        const output =
+            r'mysession\0371735689600\0371\0373\037$0\036'
+            r'other\0371735689700\0370\0371\037$1\036';
+
+        final sessions = TmuxParser.parseSessions(
+          output,
+          delimiters: TmuxDelimiters.random(),
+        );
+
+        expect(sessions.map((s) => s.name), ['mysession', 'other']);
+        expect(sessions.first.windowCount, 3);
       },
     );
+
+    test('TMUX-PARSER-022: hasRecordContent separates mangled output from '
+        'nothing to parse', () {
+      // An empty parse result over output that carried records means the
+      // delimiters did not survive; that used to reach the UI as
+      // "no sessions" with exit code 0.
+      expect(TmuxParser.hasRecordContent(''), isFalse);
+      expect(TmuxParser.hasRecordContent('  \n '), isFalse);
+      expect(TmuxParser.hasRecordContent(kNoServerOutput), isFalse);
+      expect(TmuxParser.hasRecordContent('claude/monoroll_\$0\n'), isTrue);
+    });
 
     group('parseSessions', () {
       test('parses detailed session output', () {
@@ -415,29 +440,36 @@ void main() {
       test('TMUX-PARSER-020: converts literal \\x1f/\\x1e to control chars', () {
         const literal =
             'sess\\x1f123\\x1f0\\x1f2\\x1f\$0\\x1eother\\x1f456\\x1f1\\x1f1\\x1f\$1\\x1e';
-        final normalized = TmuxParser.normalizeDelimiters(literal);
+        final normalized = TmuxParser.normalizeDelimiters(
+          literal,
+          TmuxDelimiters.legacy,
+        );
         expect(normalized.contains(_fs), isTrue);
         expect(normalized.contains(_rs), isTrue);
         expect(normalized.contains(r'\x1f'), isFalse);
         expect(normalized.contains(r'\x1e'), isFalse);
       });
 
-      test(
-        'TMUX-PARSER-020: converts octal literal \\037/\\036 to control chars',
-        () {
-          const literal =
-              'sess\\037123\\0370\\0372\\037\$0\\036other\\037456\\0371\\0371\\037\$1\\036';
-          final normalized = TmuxParser.normalizeDelimiters(literal);
-          expect(normalized.contains(_fs), isTrue);
-          expect(normalized.contains(_rs), isTrue);
-          expect(normalized.contains(r'\037'), isFalse);
-          expect(normalized.contains(r'\036'), isFalse);
-        },
-      );
+      test('TMUX-PARSER-020: folds the octal literal \\037/\\036 onto the '
+          'delimiters of the current call', () {
+        const literal =
+            'sess\\037123\\0370\\0372\\037\$0\\036other\\037456\\0371\\0371\\037\$1\\036';
+        final delimiters = TmuxDelimiters.random();
+
+        final normalized = TmuxParser.normalizeDelimiters(literal, delimiters);
+
+        expect(normalized.contains(delimiters.field), isTrue);
+        expect(normalized.contains(delimiters.record), isTrue);
+        expect(normalized.contains(r'\037'), isFalse);
+        expect(normalized.contains(r'\036'), isFalse);
+      });
 
       test('TMUX-PARSER-020: leaves real control chars untouched', () {
         final literal = 'sess$_fs"123"$_fs"0"$_fs"2"$_fs"\$0"$_rs"other"';
-        final normalized = TmuxParser.normalizeDelimiters(literal);
+        final normalized = TmuxParser.normalizeDelimiters(
+          literal,
+          TmuxDelimiters.legacy,
+        );
         expect(normalized, literal);
       });
 

--- a/test/services/tmux/tmux_parser_test.dart
+++ b/test/services/tmux/tmux_parser_test.dart
@@ -13,10 +13,22 @@ const _rs = TmuxParser.defaultRecordDelimiter;
 void main() {
   group('TmuxParser', () {
     test(
-      'TMUX-PARSER-001: deprecated defaultDelimiter remains the US delimiter',
+      'TMUX-PARSER-001: deprecated defaultDelimiter tracks the field delimiter',
       () {
-        expect(TmuxParser.defaultDelimiter, String.fromCharCode(0x1f));
         expect(TmuxParser.defaultDelimiter, TmuxParser.defaultFieldDelimiter);
+        // Must stay printable: tmux 3.7 rewrites every non-printable byte in
+        // -F output to '_', which silently collapses the fields into one.
+        for (final d in [
+          TmuxParser.defaultFieldDelimiter,
+          TmuxParser.defaultRecordDelimiter,
+        ]) {
+          expect(d, isNotEmpty);
+          expect(
+            d.codeUnits.every((c) => c >= 0x20 && c != 0x7f),
+            isTrue,
+            reason: 'delimiter must contain no control characters: $d',
+          );
+        }
       },
     );
 

--- a/tool/herdr-inventory/tmux-contract-inventory.json
+++ b/tool/herdr-inventory/tmux-contract-inventory.json
@@ -10048,29 +10048,23 @@
     {
       "id": "TMUX-CMD-001",
       "sourceFile": "lib/services/tmux/tmux_command_builder.dart",
-      "line": 16,
-      "name": "TmuxCommands.fieldDelimiter",
-      "public": true,
-      "symbolType": "field",
-      "signature": "static const String fieldDelimiter = '\\x1f'",
-      "contract": "tmux フォーマットのフィールド区切りに US (0x1f) を使用する。",
-      "characterization": "list 系コマンドの各フィールド間に使用する。",
+      "line": 17,
+      "name": "TmuxCommands._listFormat",
+      "public": false,
+      "symbolType": "method",
+      "signature": "static String _listFormat(List<String> fields, TmuxDelimiters delimiters)",
+      "contract": "list 系コマンドの -F 文字列を、呼び出しごとの区切り文字ペアで組み立てる。",
+      "characterization": "区切り文字は TmuxDelimiters から受け取り、この class は固定値を持たない。",
       "failureMode": "N/A",
       "sideEffects": "none",
-      "consumers": [
-        "lib/screens/connections/connection_form_screen.dart",
-        "lib/services/tmux/tmux_commands.dart",
-        "lib/services/tmux/tmux_facade.dart",
-        "lib/services/tmux/tmux_parser_adapter.dart",
-        "lib/services/tmux/tmux_shell_lifecycle.dart"
-      ],
+      "consumers": [],
       "tests": [
         "test/services/tmux/tmux_commands_test.dart"
       ],
       "dependsOn": [],
       "searchTokens": [
-        "fieldDelimiter",
-        "TmuxCommands.fieldDelimiter",
+        "_listFormat",
+        "TmuxCommands._listFormat",
         "TmuxCommands"
       ]
     },
@@ -14063,28 +14057,24 @@
     {
       "id": "TMUX-PARSER-001",
       "sourceFile": "lib/services/tmux/tmux_parser_adapter.dart",
-      "line": 15,
-      "name": "TmuxParser.defaultFieldDelimiter",
+      "line": 14,
+      "name": "TmuxParser.defaultDelimiters",
       "public": true,
       "symbolType": "field",
-      "signature": "static const String defaultFieldDelimiter = '\\x1f'",
-      "contract": "tmux 出力の既定フィールド区切りに US (0x1f) を使用する。",
-      "characterization": "session/window/pane parser の既定フィールド区切り。",
+      "signature": "static const TmuxDelimiters defaultDelimiters = TmuxDelimiters.legacy",
+      "contract": "TmuxCommands 由来でない出力に仮定する区切り文字ペア（旧 US/RS）。",
+      "characterization": "アプリが自分で発行した出力は、その呼び出しで生成したペアで解析する。",
       "failureMode": "N/A",
       "sideEffects": "none",
-      "consumers": [
-        "lib/services/tmux/tmux_command_builder.dart",
-        "lib/services/tmux/tmux_facade.dart",
-        "lib/services/tmux/tmux_parser.dart"
-      ],
+      "consumers": [],
       "tests": [
         "test/services/tmux/tmux_parser_test.dart"
       ],
       "dependsOn": [],
       "searchTokens": [
         "TmuxParser",
-        "defaultFieldDelimiter",
-        "TmuxParser.defaultFieldDelimiter"
+        "defaultDelimiters",
+        "TmuxParser.defaultDelimiters"
       ]
     },
     {


### PR DESCRIPTION
On tmux 3.7 the session list comes back empty while the sessions are there and SSH is fine.

## Cause

tmux 3.7 replaces every non-printable byte in `-F` output with `_`. Verified with `od -c` on the remote side against tmux 3.7c:

```
$ tmux list-sessions -F "#{session_name}\x1f#{session_id}\x1e" | od -c
0000000   c   l   a   u   d   e   /   m   o   n   o   r   o   l   l   _
0000020   $   8  \n
```

`0x1f`, `0x1e`, `0x01` and even TAB all arrive as the same character, so the delimiter is indistinguishable from the content. `parseSessionLine` sees one field, returns `null` for every record, and `listSessions` returns `[]`.

Nothing throws and `_execChecked` sees `exitCode == 0` with empty stderr, so the UI shows **"No tmux sessions found"** rather than an error — which reads as a connection problem.

## Why printable

The control character never actually survived. On tmux 3.4 the same command emits the literal text `\037`, which is what `normalizeDelimiters` was already working around. 3.7 only changed the mangling into a form that cannot be recovered, because `_` is a legal character in a session name.

This is the same direction as 23f8503 (*"change delimiter from tab to ||| for SSH compatibility"*), before the later move to `0x1f`/`0x1e` reintroduced the problem.

`normalizeDelimiters` still accepts the raw control characters and their literal spellings, so output from older tmux keeps parsing through the same path — no behaviour change there.

## Tests

`TMUX-CMD-001` / `TMUX-PARSER-001` now assert the invariant instead of a specific byte: the delimiters contain no control characters, and the builder agrees with the parser. A future delimiter change then fails in CI rather than silently emptying the session list.

`flutter analyze` clean, `flutter test --exclude-tags=repro` → 1594 passed.

Found while running MuxPod against Arch Linux (tmux 3.7c) and macOS (Homebrew tmux 3.7c). Thanks for MuxPod — it is doing real work for me over an overlay network.