### PR TITLE
fix(ssh): do not drop the session on a single keep-alive miss

### DIFF
--- a/lib/services/ssh/ssh_client.dart
+++ b/lib/services/ssh/ssh_client.dart
@@ -265,8 +265,19 @@ class SshClient implements BackendAdapter {
   /// Keep-alive最大間隔（秒）
   static const int _maxKeepAliveIntervalSeconds = 30;
 
-  /// Keep-aliveタイムアウト（秒）- 高速検知のため3秒に短縮
-  static const int _keepAliveTimeoutSeconds = 3;
+  /// Keep-alive timeout. 3s gives fast detection and holds on a LAN, but a
+  /// cellular link, a VPN or a relayed hop misses a 3s round trip routinely,
+  /// and the phone throttling timers in the background makes it likelier still.
+  static const int _keepAliveTimeoutSeconds = 10;
+
+  /// Consecutive keep-alive failures before the connection is declared dead.
+  /// A single lost probe is normal on a mobile link and must not tear down a
+  /// live session; detection stays fast because the probe interval already
+  /// shortens on failure.
+  static const int _keepAliveFailureThreshold = 3;
+
+  /// Consecutive keep-alive failures so far.
+  int _keepAliveFailureCount = 0;
 
   /// 現在のKeep-alive間隔（動的に調整）
   int _currentKeepAliveIntervalSeconds = 10;
@@ -728,6 +739,7 @@ class SshClient implements BackendAdapter {
     _stopKeepAlive();
     _currentKeepAliveIntervalSeconds = 10; // 初期値10秒
     _keepAliveSuccessCount = 0;
+    _keepAliveFailureCount = 0;
     // inventory: SSH-LIFE-009
     _scheduleNextKeepAlive();
   }
@@ -792,10 +804,16 @@ class SshClient implements BackendAdapter {
           timeout: Duration(seconds: _keepAliveTimeoutSeconds),
         ),
       );
+      _keepAliveFailureCount = 0;
       _adjustKeepAliveInterval(success: true);
     } catch (e) {
       _adjustKeepAliveInterval(success: false);
-      // Keep-alive失敗 = 接続切断
+      _keepAliveFailureCount++;
+      if (_keepAliveFailureCount < _keepAliveFailureThreshold) {
+        // Probe more often (the interval already shortened) and give the link
+        // a chance to come back before tearing the session down.
+        return;
+      }
       _lastError =
           _l10n?.sshConnectionLostDetail(e.toString()) ?? 'Connection lost: $e';
       _updateState(SshConnectionState.error);

--- a/test/services/ssh/ssh_client_test.dart
+++ b/test/services/ssh/ssh_client_test.dart
@@ -525,7 +525,18 @@ void main() {
         expect(shells.first.commands, ['echo ping', 'echo ping', 'echo ping']);
         expect(timers.last.duration, const Duration(seconds: 15));
 
+        // A lost probe must NOT tear the session down on its own: on a mobile
+        // link single misses are routine, and treating one as a disconnect
+        // puts the terminal into a permanent reconnect loop.
         shells.first.error = StateError('lost');
+        for (var i = 0; i < 2; i++) {
+          timers.last.fire();
+          await Future<void>.delayed(Duration.zero);
+          expect(client.state, isNot(SshConnectionState.error));
+          expect(closeCalls, 0);
+        }
+
+        // The third consecutive failure is the disconnect.
         timers.last.fire();
         await Future<void>.delayed(Duration.zero);
         expect(client.state, SshConnectionState.error);


### PR DESCRIPTION
On a high-latency link the terminal sits in **"Reconnecting"** while the network is perfectly fine.

## Cause

`_sendKeepAlive` runs `echo ping` with a 3s timeout, and any failure is treated as a disconnect:

```dart
} catch (e) {
  _adjustKeepAliveInterval(success: false);
  // Keep-alive失敗 = 接続切断
  _updateState(SshConnectionState.error);
  ...
  _events.onClose?.call();
}
```

A single missed probe tears down a live session and triggers a full reconnect.

3s is a reasonable choice on a LAN. Over a cellular link, a VPN or a relayed hop it is missed routinely, and Android throttling timers while the app is backgrounded makes it likelier still.

## Measured

Against a host reached over an overlay network: **110 SSH handshakes in 15 minutes**, in bursts, with no packet loss, no tunnel drop, and no disconnect logged on the server side. Every burst was one lost probe followed by the reconnect loop.

## Change

- timeout 3s → 10s, still well inside the 5–30s probe interval
- the connection is declared dead only after **3 consecutive** failures

Detection stays fast: `_adjustKeepAliveInterval` already shortens the interval on failure, so a genuinely dead link is still caught within a few seconds.

`SSH-LIFE-008..012` is updated to assert that: two failures keep the session, the third disconnects.

`flutter analyze` clean, `flutter test --exclude-tags=repro` → 1594 passed.