### PR TITLE
feat(keys): add a backspace key to the special keys bar

### DIFF
--- a/lib/providers/custom_keys_provider.dart
+++ b/lib/providers/custom_keys_provider.dart
@@ -81,7 +81,10 @@ class CustomKeysNotifier extends Notifier<CustomKeysState> {
         ? _loadRows(prefs)
         : await _migrateLegacyRows(prefs);
     if (!ref.mounted) return;
-    state = CustomKeysState(buttons: buttons, rows: _ensureBackspace(prefs, rows));
+    state = CustomKeysState(
+      buttons: buttons,
+      rows: _ensureBackspace(prefs, rows),
+    );
     await _persist();
   }
 

--- a/lib/providers/custom_keys_provider.dart
+++ b/lib/providers/custom_keys_provider.dart
@@ -62,6 +62,11 @@ class CustomKeysNotifier extends Notifier<CustomKeysState> {
 
   static const String shelfMigrationKey = 'custom_keys_shelf_v1';
 
+  /// One-shot: put the backspace key into layouts saved before it existed.
+  /// Without this the key ships only to fresh installs, and anyone who already
+  /// opened the app keeps a bar with no way to erase.
+  static const String bspaceMigrationKey = 'custom_keys_bspace_v1';
+
   @override
   CustomKeysState build() {
     _load();
@@ -76,8 +81,29 @@ class CustomKeysNotifier extends Notifier<CustomKeysState> {
         ? _loadRows(prefs)
         : await _migrateLegacyRows(prefs);
     if (!ref.mounted) return;
-    state = CustomKeysState(buttons: buttons, rows: rows);
+    state = CustomKeysState(buttons: buttons, rows: _ensureBackspace(prefs, rows));
     await _persist();
+  }
+
+  /// Adds 'bspace' next to 'dash' once, for layouts saved before it existed.
+  List<List<String>> _ensureBackspace(
+    SharedPreferences prefs,
+    List<List<String>> rows,
+  ) {
+    if (prefs.getBool(bspaceMigrationKey) ?? false) return rows;
+    prefs.setBool(bspaceMigrationKey, true);
+    if (rows.any((row) => row.contains('bspace'))) return rows;
+    // Only ever placed next to '-', never appended somewhere arbitrary: a
+    // layout without '-' is one the user rearranged deliberately, and the key
+    // stays available from the customizer shelf either way.
+    for (final row in rows) {
+      final i = row.indexOf('dash');
+      if (i >= 0) {
+        row.insert(i + 1, 'bspace');
+        return rows;
+      }
+    }
+    return rows;
   }
 
   List<CustomKeyButton> _loadButtons(SharedPreferences prefs) {

--- a/lib/services/custom_keys/custom_key_button.dart
+++ b/lib/services/custom_keys/custom_key_button.dart
@@ -96,6 +96,7 @@ class CustomKeyRows {
     'senter',
     'slash',
     'dash',
+    'bspace',
   ];
 
   static const List<String> standardRow2 = [
@@ -150,6 +151,7 @@ class CustomKeyRows {
     'senter' => 'S-RET',
     'slash' => '/',
     'dash' => '-',
+    'bspace' => '\u232b',
     'pgup' => 'PgUp',
     'pgdn' => 'PgDn',
     'left' => 'Left',

--- a/lib/widgets/special_keys_bar.dart
+++ b/lib/widgets/special_keys_bar.dart
@@ -665,6 +665,10 @@ class _SpecialKeysBarState extends State<SpecialKeysBar> {
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 4),
       color: isDark ? DesignColors.surfaceDark : DesignColors.surfaceLight,
+      // Plain Row on purpose: these builders return Expanded, so they share the
+      // width. Wrapping this in a horizontal scroll view makes the row
+      // unbounded and every flex child an error — the backspace key is just a
+      // tenth flex child, and they all get slightly narrower.
       child: Row(
         children: [
           _buildSpecialKeyButton('ESC', 'Escape'),
@@ -682,6 +686,7 @@ class _SpecialKeysBarState extends State<SpecialKeysBar> {
           _buildShiftEnterKeyButton(),
           _buildLiteralKeyButton('/', '/'),
           _buildLiteralKeyButton('-', '-'),
+          _buildSpecialKeyButton('\u232b', 'BSpace'),
           if (withManageButton) _buildManageButton(),
         ],
       ),
@@ -796,6 +801,11 @@ class _SpecialKeysBarState extends State<SpecialKeysBar> {
         return _buildLiteralKeyButton('/', '/', width: 32);
       case 'dash':
         return _buildLiteralKeyButton('-', '-', width: 32);
+      // Without this there is no way to erase anything typed from this bar:
+      // its literal keys go straight into the pane, and the phone keyboard is
+      // only reachable in Direct Input mode.
+      case 'bspace':
+        return _buildNavigationKeyButton('\u232b', 'BSpace');
       case 'pgup':
         return _buildNavigationKeyButton('PgUp', 'PPage');
       case 'pgdn':

--- a/test/providers/custom_keys_provider_test.dart
+++ b/test/providers/custom_keys_provider_test.dart
@@ -327,30 +327,33 @@ void main() {
     expect(s.rows[1].first, 'tab');
   });
 
-  test('backspace is inserted next to dash in a layout saved without it', () async {
-    // The real upgrade path: the app was already opened, so a layout without
-    // 'bspace' is persisted. Without the migration the bar would keep no way
-    // to erase, since the key only ships in the defaults.
-    SharedPreferences.setMockInitialValues({
-      CustomKeysNotifier.rowsKey: jsonEncode([
-        <String>[],
-        ['esc', 'tab', 'slash', 'dash'],
-        ['left', 'right'],
-      ]),
-    });
-    final container = ProviderContainer();
-    addTearDown(container.dispose);
-    container.read(customKeysProvider);
-    await Future<void>.delayed(Duration.zero);
+  test(
+    'backspace is inserted next to dash in a layout saved without it',
+    () async {
+      // The real upgrade path: the app was already opened, so a layout without
+      // 'bspace' is persisted. Without the migration the bar would keep no way
+      // to erase, since the key only ships in the defaults.
+      SharedPreferences.setMockInitialValues({
+        CustomKeysNotifier.rowsKey: jsonEncode([
+          <String>[],
+          ['esc', 'tab', 'slash', 'dash'],
+          ['left', 'right'],
+        ]),
+      });
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      container.read(customKeysProvider);
+      await Future<void>.delayed(Duration.zero);
 
-    expect(container.read(customKeysProvider).rows[1], [
-      'esc',
-      'tab',
-      'slash',
-      'dash',
-      'bspace',
-    ]);
-  });
+      expect(container.read(customKeysProvider).rows[1], [
+        'esc',
+        'tab',
+        'slash',
+        'dash',
+        'bspace',
+      ]);
+    },
+  );
 
   test('a layout without dash is left untouched', () async {
     // Rearranged by hand: inserting into it would be presumptuous, and the key

--- a/test/providers/custom_keys_provider_test.dart
+++ b/test/providers/custom_keys_provider_test.dart
@@ -327,6 +327,50 @@ void main() {
     expect(s.rows[1].first, 'tab');
   });
 
+  test('backspace is inserted next to dash in a layout saved without it', () async {
+    // The real upgrade path: the app was already opened, so a layout without
+    // 'bspace' is persisted. Without the migration the bar would keep no way
+    // to erase, since the key only ships in the defaults.
+    SharedPreferences.setMockInitialValues({
+      CustomKeysNotifier.rowsKey: jsonEncode([
+        <String>[],
+        ['esc', 'tab', 'slash', 'dash'],
+        ['left', 'right'],
+      ]),
+    });
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    container.read(customKeysProvider);
+    await Future<void>.delayed(Duration.zero);
+
+    expect(container.read(customKeysProvider).rows[1], [
+      'esc',
+      'tab',
+      'slash',
+      'dash',
+      'bspace',
+    ]);
+  });
+
+  test('a layout without dash is left untouched', () async {
+    // Rearranged by hand: inserting into it would be presumptuous, and the key
+    // is still reachable from the customizer shelf.
+    SharedPreferences.setMockInitialValues({
+      CustomKeysNotifier.rowsKey: jsonEncode([
+        <String>[],
+        ['esc', 'tab'],
+        ['left', 'right'],
+      ]),
+    });
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    container.read(customKeysProvider);
+    await Future<void>.delayed(Duration.zero);
+
+    final rows = container.read(customKeysProvider).rows;
+    expect(rows.any((row) => row.contains('bspace')), isFalse);
+  });
+
   test(
     'placeToken same-row move to higher index adjusts for removal',
     () async {
@@ -337,7 +381,8 @@ void main() {
       await Future<void>.delayed(Duration.zero);
       final notifier = container.read(customKeysProvider.notifier);
 
-      // row1 default: [esc, tab, ctrl, alt, shift, enter, senter, slash, dash]
+      // row1 default:
+      // [esc, tab, ctrl, alt, shift, enter, senter, slash, dash, bspace]
       notifier.placeToken('esc', toRow: 1, toIndex: 2);
 
       expect(container.read(customKeysProvider).rows[1], [
@@ -350,6 +395,7 @@ void main() {
         'senter',
         'slash',
         'dash',
+        'bspace',
       ]);
     },
   );


### PR DESCRIPTION
The special keys bar has no way to erase.

Its literal keys (`/`, `-`) and any custom key send their text straight into the pane, and the phone keyboard — the only thing that carries a backspace — is reachable only in Direct Input mode. A typo made from the bar cannot be corrected from the bar.

## Change

A `⌫` key that sends the tmux key name `BSpace`, alongside the existing Escape/Tab buttons.

It is a **tenth flex child** of the modifier row. Those builders return `Expanded` and share the width, so the row stays exactly as wide and every key gets slightly narrower. A horizontal scroll view is not an option here: it makes the row unbounded, and every flex child in it becomes an error.

`bspace` is a placeable token too, so it can be moved or removed from the customizer like any other key.

## Migration

A one-shot migration (`custom_keys_bspace_v1`) puts the key into layouts saved before it existed, next to `-`.

Without it the key would only ever reach a fresh install — anyone who had already opened the app would keep a bar with no way to erase, which is the whole point of the change.

A layout with no `-` is one the user rearranged deliberately and is left untouched; the key is still reachable from the customizer shelf there. Both paths are covered by tests.

`flutter analyze` clean, `flutter test --exclude-tags=repro` → 1596 passed.