### PR TITLE
fix(tmux): force UTF-8 mode on the tmux client (non-ASCII names come back as ______)

### DIFF
--- a/lib/services/tmux/tmux_executable_resolver.dart
+++ b/lib/services/tmux/tmux_executable_resolver.dart
@@ -109,20 +109,27 @@ class TmuxExecutableResolver {
   }
 
   // inventory: SSH-LIFE-006
-  /// [command] 内の `tmux` コマンドを解決済み絶対パスに置換する。
+  /// [command] 内の `tmux` 起動を解決済み絶対パス + `-u` に置換する。
   ///
   /// ユーザーが明示パスを指定していればそれを優先し、検出失敗時も
   /// そのパスをそのまま使用して bare `tmux` への勝手な fallback を防ぐ。
   /// 未指定時のみ bare `tmux` または自動検出したパスを使用する。
   /// 挿入するパスは [shQuote] 済みのため、ユーザ入力によるシェルインジェクション
   /// を防ぐ。
+  ///
+  /// `-u` は必須。tmux クライアントが UTF-8 モードになるのは `$TMUX` /
+  /// `LC_ALL` / `LC_CTYPE` / `LANG` がそう言っているときだけで、SSH の
+  /// コマンドチャネルはそのどれも運ばない。UTF-8 でないクライアントに対し、
+  /// tmux は `-F` と `display-message` の出力を `utf8_sanitize()` に通し、
+  /// `0x20..0x7e` の外のバイトをすべて `_` に書き換える。セッション名
+  /// `プロジェクト` は `______` として届き、その名前で attach しても一致しない。
+  /// 既に `-u` が付いている起動には二重に付けない。
   String resolve(String command) {
     final bin = tmuxBin;
-    if (bin == 'tmux') return command;
-    final quoted = shQuote(bin);
+    final invocation = bin == 'tmux' ? 'tmux' : shQuote(bin);
     return command.replaceAllMapped(
-      RegExp(r'(^|;\s*)tmux\b'),
-      (m) => '${m[1]}$quoted',
+      RegExp(r'(^|;\s*)tmux\b(?!\s+-u\b)'),
+      (m) => '${m[1]}$invocation -u',
     );
   }
 

--- a/test/services/tmux/ssh_tmux_command_executor_test.dart
+++ b/test/services/tmux/ssh_tmux_command_executor_test.dart
@@ -39,7 +39,7 @@ void main() {
       sshClient.setConnected(SshConnectionState.connected);
       sshClient.execOutputs = {
         r"$SHELL -lc 'command -v tmux'": '/usr/bin/tmux',
-        '/usr/bin/tmux -V': 'tmux 3.2a',
+        '/usr/bin/tmux -u -V': 'tmux 3.2a',
       };
       executor = SshTmuxCommandExecutor(sshClient);
     });
@@ -57,7 +57,7 @@ void main() {
       expect(output, 'tmux 3.2a');
       expect(TmuxVersionInfo.parse(output), isNotNull);
       expect(executor.tmuxPath, '/usr/bin/tmux');
-      expect(sshClient.execCommands, contains("'/usr/bin/tmux' -V"));
+      expect(sshClient.execCommands, contains("'/usr/bin/tmux' -u -V"));
     });
 
     test(
@@ -81,7 +81,7 @@ void main() {
         await executor.sendKeysCommand(TmuxCommands.sendKeys('target', 'C-c'));
 
         expect(input.sent, hasLength(1));
-        expect(input.sent.single, contains("'/usr/bin/tmux' send-keys"));
+        expect(input.sent.single, contains("'/usr/bin/tmux' -u send-keys"));
         expect(sshClient.execCommands, [r"$SHELL -lc 'command -v tmux'"]);
       },
     );
@@ -173,7 +173,7 @@ void main() {
 
       client.execExceptions = {};
       client.execExitCodes = {"test -x '/custom/tmux'": 0};
-      client.execOutputs = {'/custom/tmux -V': 'tmux 3.2a'};
+      client.execOutputs = {'/custom/tmux -u -V': 'tmux 3.2a'};
 
       final result = await retryExecutor.execute(
         CommandRequest(

--- a/test/services/tmux/tmux_executable_resolver_test.dart
+++ b/test/services/tmux/tmux_executable_resolver_test.dart
@@ -88,7 +88,7 @@ void main() {
         expect(resolver.tmuxPath, isNull);
         expect(resolver.customPath, '/custom/tmux');
         expect(resolver.tmuxBin, '/custom/tmux');
-        expect(resolver.resolve('tmux -V'), "'/custom/tmux' -V");
+        expect(resolver.resolve('tmux -V'), "'/custom/tmux' -u -V");
       },
     );
 
@@ -101,13 +101,38 @@ void main() {
       expect(resolver.tmuxPath, isNull);
     });
 
+    test('resolve forces UTF-8 mode on an unresolved tmux', () async {
+      // A tmux client speaks UTF-8 only when $TMUX, LC_ALL, LC_CTYPE or LANG
+      // says so, and an SSH command channel carries none of them. Without -u
+      // tmux runs every -F field through utf8_sanitize(), which rewrites each
+      // byte outside 0x20..0x7e to '_': a session named 'プロジェクト' comes
+      // back as '______' and attaching to that name cannot match.
+      expect(resolver.resolve('tmux list-sessions'), 'tmux -u list-sessions');
+    });
+
+    test('resolve forces UTF-8 mode on every tmux of a compound command', () {
+      expect(
+        resolver.resolve(
+          "printf 'x'; tmux capture-pane -p; tmux display-message -p '#{pane_id}'",
+        ),
+        "printf 'x'; tmux -u capture-pane -p; "
+        "tmux -u display-message -p '#{pane_id}'",
+      );
+    });
+
+    test('resolve does not add -u twice', () {
+      final once = resolver.resolve('tmux list-sessions');
+
+      expect(resolver.resolve(once), once);
+    });
+
     test('resolve rewrites only tmux commands at command boundaries', () async {
       client.execExitCodes = {"test -x '/path with space/tmux'": 0};
       await resolver.detect(client, executablePath: '/path with space/tmux');
 
       expect(
         resolver.resolve('echo tmux; tmux -V; nottmux -V'),
-        "echo tmux; '/path with space/tmux' -V; nottmux -V",
+        "echo tmux; '/path with space/tmux' -u -V; nottmux -V",
       );
     });
   });


### PR DESCRIPTION
The follow-up to #108 you asked about. Independent of it — this only touches `TmuxExecutableResolver` — so it can be reviewed in parallel and merged in either order.

## Why

A tmux client is in UTF-8 mode only when `$TMUX`, `LC_ALL`, `LC_CTYPE` or `LANG` says so (`tmux.c`, `main()`):

```c
if (getenv("TMUX") != NULL)
        flags |= CLIENT_UTF8;
else {
        s = getenv("LC_ALL");
        if (s == NULL || *s == '\0') s = getenv("LC_CTYPE");
        if (s == NULL || *s == '\0') s = getenv("LANG");
        if (s == NULL || *s == '\0') s = "";
        if (strcasestr(s, "UTF-8") != NULL || strcasestr(s, "UTF8") != NULL)
                flags |= CLIENT_UTF8;
}
```

An SSH command channel carries none of them: sshd forwards `LANG`/`LC_*` only with a matching `SendEnv`/`AcceptEnv` pair, and a remote command runs non-login and non-interactive, so no rc file sets one either. MuxPod therefore always talks to tmux as a non-UTF-8 client — verified on both boxes I have: `ssh host 'echo "[$LANG]"'` prints `[]` on Arch and on macOS, while the same shell interactively has `en_US.UTF-8` / `C.UTF-8`.

For a non-UTF-8 client, `server_client_print()` runs the output through `utf8_sanitize()`, which rewrites every byte outside `0x20..0x7e` to `_`. Same server, same client, locale variables unset:

```
list-sessions   -F '#{session_name}'             ->  ______
display-message -p '#{session_name}'             ->  ______
list-panes      -F '#{pane_title}|#{session_name}' -> <title>|______
```

So any session, window or pane name that is not pure ASCII reaches the app as a row of underscores — and an `attach -t` built from that name cannot match the session it came from. With `-u`, all three return the name intact (Arch `tmux 3.7_c-1`, macOS Homebrew `tmux 3.7c`).

## Scope

Names only. I checked the neighbouring paths rather than assuming:

```
capture-pane -p        ->  привет こんにちは ┌─┐ ✓   (intact)
capture-pane -p -e     ->  intact
send-keys -l  / paste-buffer with UTF-8 text  ->  arrives intact
```

Pane content and input never go through that path, so this changes nothing about what the terminal shows or sends.

## The change

`-u` is added where the executable is resolved, the single choke point every tmux invocation passes through — including each command of a compound one, since `resolve()` already rewrites at `;` boundaries. It applies to a bare `tmux` as well as to a detected or user-specified path, and it is idempotent (a command that already carries `-u` is left alone).

The window-restore trap and the resize-auto command inline the resolved binary themselves and are deliberately left alone: they parse no output.

Tests cover the unresolved binary, the resolved path, every command of a compound one, and the no-double-`-u` property. `flutter analyze` clean, `flutter test --exclude-tags=repro` → 1597 passed. Three fixtures in `ssh_tmux_command_executor_test.dart` that pinned the exact resolved command string were updated to the new one.
