### PR TITLE
fix: accept herdr protocol 17 or higher instead of exactly 17

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -78,7 +78,7 @@
   },
   "connHerdrNotFound": "herdr not found",
   "connTmuxNotFound": "tmux not found",
-  "connHerdrProtocolMismatch": "Herdr protocol {actual} is not supported (expected {supported}).",
+  "connHerdrProtocolMismatch": "Herdr protocol {actual} is not supported (minimum supported: {supported}).",
   "@connHerdrProtocolMismatch": {
     "placeholders": {
       "actual": {

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -78,7 +78,7 @@
   },
   "connHerdrNotFound": "herdr が見つかりません",
   "connTmuxNotFound": "tmux が見つかりません",
-  "connHerdrProtocolMismatch": "Herdr プロトコル {actual} はサポートされていません（対応: {supported}）。",
+  "connHerdrProtocolMismatch": "Herdr プロトコル {actual} はサポートされていません（最小対応: {supported}）。",
   "@connHerdrProtocolMismatch": {
     "placeholders": {
       "actual": {

--- a/lib/screens/connections/connection_form_screen.dart
+++ b/lib/screens/connections/connection_form_screen.dart
@@ -1176,7 +1176,7 @@ class _ConnectionFormScreenState extends ConsumerState<ConnectionFormScreen> {
       );
 
       if (isHerdr) {
-        // Herdr preflight: `herdr status --json` で protocol 17 を確認
+        // Herdr preflight: `herdr status --json` で protocol（最小 17）を確認
         try {
           final adapter = HerdrAdapter(sshClient);
           await adapter.preflight();

--- a/lib/services/herdr/herdr_adapter.dart
+++ b/lib/services/herdr/herdr_adapter.dart
@@ -46,10 +46,10 @@ class HerdrAdapter {
   bool get isConnected => _backend.isConnected;
 
   // inventory: HERDR-ADAPTER-002
-  /// preflight: `herdr status --json` を実行し protocol 17 を検証する。
+  /// preflight: `herdr status --json` を実行し protocol（最小 17）を検証する。
   ///
   /// server 未稼働の場合は [HerdrServerNotRunningException]、
-  /// protocol が 17 以外の場合は [HerdrProtocolMismatchException] を投げる。
+  /// protocol が 17 未満の場合は [HerdrProtocolMismatchException] を投げる。
   Future<HerdrStatus> preflight({Duration? timeout}) async {
     final stdout = await _execChecked(
       HerdrCommands.preflightCommand(),

--- a/lib/services/herdr/herdr_commands.dart
+++ b/lib/services/herdr/herdr_commands.dart
@@ -10,9 +10,9 @@ import '../../l10n/l10n_lookup.dart';
 import 'herdr_models.dart';
 
 // inventory: HERDR-CMD-PROTO-001
-/// サポートする herdr protocol 番号。
+/// サポートする herdr protocol の最小番号。
 ///
-/// G6 合意#2・#6: protocol 17 固定・最小対応版。
+/// G6 合意#2・#6: protocol は最小 17（17 以上）に対応。
 const int kHerdrSupportedProtocol = 17;
 
 // inventory: HERDR-CMD-001
@@ -378,9 +378,9 @@ class HerdrTargetNotFoundException implements Exception {
 }
 
 // inventory: HERDR-ERR-002
-/// preflight で protocol が非対応（17 以外）の場合に投げる例外。
+/// preflight で protocol が非対応（17 未満）の場合に投げる例外。
 class HerdrProtocolMismatchException implements Exception {
-  /// サポートする protocol 番号（17）。
+  /// サポートする protocol の最小番号（17）。
   final int supported;
 
   /// 実測された protocol 番号。
@@ -394,7 +394,7 @@ class HerdrProtocolMismatchException implements Exception {
   @override
   String toString() =>
       'HerdrProtocolMismatchException: protocol $actual is not supported '
-      '(expected $supported)';
+      '(minimum $supported)';
 }
 
 // inventory: HERDR-ERR-003
@@ -421,12 +421,12 @@ class HerdrServerNotRunningException implements Exception {
 }
 
 // inventory: HERDR-PREFLIGHT-001
-/// `herdr status --json` の結果から protocol 17 を検証する preflight。
+/// `herdr status --json` の結果から protocol（最小 17）を検証する preflight。
 ///
 /// コマンド実行は [HerdrAdapter.preflight] が行い、このクラスは検証のみを
 /// 担当する。server 未稼働の場合は [HerdrServerNotRunningException]、
-/// protocol が 17 以外の場合は [HerdrProtocolMismatchException] を投げる
-/// （G6 合意#2・#6: protocol 17 固定・最小対応版）。
+/// protocol が 17 未満の場合は [HerdrProtocolMismatchException] を投げる
+/// （G6 合意#2・#6: 最小 17（17 以上））。
 class HerdrPreflight {
   HerdrPreflight._();
 
@@ -434,12 +434,12 @@ class HerdrPreflight {
   static const int supportedProtocol = kHerdrSupportedProtocol;
 
   // inventory: HERDR-PREFLIGHT-002
-  /// [status] の client/server protocol が 17 であることを検証する。
+  /// [status] の client/server protocol が 17 以上であることを検証する。
   ///
   /// 検証順序:
   /// 1. server 未稼働（[HerdrStatus.running] == false）なら
   ///    [HerdrServerNotRunningException] を投げる（protocol 判定より先）。
-  /// 2. client/server protocol が 17 以外なら [HerdrProtocolMismatchException]。
+  /// 2. client/server protocol が 17 未満なら [HerdrProtocolMismatchException]。
   ///
   /// 検証に成功した場合は [status] をそのまま返す。
   static HerdrStatus validate(HerdrStatus status, {AppLocalizations? l10n}) {
@@ -451,9 +451,9 @@ class HerdrPreflight {
     }
     final client = status.clientProtocol;
     final server = status.serverProtocol;
-    if (client != supportedProtocol || server != supportedProtocol) {
+    if (client < supportedProtocol || server < supportedProtocol) {
       // より具体的な方（server 優先）を actual として報告する。
-      final actual = server != supportedProtocol ? server : client;
+      final actual = server < supportedProtocol ? server : client;
       throw HerdrProtocolMismatchException(
         supported: supportedProtocol,
         actual: actual,

--- a/lib/services/herdr/herdr_models.dart
+++ b/lib/services/herdr/herdr_models.dart
@@ -277,7 +277,7 @@ class HerdrLayout {
 // inventory: HERDR-MODELS-SNAPSHOT-001
 /// `herdr api snapshot` の結果（全階層）。
 class HerdrSnapshot {
-  /// protocol 番号（17 がサポート対象）。
+  /// protocol 番号（17 以上がサポート対象）。
   final int protocol;
 
   /// herdr のバージョン（例: "0.7.5"）。

--- a/test/screens/connections/connection_form_screen_test.dart
+++ b/test/screens/connections/connection_form_screen_test.dart
@@ -293,7 +293,7 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(
-        find.textContaining('protocol 16 is not supported'),
+        find.textContaining('protocol 16 is not supported (minimum supported: 17)'),
         findsOneWidget,
       );
     });

--- a/test/screens/connections/connection_form_screen_test.dart
+++ b/test/screens/connections/connection_form_screen_test.dart
@@ -293,7 +293,9 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(
-        find.textContaining('protocol 16 is not supported (minimum supported: 17)'),
+        find.textContaining(
+          'protocol 16 is not supported (minimum supported: 17)',
+        ),
         findsOneWidget,
       );
     });

--- a/test/services/herdr/herdr_adapter_test.dart
+++ b/test/services/herdr/herdr_adapter_test.dart
@@ -87,7 +87,7 @@ void main() {
     });
 
     test(
-      'throws HerdrProtocolMismatchException when protocol is not 17',
+      'throws HerdrProtocolMismatchException when server protocol is below 17',
       () async {
         final client = FakeSshClient();
         client.execOutputs['herdr status --json'] = kStatusProtocol16;

--- a/test/services/herdr/herdr_commands_test.dart
+++ b/test/services/herdr/herdr_commands_test.dart
@@ -295,21 +295,22 @@ void main() {
       },
     );
 
-    test(
-      'throws HerdrProtocolMismatchException when client protocol is 18',
-      () {
-        expect(
-          () => HerdrPreflight.validate(status(client: 18)),
-          throwsA(
-            isA<HerdrProtocolMismatchException>().having(
-              (e) => e.actual,
-              'actual',
-              18,
-            ),
-          ),
-        );
-      },
-    );
+    test('accepts protocol 18 on client (18 >= minimum 17)', () {
+      final result = HerdrPreflight.validate(status(client: 18));
+      expect(result.clientProtocol, 18);
+      expect(result.serverProtocol, 17);
+    });
+
+    test('reports client as actual when server is new but client is old', () {
+      expect(
+        () => HerdrPreflight.validate(status(client: 16, server: 18)),
+        throwsA(
+          isA<HerdrProtocolMismatchException>()
+              .having((e) => e.actual, 'actual', 16)
+              .having((e) => e.supported, 'supported', 17),
+        ),
+      );
+    });
 
     test('throws when protocol fields are missing (0)', () {
       expect(


### PR DESCRIPTION
## Summary
- Herdr preflight rejected any client/server protocol other than exactly 17, so herdr builds reporting protocol 18 or later failed the connection check
- Relax the validation to a minimum-version check (client/server protocol >= 17), report the outdated side as `actual`, and align the user-facing message and tests with the new semantics

## Changes
- `lib/services/herdr/herdr_commands.dart`: `HerdrPreflight.validate` now requires client/server protocol of at least 17 (`!=` → `<` on both sides); the `actual` selection is synced so the outdated side is reported; doc comments and the exception `toString` use "minimum" wording. Constant and exception field names are unchanged
- `lib/l10n/app_en.arb`, `lib/l10n/app_ja.arb`: `connHerdrProtocolMismatch` reworded to "(minimum supported: X)" / "（最小対応: X）"; l10n regenerated
- `lib/services/herdr/herdr_adapter.dart`, `lib/services/herdr/herdr_models.dart`, `lib/screens/connections/connection_form_screen.dart`: comments updated to the minimum-version semantics
- `test/services/herdr/herdr_commands_test.dart`: protocol 18 is now accepted (was rejected); added a case verifying an outdated client is reported as `actual` against a newer server
- `test/services/herdr/herdr_adapter_test.dart`: mismatch test renamed to "when server protocol is below 17" (fixture unchanged, server still 16)
- `test/screens/connections/connection_form_screen_test.dart`: expected warning text synced with the new l10n wording

## Test plan
- [x] `make analyze` — No issues found! (HEAD 7cf0dc7)
- [x] `make test` — All 1760 tests passed (includes: protocol 18 acceptance, outdated-client `actual` reporting, protocol 16 / missing-protocol rejection, server-not-running precedence). Note: the tagged repro SSH tests require the local fixtures documented in the test file header (`/tmp/bugfix-repro-key*` plus its entry in `authorized_keys`)
- [x] On-device verification (Android 15 emulator, HEAD build): protocol 18 stub → connection test passes and a new workspace reaches a LIVE terminal; protocol 16 stub → warning "protocol 16 is not supported (minimum supported: 17)"; real herdr 0.7.5 (protocol 17) → terminal LIVE with no regression